### PR TITLE
Shimmed cesium for browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,8 @@
     "object-values": "^1.0.0"
   },
   "devDependencies": {
+    "browserify": "^13.0.1",
+    "browserify-shim": "^3.8.12",
     "clone": "^1.0.2",
     "coveralls": "^2.11.6",
     "gulp": "3.9.0",
@@ -53,5 +55,14 @@
     "jasmine": "^2.4.1",
     "jshint": "2.8.0",
     "jshint-stylish": "2.1.0"
+  },
+  "browser": {
+    "cesium": "cesium/Build/Cesium/Cesium.js"
+  },
+  "browserify-shim": {
+    "cesium": "cesium"
+  },
+  "browserify": {
+    "transform": [ "browserify-shim" ]
   }
 }


### PR DESCRIPTION
Should resolve #12.

Note that the outputted browserified script is bundled separately from Cesium, since browserify and require don't play nicely together. If you use the browserified script, you will need to include Cesium as well.