### PR TITLE
Use Cesium for Core types

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -35,3 +35,17 @@ FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
 COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+### Cesium
+
+http://cesiumjs.org/
+
+> Copyright 2011-2016 Cesium Contributors
+>
+> Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+>
+> http://www.apache.org/licenses/LICENSE-2.0
+>
+> Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+See https://github.com/AnalyticalGraphicsInc/cesium/blob/master/LICENSE.md

--- a/bin/gltf-pipeline.js
+++ b/bin/gltf-pipeline.js
@@ -3,11 +3,13 @@
 var fs = require('fs');
 var path = require('path');
 var argv = require('minimist')(process.argv.slice(2));
-var definedNotNull = require('../lib/definedNotNull');
+var addDefaults = require('../').addDefaults;
 var removeUnusedImages = require('../').removeUnusedImages;
 var OptimizationStatistics = require('../').OptimizationStatistics;
+var Cesium = require('cesium');
+var defined = Cesium.defined;
 
-if (!definedNotNull(argv._[0]) || definedNotNull(argv.h) || definedNotNull(argv.help)) {
+if (!defined(argv._[0]) || defined(argv.h) || defined(argv.help)) {
 	var help =
         'Usage: node ' + path.basename(__filename) + ' [path-to.gltf or path-to.bgltf] [OPTIONS]\n' +
         '  -o=PATH  Write optimized glTF to the specified file.\n';
@@ -25,12 +27,14 @@ fs.readFile(gltfPath, function (err, data) {
     var gltf = JSON.parse(data);
     var stats = new OptimizationStatistics();
 
+    // TODO: custom pipeline based on arguments / config
     removeUnusedImages(gltf, stats);
+    addDefaults(gltf, stats);
 
     stats.print();
 
     var outputPath = argv.o;
-    if (!definedNotNull(outputPath)) {
+    if (!defined(outputPath)) {
         // Default output.  For example, path/asset.gltf becomes path/asset-optimized.gltf
         var fileExtension = path.extname(gltfPath);
         var filename = path.basename(gltfPath, fileExtension);

--- a/lib/definedNotNull.js
+++ b/lib/definedNotNull.js
@@ -1,7 +1,0 @@
-'use strict';
-
-module.exports = definedNotNull;
-
-function definedNotNull(value) {
-    return (value !== undefined) && (value !== null);
-}

--- a/lib/removeUnusedImages.js
+++ b/lib/removeUnusedImages.js
@@ -1,5 +1,6 @@
 'use strict';
-var definedNotNull = require('./definedNotNull');
+var Cesium = require('cesium');
+var defined = Cesium.defined;
 
 module.exports = removeUnusedImages;
 
@@ -8,7 +9,7 @@ function removeUnusedImages(gltf, stats) {
     var textures = gltf.textures;
 
     // Build hash of used images by iterating through textures
-    if (definedNotNull(textures)) {
+    if (defined(textures)) {
         for (var textureId in textures) {
             if (textures.hasOwnProperty(textureId)) {
                 var id = textures[textureId].source;
@@ -20,13 +21,13 @@ function removeUnusedImages(gltf, stats) {
     // Iterate through images and remove those that are not in the hash
     var numberOfImagesRemoved = 0;
     var images = gltf.images;
-    if (definedNotNull(images)) {
+    if (defined(images)) {
         var usedImages = {};
 
         for (var imageId in images) {
             if (images.hasOwnProperty(imageId)) {
                 // If this image is in the hash, then keep it in the glTF asset
-                if (definedNotNull(usedImageIds[imageId])) {
+                if (defined(usedImageIds[imageId])) {
                     usedImages[imageId] = images[imageId];
                 } else {
                     ++numberOfImagesRemoved;
@@ -34,7 +35,7 @@ function removeUnusedImages(gltf, stats) {
             }
         }
 
-        if (definedNotNull(stats)) {
+        if (defined(stats)) {
             stats.numberOfImagesRemoved += numberOfImagesRemoved;
         }
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "lib": "./lib"
   },
   "dependencies": {
+    "cesium": "^1.17.0",
     "minimist": "1.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
There is a lot of useful math and utility types in Cesium: http://cesiumjs.org/refdoc.html

Long-term, we'll streamline this dependency since Cesium is overkill here.  There's a note in the roadmap, #1.