### PR TITLE
Added removeUnusedVertices stage

### DIFF
--- a/bin/gltf-pipeline.js
+++ b/bin/gltf-pipeline.js
@@ -26,6 +26,7 @@ var addPipelineExtras = require('../').addPipelineExtras;
 var convertDagToTree = require('../').convertDagToTree;
 var combineMeshes = require('../').combineMeshes;
 var combinePrimitives = require('../').combinePrimitives;
+var removeUnusedVertices = require('../').removeUnusedVertices;
 var OptimizationStatistics = require('../').OptimizationStatistics;
 var Cesium = require('cesium');
 var defined = Cesium.defined;
@@ -78,6 +79,8 @@ fs.readFile(gltfPath, function (err, data) {
 
         combineMeshes(gltf);
         combinePrimitives(gltf);
+
+        removeUnusedVertices(gltf);
 
         var outputPath = argv.o;
         if (!defined(outputPath)) {

--- a/index.js
+++ b/index.js
@@ -25,5 +25,6 @@ module.exports = {
     convertDagToTree : require('./lib/convertDagToTree'),
     combineMeshes : require('./lib/combineMeshes'),
     combinePrimitives : require('./lib/combinePrimitives'),
+    removeUnusedVertices : require('./lib/removeUnusedVertices'),
     OptimizationStatistics : require('./lib/OptimizationStatistics')
 };

--- a/lib/removeUnusedVertices.js
+++ b/lib/removeUnusedVertices.js
@@ -28,8 +28,8 @@ function removeUnusedBufferData(gltf) {
     sortedBufferViews.sort(function(a, b) {
         return a.byteOffset - b.byteOffset;
     });
-
-    for (var i = 0; i < sortedBufferViews.length; i++) {
+    var bufferViewsLength = sortedBufferViews.length;
+    for (var i = 0; i < bufferViewsLength; i++) {
         var bufferView = sortedBufferViews[i];
         var viewedBuffer = buffers[bufferView.buffer];
         var source = viewedBuffer.extras._pipeline.source;
@@ -85,15 +85,7 @@ function removeUnusedIndexData(gltf) {
     var bufferViews = gltf.bufferViews;
     var meshes = gltf.meshes;
 
-    var primitives = [];
-    for (var meshId in meshes) {
-        if (meshes.hasOwnProperty(meshId)) {
-            if (defined(meshes[meshId].primitives)) {
-                primitives.push.apply(primitives, meshes[meshId].primitives);
-            }
-        }
-    }
-    calculateIndexIntervals(accessors, bufferViews, buffers, primitives);
+    calculateIndexIntervals(accessors, buffers, bufferViews, meshes);
 
     compressBuffers(accessors, bufferViews, buffers);
 
@@ -111,109 +103,121 @@ function removeUnusedIndexData(gltf) {
 }
 
 //Calculate the range of indices used by primitives and their accessors.
-function calculateIndexIntervals(accessors, bufferViews, buffers, primitives) {
+function calculateIndexIntervals(accessors, buffers, bufferViews, meshes) {
     for (var bufferViewId in bufferViews) {
         if (bufferViews.hasOwnProperty(bufferViewId)) {
             bufferViews[bufferViewId].extras._pipeline.accessors = {};
         }
     }
 
-    for (var i = 0; i < primitives.length; i++) {
-        var primitive = primitives[i];
-        if (defined(primitive.indices)) {
-            var indexAccessor = accessors[primitive.indices];
-            var indexView = bufferViews[indexAccessor.bufferView];
-            var indexBuffer = buffers[indexView.buffer];
-            var indexSource = indexBuffer.extras._pipeline.source.slice(indexView.byteOffset, indexView.byteOffset + defaultValue(indexView.byteLength, 0));
-            var indexStride = indexAccessor.componentType === WebGLConstants.UNSIGNED_SHORT ? 2 : 1;
-            indexView.extras._pipeline.indexStride = defaultValue(indexView.extras._pipeline.indexStride, indexStride);
-            indexView.extras._pipeline.indexIntervals = defaultValue(indexView.extras._pipeline.indexIntervals, []);
+    for (var meshId in meshes) {
+        if (meshes.hasOwnProperty(meshId)) {
+            var primitives = meshes[meshId].primitives;
+            if (defined(primitives)) {
+                var primitiveLength = primitives.length;
+                for (var i = 0; i < primitiveLength; i++) {
+                    var primitive = primitives[i];
+                    if (defined(primitive.indices)) {
+                        var indexAccessor = accessors[primitive.indices];
+                        var indexView = bufferViews[indexAccessor.bufferView];
+                        var indexBuffer = buffers[indexView.buffer];
+                        var indexSource = indexBuffer.extras._pipeline.source.slice(indexView.byteOffset, indexView.byteOffset + defaultValue(indexView.byteLength, 0));
+                        var indexStride = indexAccessor.componentType === WebGLConstants.UNSIGNED_SHORT ? 2 : 1;
+                        indexView.extras._pipeline.indexStride = defaultValue(indexView.extras._pipeline.indexStride, indexStride);
+                        indexView.extras._pipeline.indexIntervals = defaultValue(indexView.extras._pipeline.indexIntervals, []);
 
-            //Create a sorted array of unique index values.
-            var indexArray = [];
-            var accessorSource = indexSource.slice(indexAccessor.byteOffset, indexAccessor.byteOffset + indexStride * indexAccessor.count);
-            var accessorIndex = 0;
-            while (accessorIndex < accessorSource.length) {
-                var index = WebGLConstants.UNSIGNED_SHORT ? accessorSource.readUInt16LE(accessorIndex) : accessorSource.readUInt8LE(accessorIndex);
-                if (indexArray.indexOf(index) === -1) {
-                    indexArray.push(index);
-                }
-                accessorIndex += indexStride;
-            }
-            indexArray.sort(function(a, b) {
-                return a - b;
-            });
-
-            //Calculate the index intervals based on the array of sorted indices.
-            var indexIntervals = [];
-            var intervalStart, prevIndex;
-            var newAccessorCount = 0;
-
-            for (var j = 0; j < indexArray.length; j++) {
-                var currentIndex = indexArray[j];
-
-                var pushInterval = function(start, end) {
-                    var interval = [start, end];
-                    indexIntervals.push(interval);
-                    indexView.extras._pipeline.indexIntervals.push(interval);
-                    newAccessorCount += interval[1] - interval[0] + 1;
-                };
-                if (currentIndex !== prevIndex + 1) {
-                    if (j > 0) {
-                        //If the current index is not part of the current interval, start a new interval.
-                        pushInterval(intervalStart, prevIndex);
-                    }
-                    intervalStart = currentIndex;
-                }
-                if (j === indexArray.length - 1) {
-                    pushInterval(intervalStart, currentIndex);
-                }
-
-                prevIndex = currentIndex;
-            }
-
-            //Calculate the indexIntervals of the attributes relative to their corresponding buffer views based on their byte stride.
-            var attributes = primitive.attributes;
-            for (var attributeId in attributes) {
-                if (attributes.hasOwnProperty(attributeId)) {
-                    var attributeAccessor = accessors[attributes[attributeId]];
-                    var attributeView = bufferViews[attributeAccessor.bufferView];
-
-                    if (Object.keys(attributeView.extras._pipeline.accessors).indexOf(attributes[attributeId]) === -1) {
-                        var attributeStride = 1;
-                        if (attributeAccessor.byteStride > 0) {
-                            attributeStride = attributeAccessor.byteStride;
-                        }
-                        else {
-                            //Int16
-                            if (attributeAccessor.componentType === WebGLConstants.SHORT || attributeAccessor.componentType === WebGLConstants.UNSIGNED_SHORT) {
-                                attributeStride = 2;
+                        //Create a sorted array of unique index values.
+                        var indexArray = [];
+                        var accessorSource = indexSource.slice(indexAccessor.byteOffset, indexAccessor.byteOffset + indexStride * indexAccessor.count);
+                        var accessorIndex = 0;
+                        var accessorSourceLength = accessorSource.length;
+                        while (accessorIndex < accessorSourceLength) {
+                            var index = WebGLConstants.UNSIGNED_SHORT ? accessorSource.readUInt16LE(accessorIndex) : accessorSource.readUInt8LE(accessorIndex);
+                            if (indexArray.indexOf(index) === -1) {
+                                indexArray.push(index);
                             }
-                            //Float32
-                            if (attributeAccessor.componentType === WebGLConstants.FLOAT) {
-                                attributeStride = 4;
+                            accessorIndex += indexStride;
+                        }
+                        indexArray.sort(function(a, b) {
+                            return a - b;
+                        });
+
+                        //Calculate the index intervals based on the array of sorted indices.
+                        var indexIntervals = [];
+                        var intervalStart, prevIndex;
+                        var newAccessorCount = 0;
+
+                        var indexArrayLength = indexArray.length;
+                        for (var j = 0; j < indexArrayLength; j++) {
+                            var currentIndex = indexArray[j];
+
+                            var pushInterval = function(start, end) {
+                                var interval = [start, end];
+                                indexIntervals.push(interval);
+                                indexView.extras._pipeline.indexIntervals.push(interval);
+                                newAccessorCount += interval[1] - interval[0] + 1;
+                            };
+                            if (currentIndex !== prevIndex + 1) {
+                                if (j > 0) {
+                                    //If the current index is not part of the current interval, start a new interval.
+                                    pushInterval(intervalStart, prevIndex);
+                                }
+                                intervalStart = currentIndex;
+                            }
+                            if (j === indexArrayLength - 1) {
+                                pushInterval(intervalStart, currentIndex);
+                            }
+
+                            prevIndex = currentIndex;
+                        }
+
+                        //Calculate the indexIntervals of the attributes relative to their corresponding buffer views based on their byte stride.
+                        var attributes = primitive.attributes;
+                        for (var attributeId in attributes) {
+                            if (attributes.hasOwnProperty(attributeId)) {
+                                var attributeAccessor = accessors[attributes[attributeId]];
+                                var attributeView = bufferViews[attributeAccessor.bufferView];
+
+                                if (Object.keys(attributeView.extras._pipeline.accessors).indexOf(attributes[attributeId]) === -1) {
+                                    var attributeStride = 1;
+                                    if (attributeAccessor.byteStride > 0) {
+                                        attributeStride = attributeAccessor.byteStride;
+                                    }
+                                    else {
+                                        //Int16
+                                        if (attributeAccessor.componentType === WebGLConstants.SHORT || attributeAccessor.componentType === WebGLConstants.UNSIGNED_SHORT) {
+                                            attributeStride = 2;
+                                        }
+                                        //Float32
+                                        if (attributeAccessor.componentType === WebGLConstants.FLOAT) {
+                                            attributeStride = 4;
+                                        }
+                                    }
+
+                                    var attributeIntervals = indexIntervals.slice();
+                                    var attributeIntervalsLength = attributeIntervals.length;
+                                    for (var k = 0; k < attributeIntervalsLength; k++) {
+                                        var attributeInterval = attributeIntervals[k];
+                                        var viewStart = attributeAccessor.byteOffset + attributeInterval[0] * attributeStride;
+                                        var intervalLength = attributeInterval[1] - attributeInterval[0] + 1;
+                                        attributeIntervals[k] = [viewStart, (viewStart + intervalLength * attributeStride) - 1];
+
+                                    }
+                                    attributeView.extras._pipeline.accessors[attributes[attributeId]] = attributeIntervals;
+
+                                    if (!defined(attributeAccessor.extras._pipeline.byteLength)) {
+                                        attributeAccessor.extras._pipeline.originalByteLength = attributeStride * attributeAccessor.count;
+                                    }
+                                    attributeAccessor.count = newAccessorCount;
+                                }
                             }
                         }
-
-                        var attributeIntervals = indexIntervals.slice();
-                        for (var k = 0; k < attributeIntervals.length; k++) {
-                            var attributeInterval = attributeIntervals[k];
-                            var viewStart = attributeAccessor.byteOffset + attributeInterval[0] * attributeStride;
-                            var intervalLength = attributeInterval[1] - attributeInterval[0] + 1;
-                            attributeIntervals[k] = [viewStart, (viewStart + intervalLength * attributeStride) - 1];
-
-                        }
-                        attributeView.extras._pipeline.accessors[attributes[attributeId]] = attributeIntervals;
-
-                        if (!defined(attributeAccessor.extras._pipeline.byteLength)) {
-                            attributeAccessor.extras._pipeline.originalByteLength = attributeStride * attributeAccessor.count;
-                        }
-                        attributeAccessor.count = newAccessorCount;
                     }
                 }
             }
         }
     }
+    
 }
 
 //Go through the index intervals for each buffer view and remove unused sections from the corresponding buffers.
@@ -223,10 +227,12 @@ function compressBuffers(accessors, bufferViews, buffers) {
     sortedBufferViews.sort(function(a, b) {
         return a.byteOffset - b.byteOffset;
     });
-    for (var i = 0; i < sortedBufferViews.length; i++) {
+    var bufferViewsLength = sortedBufferViews.length;
+    for (var i = 0; i < bufferViewsLength; i++) {
         var bufferView = sortedBufferViews[i];
         var accessorIds = Object.keys(bufferView.extras._pipeline.accessors);
-        if (Object.keys(accessorIds).length > 0) {
+        var accessorIdsLength = accessorIds.length;
+        if (accessorIdsLength > 0) {
             bufferView.extras._pipeline.offset = 0;
             var viewedBuffer = buffers[bufferView.buffer];
             var source = viewedBuffer.extras._pipeline.source;
@@ -242,12 +248,13 @@ function compressBuffers(accessors, bufferViews, buffers) {
 
             //Examine the intervals used by each accessor and remove sections from the buffer as gaps between intervals are encountered.
             var previousEnd = 0;
-            for (var j = 0; j < accessorIds.length; j++) {
+            for (var j = 0; j < accessorIdsLength; j++) {
                 var viewAccessor = accessors[accessorIds[j]];
                 viewAccessor.byteOffset -= bufferView.extras._pipeline.offset;
-                var accessorIntervals = bufferView.extras._pipeline.accessors[accessorIds[j]];
                 var newAccessorLength = 0;
-                for (var k = 0; k < accessorIntervals.length; k++) {
+                var accessorIntervals = bufferView.extras._pipeline.accessors[accessorIds[j]];
+                var accessorIntervalsLength = accessorIntervals.length;
+                for (var k = 0; k < accessorIntervalsLength; k++) {
                     var accessorInterval = accessorIntervals[k];
                     var gap = accessorInterval[0] - previousEnd;
                     previousEnd = accessorInterval[1] + 1;
@@ -333,7 +340,8 @@ function updateIndices(bufferViews, buffers) {
                 var offsetArray = [];
                 var totalOffset = indexIntervals[0][0];
                 offsetArray.push([indexIntervals[0][0], indexIntervals[0][0]]);
-                for (var j = 1; j < indexIntervals.length; j++) {
+                var indexIntervalsLength = indexIntervals.length;
+                for (var j = 1; j < indexIntervalsLength; j++) {
                     var gap = indexIntervals[j][0] - (indexIntervals[j-1][1] + 1);
                     totalOffset += gap;
                     offsetArray.push([indexIntervals[j][0], totalOffset]);
@@ -343,9 +351,10 @@ function updateIndices(bufferViews, buffers) {
                 var sourceIndex = bufferView.byteOffset;
                 var viewEnd = bufferView.byteOffset + bufferView.byteLength;
                 var indexStride = bufferView.extras._pipeline.indexStride;
+                var offsetArrayLength = offsetArray.length;
                 while (sourceIndex < viewEnd) {
                     var index = (indexStride === 2) ? indexSource.readUInt16LE(sourceIndex) : indexSource.readUInt8LE(sourceIndex);
-                    for (var k = offsetArray.length - 1; k >= 0; k--) {
+                    for (var k = offsetArrayLength - 1; k >= 0; k--) {
                         if (index >= offsetArray[k][0]) {
                             if (indexStride === 2) {
                                 indexSource.writeUInt16LE(index - offsetArray[k][1], sourceIndex);

--- a/lib/removeUnusedVertices.js
+++ b/lib/removeUnusedVertices.js
@@ -1,71 +1,364 @@
+/*jshint loopfunc: true */
 'use strict';
 var Cesium = require('cesium');
 var defined = Cesium.defined;
 var defaultValue = Cesium.defaultValue;
+var WebGLConstants = Cesium.WebGLConstants;
 var objectValues = require('object-values');
 
 module.exports = removeUnusedVertices;
 
-//Removes unreferenced sections of buffers and updates their corresponding buffer views.
+//Removes sections of buffers which are unreferenced by buffer views and accessors.
 function removeUnusedVertices(gltf) {
+    if (defined(gltf.accessors) && defined(gltf.buffers) && defined(gltf.bufferViews) && defined(gltf.meshes)) {
+        removeUnusedBufferData(gltf);
+        removeUnusedIndexData(gltf);
+    }
+
+    return gltf;
+}
+
+//Removes sections of buffers which are not referenced by buffer views and updates its corresponding buffer views.
+function removeUnusedBufferData(gltf) {
     var buffers = gltf.buffers;
     var bufferViews = gltf.bufferViews;
 
-    if (defined(bufferViews)) {
-        //Create and traverse an array of buffer views sorted by increasing byteOffset
-        var sortedBufferViews = objectValues(bufferViews);
-        sortedBufferViews.sort(function(a, b) {
-            return a.byteOffset - b.byteOffset;
-        });
+    //Create and traverse an array of buffer views sorted by increasing byteOffset
+    var sortedBufferViews = objectValues(bufferViews);
+    sortedBufferViews.sort(function(a, b) {
+        return a.byteOffset - b.byteOffset;
+    });
 
-        for (var i = 0; i < sortedBufferViews.length; i++) {
-            var bufferView = sortedBufferViews[i];
-            var viewedBuffer = buffers[bufferView.buffer];
-            var source = viewedBuffer.extras._pipeline.source;
-            var viewStart = bufferView.byteOffset;
-            var viewLength = defaultValue(bufferView.byteLength, 0);
-            var viewEnd = viewStart + viewLength;
+    for (var i = 0; i < sortedBufferViews.length; i++) {
+        var bufferView = sortedBufferViews[i];
+        var viewedBuffer = buffers[bufferView.buffer];
+        var source = viewedBuffer.extras._pipeline.source;
+        var viewStart = bufferView.byteOffset;
+        var viewLength = defaultValue(bufferView.byteLength, 0);
+        var viewEnd = viewStart + viewLength;
 
-            //While processing the buffer views, store the accumulated length of deleted portions of referenced buffers in the offset extra
-            //The end extra property denotes the largest index in the buffer referenced thus far by buffer views.
-            if (!defined(viewedBuffer.extras._pipeline.offset)) {
-                viewedBuffer.extras._pipeline.offset = viewStart;
-                viewedBuffer.extras._pipeline.end = viewStart + viewLength;
-                if (viewStart > 0) {
-                    bufferView.byteOffset = 0;
-                    viewedBuffer.extras._pipeline.source = source.slice(viewStart);
-                }
-            }
-            else {
-                if (viewStart > viewedBuffer.extras._pipeline.end) {
-                    viewedBuffer.extras._pipeline.source = Buffer.concat([source.slice(0, viewedBuffer.extras._pipeline.end - viewedBuffer.extras._pipeline.offset), 
-                        source.slice(viewStart - viewedBuffer.extras._pipeline.offset)]);
-                    viewedBuffer.extras._pipeline.offset += viewStart - viewedBuffer.extras._pipeline.end;
-                }
-                bufferView.byteOffset -= viewedBuffer.extras._pipeline.offset;
-
-                if (viewEnd > viewedBuffer.extras._pipeline.end) {
-                    viewedBuffer.extras._pipeline.end = viewEnd;
-                }
+        //While processing the buffer views, store the accumulated length of deleted portions of referenced buffers in the offset extra
+        //The end extra property denotes the largest index in the buffer referenced thus far by buffer views.
+        if (!defined(viewedBuffer.extras._pipeline.offset)) {
+            viewedBuffer.extras._pipeline.offset = viewStart;
+            viewedBuffer.extras._pipeline.end = viewStart + viewLength;
+            if (viewStart > 0) {
+                bufferView.byteOffset = 0;
+                viewedBuffer.extras._pipeline.source = source.slice(viewStart);
             }
         }
+        else {
+            if (viewStart > viewedBuffer.extras._pipeline.end) {
+                viewedBuffer.extras._pipeline.source = Buffer.concat([source.slice(0, viewedBuffer.extras._pipeline.end - viewedBuffer.extras._pipeline.offset), 
+                    source.slice(viewStart - viewedBuffer.extras._pipeline.offset)]);
+                viewedBuffer.extras._pipeline.offset += viewStart - viewedBuffer.extras._pipeline.end;
+            }
+            bufferView.byteOffset -= viewedBuffer.extras._pipeline.offset;
 
-        //Update the buffers based on their new source, offset, and end. The buffer will be deleted if it was never referenced.
-        if (defined(buffers)) {
-            for (var bufferId in buffers) {
-                if (buffers.hasOwnProperty(bufferId)) {
-                    var buffer = buffers[bufferId];
-                    if (!defined(buffer.extras._pipeline.offset)) {
-                        delete buffers[bufferId];
+            if (viewEnd > viewedBuffer.extras._pipeline.end) {
+                viewedBuffer.extras._pipeline.end = viewEnd;
+            }
+        }
+    }
+
+    //Update the buffers based on their new source, offset, and end. The buffer will be deleted if it was never referenced.
+    for (var bufferId in buffers) {
+        if (buffers.hasOwnProperty(bufferId)) {
+            var buffer = buffers[bufferId];
+            if (!defined(buffer.extras._pipeline.offset)) {
+                delete buffers[bufferId];
+            }
+            else {
+                buffer.extras._pipeline.source = buffer.extras._pipeline.source.slice(0, buffer.extras._pipeline.end - buffer.extras._pipeline.offset);
+                buffer.byteLength = buffer.extras._pipeline.source.length;
+                delete buffer.extras._pipeline.offset;
+                delete buffer.extras._pipeline.end;
+            }
+        }
+    }
+}
+
+//Remove sections of buffers which are not accessed by indices.
+function removeUnusedIndexData(gltf) {
+    var accessors = gltf.accessors;
+    var buffers = gltf.buffers;
+    var bufferViews = gltf.bufferViews;
+    var meshes = gltf.meshes;
+
+    var primitives = [];
+    for (var meshId in meshes) {
+        if (meshes.hasOwnProperty(meshId)) {
+            if (defined(meshes[meshId].primitives)) {
+                primitives.push.apply(primitives, meshes[meshId].primitives);
+            }
+        }
+    }
+    calculateIndexIntervals(accessors, bufferViews, buffers, primitives);
+
+    compressBuffers(accessors, bufferViews, buffers);
+
+    //Recalculate the byte length for each buffer.
+    for (var bufferId in buffers) {
+        if (buffers.hasOwnProperty(bufferId)) {
+            var buffer = buffers[bufferId];
+            if (defined(buffer.extras._pipeline.offset)) {
+                buffer.byteLength = buffer.extras._pipeline.source.length;
+            }
+        }
+    }
+    
+    updateIndices(bufferViews, buffers);
+}
+
+//Calculate the range of indices used by primitives and their accessors.
+function calculateIndexIntervals(accessors, bufferViews, buffers, primitives) {
+    for (var bufferViewId in bufferViews) {
+        if (bufferViews.hasOwnProperty(bufferViewId)) {
+            bufferViews[bufferViewId].extras._pipeline.accessors = {};
+        }
+    }
+
+    for (var i = 0; i < primitives.length; i++) {
+        var primitive = primitives[i];
+        if (defined(primitive.indices)) {
+            var indexAccessor = accessors[primitive.indices];
+            var indexView = bufferViews[indexAccessor.bufferView];
+            var indexBuffer = buffers[indexView.buffer];
+            var indexSource = indexBuffer.extras._pipeline.source.slice(indexView.byteOffset, indexView.byteOffset + defaultValue(indexView.byteLength, 0));
+            var indexStride = indexAccessor.componentType === WebGLConstants.UNSIGNED_SHORT ? 2 : 1;
+            indexView.extras._pipeline.indexStride = defaultValue(indexView.extras._pipeline.indexStride, indexStride);
+            indexView.extras._pipeline.indexIntervals = defaultValue(indexView.extras._pipeline.indexIntervals, []);
+
+            //Create a sorted array of unique index values.
+            var indexArray = [];
+            var accessorSource = indexSource.slice(indexAccessor.byteOffset, indexAccessor.byteOffset + indexStride * indexAccessor.count);
+            var accessorIndex = 0;
+            while (accessorIndex < accessorSource.length) {
+                var index = WebGLConstants.UNSIGNED_SHORT ? accessorSource.readUInt16LE(accessorIndex) : accessorSource.readUInt8LE(accessorIndex);
+                if (indexArray.indexOf(index) === -1) {
+                    indexArray.push(index);
+                }
+                accessorIndex += indexStride;
+            }
+            indexArray.sort(function(a, b) {
+                return a - b;
+            });
+
+            //Calculate the index intervals based on the array of sorted indices.
+            var indexIntervals = [];
+            var intervalStart, prevIndex;
+            var newAccessorCount = 0;
+
+            for (var j = 0; j < indexArray.length; j++) {
+                var currentIndex = indexArray[j];
+
+                var pushInterval = function(start, end) {
+                    var interval = [start, end];
+                    indexIntervals.push(interval);
+                    indexView.extras._pipeline.indexIntervals.push(interval);
+                    newAccessorCount += interval[1] - interval[0] + 1;
+                };
+                if (currentIndex !== prevIndex + 1) {
+                    if (j > 0) {
+                        //If the current index is not part of the current interval, start a new interval.
+                        pushInterval(intervalStart, prevIndex);
                     }
-                    else {
-                        buffer.extras._pipeline.source = buffer.extras._pipeline.source.slice(0, buffer.extras._pipeline.end - buffer.extras._pipeline.offset);
-                        buffer.byteLength = buffer.extras._pipeline.source.length;
+                    intervalStart = currentIndex;
+                }
+                if (j === indexArray.length - 1) {
+                    pushInterval(intervalStart, currentIndex);
+                }
+
+                prevIndex = currentIndex;
+            }
+
+            //Calculate the indexIntervals of the attributes relative to their corresponding buffer views based on their byte stride.
+            var attributes = primitive.attributes;
+            for (var attributeId in attributes) {
+                if (attributes.hasOwnProperty(attributeId)) {
+                    var attributeAccessor = accessors[attributes[attributeId]];
+                    var attributeView = bufferViews[attributeAccessor.bufferView];
+
+                    if (Object.keys(attributeView.extras._pipeline.accessors).indexOf(attributes[attributeId]) === -1) {
+                        var attributeStride = 1;
+                        if (attributeAccessor.byteStride > 0) {
+                            attributeStride = attributeAccessor.byteStride;
+                        }
+                        else {
+                            //Int16
+                            if (attributeAccessor.componentType === WebGLConstants.SHORT || attributeAccessor.componentType === WebGLConstants.UNSIGNED_SHORT) {
+                                attributeStride = 2;
+                            }
+                            //Float32
+                            if (attributeAccessor.componentType === WebGLConstants.FLOAT) {
+                                attributeStride = 4;
+                            }
+                        }
+
+                        var attributeIntervals = indexIntervals.slice();
+                        for (var k = 0; k < attributeIntervals.length; k++) {
+                            var attributeInterval = attributeIntervals[k];
+                            var viewStart = attributeAccessor.byteOffset + attributeInterval[0] * attributeStride;
+                            var intervalLength = attributeInterval[1] - attributeInterval[0] + 1;
+                            attributeIntervals[k] = [viewStart, (viewStart + intervalLength * attributeStride) - 1];
+
+                        }
+                        attributeView.extras._pipeline.accessors[attributes[attributeId]] = attributeIntervals;
+
+                        if (!defined(attributeAccessor.extras._pipeline.byteLength)) {
+                            attributeAccessor.extras._pipeline.originalByteLength = attributeStride * attributeAccessor.count;
+                        }
+                        attributeAccessor.count = newAccessorCount;
                     }
                 }
             }
         }
     }
+}
 
-    return gltf;
+//Go through the index intervals for each buffer view and remove unused sections from the corresponding buffers.
+function compressBuffers(accessors, bufferViews, buffers) {
+    //Process the buffer views in order based on their byte offset.
+    var sortedBufferViews = objectValues(bufferViews);
+    sortedBufferViews.sort(function(a, b) {
+        return a.byteOffset - b.byteOffset;
+    });
+    for (var i = 0; i < sortedBufferViews.length; i++) {
+        var bufferView = sortedBufferViews[i];
+        var accessorIds = Object.keys(bufferView.extras._pipeline.accessors);
+        if (Object.keys(accessorIds).length > 0) {
+            bufferView.extras._pipeline.offset = 0;
+            var viewedBuffer = buffers[bufferView.buffer];
+            var source = viewedBuffer.extras._pipeline.source;
+            var originalBufferOffset = defaultValue(viewedBuffer.extras._pipeline.offset, 0);
+            var originalViewEnd = bufferView.byteOffset + defaultValue(bufferView.byteLength, 0);
+
+            //Sort the accessors of the buffer view by their byte offset.
+            accessorIds.sort(function(a, b) {
+                return accessors[a].byteOffset - accessors[b].byteOffset;
+            });
+            //Reset the buffer view byte length to be recalculated as we process the accessors.
+            bufferView.byteLength = 0;
+
+            //Examine the intervals used by each accessor and remove sections from the buffer as gaps between intervals are encountered.
+            var previousEnd = 0;
+            for (var j = 0; j < accessorIds.length; j++) {
+                var viewAccessor = accessors[accessorIds[j]];
+                viewAccessor.byteOffset -= bufferView.extras._pipeline.offset;
+                var accessorIntervals = bufferView.extras._pipeline.accessors[accessorIds[j]];
+                var newAccessorLength = 0;
+                for (var k = 0; k < accessorIntervals.length; k++) {
+                    var accessorInterval = accessorIntervals[k];
+                    var gap = accessorInterval[0] - previousEnd;
+                    previousEnd = accessorInterval[1] + 1;
+
+                    var accessorStart = accessorInterval[0] + bufferView.byteOffset;
+                    var accessorLength = accessorInterval[1] - accessorInterval[0] + 1;
+                    var accessorEnd = accessorStart + accessorLength;
+
+                    var removeBufferSection = function(start, end) {
+                        source = Buffer.concat([source.slice(0, start), source.slice(end)]);
+                        viewedBuffer.extras._pipeline.source = source;
+                    };
+
+                    if (k === 0) {
+                        if (!defined(viewedBuffer.extras._pipeline.offset)) {
+                            viewedBuffer.extras._pipeline.offset = accessorInterval[0];
+                            if (accessorStart > bufferView.byteOffset) {
+                                removeBufferSection(bufferView.byteOffset, accessorStart);
+                            }
+                        }
+                        else {
+                            viewedBuffer.extras._pipeline.offset += gap;
+                            removeBufferSection(accessorStart - viewedBuffer.extras._pipeline.offset, accessorStart + gap - viewedBuffer.extras._pipeline.offset);
+                        }
+                    }
+                    else {
+                        if (gap > 0) {
+                            removeBufferSection(viewedBuffer.extras._pipeline.end - viewedBuffer.extras._pipeline.offset, accessorStart - viewedBuffer.extras._pipeline.offset);
+                            viewedBuffer.extras._pipeline.offset += gap;    
+                        }
+                    }
+
+                    viewedBuffer.extras._pipeline.end = accessorEnd;
+                    newAccessorLength += accessorLength;
+                }
+
+                //Calculate the new byte length and compare the new and original accessor lengths to find the number of indices removed, adding it to the offset.
+                bufferView.extras._pipeline.offset += viewAccessor.extras._pipeline.originalByteLength - newAccessorLength;
+                bufferView.byteLength += newAccessorLength;
+            }
+
+            //Remove the end the buffer view if it not used.
+            source = Buffer.concat([source.slice(0, viewedBuffer.extras._pipeline.end - viewedBuffer.extras._pipeline.offset), 
+                source.slice(originalViewEnd - viewedBuffer.extras._pipeline.offset)]);
+            viewedBuffer.extras._pipeline.source = source;
+            viewedBuffer.extras._pipeline.offset += originalViewEnd - viewedBuffer.extras._pipeline.end;   
+
+            bufferView.byteOffset -= originalBufferOffset;
+        }
+    }
+}
+
+//Update the accessed index values based on the offset from the corresponding indexIntervals.
+function updateIndices(bufferViews, buffers) {
+    for (var bufferViewId in bufferViews) {
+        if (bufferViews.hasOwnProperty(bufferViewId)) {
+            var bufferView = bufferViews[bufferViewId];
+            if (defined(bufferView.extras._pipeline.indexIntervals)) {
+                var buffer = buffers[bufferView.buffer];
+                var indexSource = buffer.extras._pipeline.source;
+                var indexIntervals = bufferView.extras._pipeline.indexIntervals;
+
+                //Sort the intervals by their start index.
+                indexIntervals.sort(function(a, b) {
+                    return a[0] - b[0];
+                });
+
+                //If the current interval overlaps with the previous interval, merge the two.
+                var previousInterval = indexIntervals[0];
+                for (var i = 1; i < indexIntervals.length; i++) {
+                    var currentInterval = indexIntervals[i];
+                    if (currentInterval[0] <= previousInterval[1] + 1) {
+                        previousInterval[1] = currentInterval[1];
+                        indexIntervals.splice(i, 1);
+                        i--;
+                    }
+                    else {
+                        previousInterval = currentInterval;
+                    }
+                }
+
+                //Create an array storing interval start values and the offset for indices within that interval.                
+                var offsetArray = [];
+                var totalOffset = indexIntervals[0][0];
+                offsetArray.push([indexIntervals[0][0], indexIntervals[0][0]]);
+                for (var j = 1; j < indexIntervals.length; j++) {
+                    var gap = indexIntervals[j][0] - (indexIntervals[j-1][1] + 1);
+                    totalOffset += gap;
+                    offsetArray.push([indexIntervals[j][0], totalOffset]);
+                }
+
+                //For each index in the buffer view, offset it based on the relevant interval in the offset array.
+                var sourceIndex = bufferView.byteOffset;
+                var viewEnd = bufferView.byteOffset + bufferView.byteLength;
+                var indexStride = bufferView.extras._pipeline.indexStride;
+                while (sourceIndex < viewEnd) {
+                    var index = (indexStride === 2) ? indexSource.readUInt16LE(sourceIndex) : indexSource.readUInt8LE(sourceIndex);
+                    for (var k = offsetArray.length - 1; k >= 0; k--) {
+                        if (index >= offsetArray[k][0]) {
+                            if (indexStride === 2) {
+                                indexSource.writeUInt16LE(index - offsetArray[k][1], sourceIndex);
+                            }
+                            else {
+                                indexSource.writeUInt8LE(index - offsetArray[k][1], sourceIndex);
+                            }
+                            break;
+                        }
+                    }
+                    sourceIndex += indexStride;
+                }
+            }
+        }
+    }
 }

--- a/lib/removeUnusedVertices.js
+++ b/lib/removeUnusedVertices.js
@@ -1,0 +1,71 @@
+'use strict';
+var Cesium = require('cesium');
+var defined = Cesium.defined;
+var defaultValue = Cesium.defaultValue;
+var objectValues = require('object-values');
+
+module.exports = removeUnusedVertices;
+
+//Removes unreferenced sections of buffers and updates their corresponding buffer views.
+function removeUnusedVertices(gltf) {
+    var buffers = gltf.buffers;
+    var bufferViews = gltf.bufferViews;
+
+    if (defined(bufferViews)) {
+        //Create and traverse an array of buffer views sorted by increasing byteOffset
+        var sortedBufferViews = objectValues(bufferViews);
+        sortedBufferViews.sort(function(a, b) {
+            return a.byteOffset - b.byteOffset;
+        });
+
+        for (var i = 0; i < sortedBufferViews.length; i++) {
+            var bufferView = sortedBufferViews[i];
+            var viewedBuffer = buffers[bufferView.buffer];
+            var source = viewedBuffer.extras._pipeline.source;
+            var viewStart = bufferView.byteOffset;
+            var viewLength = defaultValue(bufferView.byteLength, 0);
+            var viewEnd = viewStart + viewLength;
+
+            //While processing the buffer views, store the accumulated length of deleted portions of referenced buffers in the offset extra
+            //The end extra property denotes the largest index in the buffer referenced thus far by buffer views.
+            if (!defined(viewedBuffer.extras._pipeline.offset)) {
+                viewedBuffer.extras._pipeline.offset = viewStart;
+                viewedBuffer.extras._pipeline.end = viewStart + viewLength;
+                if (viewStart > 0) {
+                    bufferView.byteOffset = 0;
+                    viewedBuffer.extras._pipeline.source = source.slice(viewStart);
+                }
+            }
+            else {
+                if (viewStart > viewedBuffer.extras._pipeline.end) {
+                    viewedBuffer.extras._pipeline.source = Buffer.concat([source.slice(0, viewedBuffer.extras._pipeline.end - viewedBuffer.extras._pipeline.offset), 
+                        source.slice(viewStart - viewedBuffer.extras._pipeline.offset)]);
+                    viewedBuffer.extras._pipeline.offset += viewStart - viewedBuffer.extras._pipeline.end;
+                }
+                bufferView.byteOffset -= viewedBuffer.extras._pipeline.offset;
+
+                if (viewEnd > viewedBuffer.extras._pipeline.end) {
+                    viewedBuffer.extras._pipeline.end = viewEnd;
+                }
+            }
+        }
+
+        //Update the buffers based on their new source, offset, and end. The buffer will be deleted if it was never referenced.
+        if (defined(buffers)) {
+            for (var bufferId in buffers) {
+                if (buffers.hasOwnProperty(bufferId)) {
+                    var buffer = buffers[bufferId];
+                    if (!defined(buffer.extras._pipeline.offset)) {
+                        delete buffers[bufferId];
+                    }
+                    else {
+                        buffer.extras._pipeline.source = buffer.extras._pipeline.source.slice(0, buffer.extras._pipeline.end - buffer.extras._pipeline.offset);
+                        buffer.byteLength = buffer.extras._pipeline.source.length;
+                    }
+                }
+            }
+        }
+    }
+
+    return gltf;
+}

--- a/specs/lib/removeUnusedVerticesSpec.js
+++ b/specs/lib/removeUnusedVerticesSpec.js
@@ -1,179 +1,102 @@
 'use strict';
+var fs = require('fs');
+var path = require('path');
 var clone = require('clone');
 var bufferEqual = require('buffer-equal');
+var loadGltfUris = require('../../lib/loadGltfUris');
+var addPipelineExtras = require('../../lib/addPipelineExtras');
 var removeUnusedVertices = require('../../lib/removeUnusedVertices');
+var gltfPath = './specs/data/boxTexturedUnoptimized/CesiumTexturedBoxTest.gltf';
+
+var writeGltf = require('../../lib/writeGltf');
 
 describe('removeUnusedVertices', function() {
     var testBuffer = new Buffer(840);
-    var gltf = {
-        "buffers": {
-            "buffer_0": {
-                "uri": "data:,",
-                "byteLength": 840,
-                "extras": {
-                    "_pipeline": {
-                        "source": testBuffer
-                    }
-                }
+    var indexBuffer = new Buffer(1680);
+    for (var i = 0; i < 840; i++) {
+        indexBuffer.writeUInt16LE(i, 2*i);
+    }
+    var boxGltf;
+
+    beforeAll(function(done) {
+        fs.readFile(gltfPath, function(err, data) {
+            if (err) {
+                throw err;
             }
-        }
-    };
+            else {
+                boxGltf = JSON.parse(data);
+                addPipelineExtras(boxGltf);
+                loadGltfUris(boxGltf, path.dirname(gltfPath), function(err) {
+                    if (err) {
+                        throw err;
+                    }
+                    done();
+                });
+            }
+        });
+    });
 
     it('does not remove any data with a single buffer view', function() {
-        var testGltf = clone(gltf);
-        testGltf.bufferViews = {
-            "bufferView_0": {
-                "buffer": "buffer_0",
-                "byteOffset": 0,
-                "byteLength": 840
-            }
-        };
-        
+        var testGltf = createTestGltf([0, 840]);
         removeUnusedVertices(testGltf);
 
         expect(bufferEqual(testGltf.buffers.buffer_0.extras._pipeline.source, testBuffer)).toBe(true);
     });
 
     it('does not remove any data with overlapping buffer views', function() {
-        var testGltf = clone(gltf);
-        testGltf.bufferViews = {
-            "bufferView_0": {
-                "buffer": "buffer_0",
-                "byteOffset": 0,
-                "byteLength": 360
-            },
-            "bufferView_1": {
-                "buffer": "buffer_0",
-                "byteOffset": 240,
-                "byteLength": 600
-            }
-        };
-
+        var testGltf = createTestGltf([0, 360], [240, 600]);
         removeUnusedVertices(testGltf);
 
         expect(bufferEqual(testGltf.buffers.buffer_0.extras._pipeline.source, testBuffer)).toBe(true);
     });
 
     it('removes the beginning of a buffer', function() {
-        var testGltf = clone(gltf);
-        testGltf.bufferViews = {
-            "bufferView_0": {
-                "buffer": "buffer_0",
-                "byteOffset": 120,
-                "byteLength": 360
-            },
-            "bufferView_1": {
-                "buffer": "buffer_0",
-                "byteOffset": 240,
-                "byteLength": 600
-            }
-        };
-
+        var testGltf = createTestGltf([120, 360], [240, 600]);
         removeUnusedVertices(testGltf);
 
-        expect(bufferEqual(testGltf.buffers.buffer_0.extras._pipeline.source, testBuffer.slice(120))).toBe(true);
         expect(testGltf.buffers.buffer_0.byteLength).toEqual(720);
+        expect(bufferEqual(testGltf.buffers.buffer_0.extras._pipeline.source, testBuffer.slice(120))).toBe(true);
     });
 
     it('removes the middle of a buffer', function() {
-        var testGltf = clone(gltf);
-        testGltf.bufferViews = {
-            "bufferView_0": {
-                "buffer": "buffer_0",
-                "byteOffset": 0,
-                "byteLength": 360
-            },
-            "bufferView_1": {
-                "buffer": "buffer_0",
-                "byteOffset": 480,
-                "byteLength": 360
-            }
-        };
-
+        var testGltf = createTestGltf([0, 360], [480, 360]);
         removeUnusedVertices(testGltf);
 
+        expect(testGltf.buffers.buffer_0.byteLength).toEqual(720);
         expect(bufferEqual(testGltf.buffers.buffer_0.extras._pipeline.source, 
             Buffer.concat([testBuffer.slice(0, 360), testBuffer.slice(480)], 720))).toBe(true);
-        expect(testGltf.buffers.buffer_0.byteLength).toEqual(720);
     });
 
     it('removes the end of a buffer', function() {
-        var testGltf = clone(gltf);
-        testGltf.bufferViews = {
-            "bufferView_0": {
-                "buffer": "buffer_0",
-                "byteOffset": 0,
-                "byteLength": 360
-            },
-            "bufferView_1": {
-                "buffer": "buffer_0",
-                "byteOffset": 240,
-                "byteLength": 480
-            }
-        };
-
+        var testGltf = createTestGltf([0, 360], [240, 480]);
         removeUnusedVertices(testGltf);
 
-        expect(bufferEqual(testGltf.buffers.buffer_0.extras._pipeline.source, testBuffer.slice(0, 720))).toBe(true);
         expect(testGltf.buffers.buffer_0.byteLength).toEqual(720);
+        expect(bufferEqual(testGltf.buffers.buffer_0.extras._pipeline.source, testBuffer.slice(0, 720))).toBe(true);
     });
 
     it('removes multiple parts of a buffer', function() {
-        var testGltf = clone(gltf);
-        testGltf.bufferViews = {
-            "bufferView_0": {
-                "buffer": "buffer_0",
-                "byteOffset": 120,
-                "byteLength": 240
-            },
-            "bufferView_1": {
-                "buffer": "buffer_0",
-                "byteOffset": 240,
-                "byteLength": 360
-            },
-            "bufferView_2": {
-                "buffer": "buffer_0",
-                "byteOffset": 720,
-                "byteLength": 80
-            }
-        };
+        var testGltf = createTestGltf([120, 240], [240, 360], [720, 80]);
 
         removeUnusedVertices(testGltf);
 
+        expect(testGltf.buffers.buffer_0.byteLength).toEqual(560);
         expect(bufferEqual(testGltf.buffers.buffer_0.extras._pipeline.source, 
             Buffer.concat([testBuffer.slice(120, 600), testBuffer.slice(720, 800)], 560))).toBe(true);
-        expect(testGltf.buffers.buffer_0.byteLength).toEqual(560);
     });
 
     it('removes multiple parts of a buffer', function() {
-        var testGltf = clone(gltf);
-        testGltf.bufferViews = {
-            "bufferView_0": {
-                "buffer": "buffer_0",
-                "byteOffset": 120,
-                "byteLength": 120
-            },
-            "bufferView_1": {
-                "buffer": "buffer_0",
-                "byteOffset": 360,
-                "byteLength": 240
-            },
-            "bufferView_2": {
-                "buffer": "buffer_0",
-                "byteOffset": 720,
-                "byteLength": 80
-            }
-        };
-
+        var testGltf = createTestGltf([120, 120], [360, 240], [720, 80]);
         removeUnusedVertices(testGltf);
 
-        expect(bufferEqual(testGltf.buffers.buffer_0.extras._pipeline.source, Buffer.concat([testBuffer.slice(120, 240), testBuffer.slice(360, 600), testBuffer.slice(720, 800)], 440))).toBe(true);
         expect(testGltf.buffers.buffer_0.byteLength).toEqual(440);
+        expect(bufferEqual(testGltf.buffers.buffer_0.extras._pipeline.source, Buffer.concat([testBuffer.slice(120, 240), testBuffer.slice(360, 600), testBuffer.slice(720, 800)], 440))).toBe(true);
     });
 
     it('removes data from multiple buffers', function() {
-        var testGltf = clone(gltf);
         var testBuffer_1 = new Buffer(840);
+        var testGltf = createTestGltf([120, 720], [0, 720]);
+        testGltf.bufferViews.bufferView_1.buffer = 'buffer_1';
         testGltf.buffers.buffer_1 = {
             "uri": "data:,",
             "byteLength": 840,
@@ -184,29 +107,16 @@ describe('removeUnusedVertices', function() {
             }
         };
 
-        testGltf.bufferViews = {
-            "bufferView_0": {
-                "buffer": "buffer_0",
-                "byteOffset": 120,
-                "byteLength": 720
-            },
-            "bufferView_1": {
-                "buffer": "buffer_1",
-                "byteOffset": 0,
-                "byteLength": 720
-            }
-        };
-
         removeUnusedVertices(testGltf);
 
-        expect(bufferEqual(testGltf.buffers.buffer_0.extras._pipeline.source, testBuffer.slice(120, 840))).toBe(true);
         expect(testGltf.buffers.buffer_0.byteLength).toEqual(720);
-        expect(bufferEqual(testGltf.buffers.buffer_1.extras._pipeline.source, testBuffer_1.slice(0, 720))).toBe(true);
         expect(testGltf.buffers.buffer_1.byteLength).toEqual(720);
+        expect(bufferEqual(testGltf.buffers.buffer_0.extras._pipeline.source, testBuffer.slice(120, 840))).toBe(true);
+        expect(bufferEqual(testGltf.buffers.buffer_1.extras._pipeline.source, testBuffer_1.slice(0, 720))).toBe(true);
     });
 
     it('deletes an unreferenced buffer', function() {
-        var testGltf = clone(gltf);
+        var testGltf = createTestGltf([120, 720]);
         testGltf.buffers.buffer_1 = {
             "uri": "data:,",
             "byteLength": 840,
@@ -217,18 +127,387 @@ describe('removeUnusedVertices', function() {
             }
         };
 
-        testGltf.bufferViews = {
-            "bufferView_0": {
-                "buffer": "buffer_0",
-                "byteOffset": 120,
-                "byteLength": 720
+        removeUnusedVertices(testGltf);
+
+        expect(testGltf.buffers.buffer_0.byteLength).toEqual(720);
+        expect(testGltf.buffers.buffer_1).not.toBeDefined();
+        expect(bufferEqual(testGltf.buffers.buffer_0.extras._pipeline.source, testBuffer.slice(120, 840))).toBe(true);
+    });
+
+    it('removes the beginning of a bufferView', function() {
+        var testIndexBuffer = new Buffer(indexBuffer);
+        for (var i = 0; i < 240; i++) {
+            testIndexBuffer.writeUInt16LE(240, 2*i);
+        }
+        var testGltf = createTestGltf([120, 720]);
+        testGltf.buffers.index_buffer.extras._pipeline.source = testIndexBuffer;
+        removeUnusedVertices(testGltf);
+
+        expect(testGltf.accessors.accessor_0.byteOffset).toEqual(0);
+        expect(testGltf.accessors.accessor_0.count).toEqual(480);
+        expect(testGltf.buffers.buffer_0.byteLength).toEqual(480);
+        expect(testGltf.bufferViews.bufferView_0.byteOffset).toEqual(0);
+        expect(testGltf.bufferViews.bufferView_0.byteLength).toEqual(480);
+        expect(bufferEqual(testGltf.buffers.buffer_0.extras._pipeline.source, testBuffer.slice(360))).toBe(true);
+    });
+
+    it('removes the middle of a bufferView', function() {
+        var testIndexBuffer = new Buffer(indexBuffer);
+        for (var i = 240; i < 360; i++) {
+            testIndexBuffer.writeUInt16LE(360, 2*i);
+        }
+        var testGltf = createTestGltf([0, 840]);
+        testGltf.buffers.index_buffer.extras._pipeline.source = testIndexBuffer;
+        removeUnusedVertices(testGltf);
+
+        expect(testGltf.accessors.accessor_0.byteOffset).toEqual(0);
+        expect(testGltf.accessors.accessor_0.count).toEqual(720);
+        expect(testGltf.buffers.buffer_0.byteLength).toEqual(720);
+        expect(testGltf.bufferViews.bufferView_0.byteOffset).toEqual(0);
+        expect(testGltf.bufferViews.bufferView_0.byteLength).toEqual(720);
+        expect(bufferEqual(testGltf.buffers.buffer_0.extras._pipeline.source, 
+            Buffer.concat([testBuffer.slice(0, 240), testBuffer.slice(360)], 720))).toBe(true);
+    });
+
+    it('removes the end of a bufferView', function() {
+        var testIndexBuffer = new Buffer(indexBuffer);
+        for (var i = 720; i < 840; i++) {
+            testIndexBuffer.writeUInt16LE(719, 2*i);
+        }
+        var testGltf = createTestGltf([0, 840]);
+        testGltf.buffers.index_buffer.extras._pipeline.source = testIndexBuffer;
+        removeUnusedVertices(testGltf);
+
+        expect(testGltf.accessors.accessor_0.byteOffset).toEqual(0);
+        expect(testGltf.accessors.accessor_0.count).toEqual(720);
+        expect(testGltf.buffers.buffer_0.byteLength).toEqual(720);
+        expect(testGltf.bufferViews.bufferView_0.byteOffset).toEqual(0);
+        expect(testGltf.bufferViews.bufferView_0.byteLength).toEqual(720);
+        expect(bufferEqual(testGltf.buffers.buffer_0.extras._pipeline.source, testBuffer.slice(0, 720))).toBe(true);
+    });
+
+    it('removes multiple parts of a bufferView', function() {
+        var testIndexBuffer = new Buffer(indexBuffer);
+        for (var i = 0; i < 120; i++) {
+            testIndexBuffer.writeUInt16LE(120, 2*i);
+        }
+        for (var i = 360; i < 480; i++) {
+            testIndexBuffer.writeUInt16LE(480, 2*i);
+        }
+        for (var i = 720; i < 840; i++) {
+            testIndexBuffer.writeUInt16LE(719, 2*i);
+        }
+        var testGltf = createTestGltf([0, 840]);
+        testGltf.buffers.index_buffer.extras._pipeline.source = testIndexBuffer;
+        removeUnusedVertices(testGltf);
+
+        expect(testGltf.accessors.accessor_0.byteOffset).toEqual(0);
+        expect(testGltf.accessors.accessor_0.count).toEqual(480);
+        expect(testGltf.buffers.buffer_0.byteLength).toEqual(480);
+        expect(testGltf.bufferViews.bufferView_0.byteOffset).toEqual(0);
+        expect(testGltf.bufferViews.bufferView_0.byteLength).toEqual(480);
+        expect(bufferEqual(testGltf.buffers.buffer_0.extras._pipeline.source, 
+            Buffer.concat([testBuffer.slice(120, 360), testBuffer.slice(480, 720)], 480))).toBe(true);
+    });
+
+    it('removes multiple parts of a bufferView', function() {
+        var testIndexBuffer = new Buffer(indexBuffer);
+        for (var i = 0; i < 80; i++) {
+            testIndexBuffer.writeUInt16LE(80, 2*i);
+        }
+        for (var i = 160; i < 240; i++) {
+            testIndexBuffer.writeUInt16LE(240, 2*i);
+        }
+        for (var i = 360; i < 420; i++) {
+            testIndexBuffer.writeUInt16LE(359, 2*i);
+        }
+        var testGltf = createTestGltf([0, 420], [420, 420]);
+        testGltf.buffers.index_buffer.extras._pipeline.source = testIndexBuffer;
+        removeUnusedVertices(testGltf);
+
+        expect(testGltf.accessors.accessor_0.byteOffset).toEqual(0);
+        expect(testGltf.accessors.accessor_0.count).toEqual(200);
+        expect(testGltf.accessors.accessor_1.byteOffset).toEqual(0);
+        expect(testGltf.accessors.accessor_1.count).toEqual(200);
+        expect(testGltf.buffers.buffer_0.byteLength).toEqual(400);
+        expect(testGltf.bufferViews.bufferView_0.byteOffset).toEqual(0);
+        expect(testGltf.bufferViews.bufferView_1.byteOffset).toEqual(200);
+        expect(testGltf.bufferViews.bufferView_0.byteLength).toEqual(200);
+        expect(testGltf.bufferViews.bufferView_1.byteLength).toEqual(200);
+        expect(bufferEqual(testGltf.buffers.buffer_0.extras._pipeline.source, 
+            Buffer.concat([testBuffer.slice(80, 160), testBuffer.slice(240, 360),
+                testBuffer.slice(500, 580), testBuffer.slice(660, 780)], 400))).toBe(true);
+
+        delete testGltf.buffers.buffer_0.extras;
+    });
+
+    it('removes the beginning of the box bufferView', function() {
+        var testBoxGltf = clone(boxGltf);
+        testBoxGltf.buffers.CesiumTexturedBoxTest.extras._pipeline.source.writeUInt16LE(4, 2 * 0);
+        testBoxGltf.buffers.CesiumTexturedBoxTest.extras._pipeline.source.writeUInt16LE(5, 2 * 1);
+        testBoxGltf.buffers.CesiumTexturedBoxTest.extras._pipeline.source.writeUInt16LE(6, 2 * 2);
+
+        testBoxGltf.buffers.CesiumTexturedBoxTest.extras._pipeline.source.writeUInt16LE(7, 2 * 3);
+        testBoxGltf.buffers.CesiumTexturedBoxTest.extras._pipeline.source.writeUInt16LE(6, 2 * 4);
+        testBoxGltf.buffers.CesiumTexturedBoxTest.extras._pipeline.source.writeUInt16LE(5, 2 * 5);
+
+        removeUnusedVertices(testBoxGltf);
+
+        expect(testBoxGltf.accessors.accessor_23.byteOffset).toEqual(0);
+        expect(testBoxGltf.accessors.accessor_23.count).toEqual(20);
+        expect(testBoxGltf.accessors.accessor_25.byteOffset).toEqual(240);
+        expect(testBoxGltf.accessors.accessor_25.count).toEqual(20);
+        expect(testBoxGltf.accessors.accessor_27.byteOffset).toEqual(480);
+        expect(testBoxGltf.accessors.accessor_27.count).toEqual(20);
+
+        expect(testBoxGltf.bufferViews.bufferView_29.byteOffset).toEqual(0);
+        expect(testBoxGltf.bufferViews.bufferView_29.byteLength).toEqual(72);
+        expect(testBoxGltf.bufferViews.bufferView_30.byteOffset).toEqual(72);
+        expect(testBoxGltf.bufferViews.bufferView_30.byteLength).toEqual(640);
+
+        expect(testBoxGltf.buffers.CesiumTexturedBoxTest.byteLength).toEqual(712);
+
+        var oldPositionBuffer = boxGltf.buffers.CesiumTexturedBoxTest.extras._pipeline.source.slice(72, 360);
+        var oldNormalBuffer = boxGltf.buffers.CesiumTexturedBoxTest.extras._pipeline.source.slice(360, 648);
+        var oldTextureBuffer = boxGltf.buffers.CesiumTexturedBoxTest.extras._pipeline.source.slice(648, 840);
+        
+        var newPositionBuffer = testBoxGltf.buffers.CesiumTexturedBoxTest.extras._pipeline.source.slice(72, 312);
+        var newNormalBuffer = testBoxGltf.buffers.CesiumTexturedBoxTest.extras._pipeline.source.slice(312, 552);
+        var newTextureBuffer = testBoxGltf.buffers.CesiumTexturedBoxTest.extras._pipeline.source.slice(552, 712);
+
+        expect(bufferEqual(newPositionBuffer, oldPositionBuffer.slice(48))).toBe(true);
+        expect(bufferEqual(newNormalBuffer, oldNormalBuffer.slice(48))).toBe(true);
+        expect(bufferEqual(newTextureBuffer, oldTextureBuffer.slice(32))).toBe(true);
+    });
+
+    it('removes the middle of the box bufferView', function() {
+        var testBoxGltf = clone(boxGltf);
+        testBoxGltf.buffers.CesiumTexturedBoxTest.extras._pipeline.source.writeUInt16LE(0, 2 * 12);
+        testBoxGltf.buffers.CesiumTexturedBoxTest.extras._pipeline.source.writeUInt16LE(1, 2 * 13);
+        testBoxGltf.buffers.CesiumTexturedBoxTest.extras._pipeline.source.writeUInt16LE(2, 2 * 14);
+        testBoxGltf.buffers.CesiumTexturedBoxTest.extras._pipeline.source.writeUInt16LE(3, 2 * 15);
+        testBoxGltf.buffers.CesiumTexturedBoxTest.extras._pipeline.source.writeUInt16LE(2, 2 * 16);
+        testBoxGltf.buffers.CesiumTexturedBoxTest.extras._pipeline.source.writeUInt16LE(1, 2 * 17);
+
+        removeUnusedVertices(testBoxGltf);
+
+        expect(testBoxGltf.accessors.accessor_23.byteOffset).toEqual(0);
+        expect(testBoxGltf.accessors.accessor_23.count).toEqual(20);
+        expect(testBoxGltf.accessors.accessor_25.byteOffset).toEqual(240);
+        expect(testBoxGltf.accessors.accessor_25.count).toEqual(20);
+        expect(testBoxGltf.accessors.accessor_27.byteOffset).toEqual(480);
+        expect(testBoxGltf.accessors.accessor_27.count).toEqual(20);
+
+        expect(testBoxGltf.bufferViews.bufferView_29.byteOffset).toEqual(0);
+        expect(testBoxGltf.bufferViews.bufferView_29.byteLength).toEqual(72);
+        expect(testBoxGltf.bufferViews.bufferView_30.byteOffset).toEqual(72);
+        expect(testBoxGltf.bufferViews.bufferView_30.byteLength).toEqual(640);
+
+        expect(testBoxGltf.buffers.CesiumTexturedBoxTest.byteLength).toEqual(712);
+
+        var oldPositionBuffer = boxGltf.buffers.CesiumTexturedBoxTest.extras._pipeline.source.slice(72, 360);
+        var oldNormalBuffer = boxGltf.buffers.CesiumTexturedBoxTest.extras._pipeline.source.slice(360, 648);
+        var oldTextureBuffer = boxGltf.buffers.CesiumTexturedBoxTest.extras._pipeline.source.slice(648, 840);
+        
+        var newPositionBuffer = testBoxGltf.buffers.CesiumTexturedBoxTest.extras._pipeline.source.slice(72, 312);
+        var newNormalBuffer = testBoxGltf.buffers.CesiumTexturedBoxTest.extras._pipeline.source.slice(312, 552);
+        var newTextureBuffer = testBoxGltf.buffers.CesiumTexturedBoxTest.extras._pipeline.source.slice(552, 712);
+
+        expect(bufferEqual(newPositionBuffer, Buffer.concat([oldPositionBuffer.slice(0, 96), 
+            oldPositionBuffer.slice(144)], 240))).toBe(true);
+
+        expect(bufferEqual(newNormalBuffer, Buffer.concat([oldNormalBuffer.slice(0, 96), 
+            oldNormalBuffer.slice(144)], 240))).toBe(true);
+
+        expect(bufferEqual(newTextureBuffer, Buffer.concat([oldTextureBuffer.slice(0, 64), 
+            oldTextureBuffer.slice(96)], 160))).toBe(true);
+    });
+
+    it('removes the end of the box bufferView', function() {
+        var testBoxGltf = clone(boxGltf);
+        testBoxGltf.buffers.CesiumTexturedBoxTest.extras._pipeline.source.writeUInt16LE(0, 2 * 30);
+        testBoxGltf.buffers.CesiumTexturedBoxTest.extras._pipeline.source.writeUInt16LE(1, 2 * 31);
+        testBoxGltf.buffers.CesiumTexturedBoxTest.extras._pipeline.source.writeUInt16LE(2, 2 * 32);
+
+        testBoxGltf.buffers.CesiumTexturedBoxTest.extras._pipeline.source.writeUInt16LE(3, 2 * 33);
+        testBoxGltf.buffers.CesiumTexturedBoxTest.extras._pipeline.source.writeUInt16LE(2, 2 * 34);
+        testBoxGltf.buffers.CesiumTexturedBoxTest.extras._pipeline.source.writeUInt16LE(1, 2 * 35);
+
+        removeUnusedVertices(testBoxGltf);
+
+        expect(testBoxGltf.accessors.accessor_23.byteOffset).toEqual(0);
+        expect(testBoxGltf.accessors.accessor_23.count).toEqual(20);
+        expect(testBoxGltf.accessors.accessor_25.byteOffset).toEqual(240);
+        expect(testBoxGltf.accessors.accessor_25.count).toEqual(20);
+        expect(testBoxGltf.accessors.accessor_27.byteOffset).toEqual(480);
+        expect(testBoxGltf.accessors.accessor_27.count).toEqual(20);
+
+        expect(testBoxGltf.bufferViews.bufferView_29.byteOffset).toEqual(0);
+        expect(testBoxGltf.bufferViews.bufferView_29.byteLength).toEqual(72);
+        expect(testBoxGltf.bufferViews.bufferView_30.byteOffset).toEqual(72);
+        expect(testBoxGltf.bufferViews.bufferView_30.byteLength).toEqual(640);
+
+        expect(testBoxGltf.buffers.CesiumTexturedBoxTest.byteLength).toEqual(712);
+
+        var oldPositionBuffer = boxGltf.buffers.CesiumTexturedBoxTest.extras._pipeline.source.slice(72, 360);
+        var oldNormalBuffer = boxGltf.buffers.CesiumTexturedBoxTest.extras._pipeline.source.slice(360, 648);
+        var oldTextureBuffer = boxGltf.buffers.CesiumTexturedBoxTest.extras._pipeline.source.slice(648, 840);
+        
+        var newPositionBuffer = testBoxGltf.buffers.CesiumTexturedBoxTest.extras._pipeline.source.slice(72, 312);
+        var newNormalBuffer = testBoxGltf.buffers.CesiumTexturedBoxTest.extras._pipeline.source.slice(312, 552);
+        var newTextureBuffer = testBoxGltf.buffers.CesiumTexturedBoxTest.extras._pipeline.source.slice(552, 712);
+
+        expect(bufferEqual(newPositionBuffer, oldPositionBuffer.slice(0, 240))).toBe(true);
+        expect(bufferEqual(newNormalBuffer, oldNormalBuffer.slice(0, 240))).toBe(true);
+        expect(bufferEqual(newTextureBuffer, oldTextureBuffer.slice(0, 160))).toBe(true);
+    });
+
+    it('removes multiple parts of the box bufferView', function() {
+        var testBoxGltf = clone(boxGltf);
+        testBoxGltf.buffers.CesiumTexturedBoxTest.extras._pipeline.source.writeUInt16LE(4, 2 * 0);
+        testBoxGltf.buffers.CesiumTexturedBoxTest.extras._pipeline.source.writeUInt16LE(5, 2 * 1);
+        testBoxGltf.buffers.CesiumTexturedBoxTest.extras._pipeline.source.writeUInt16LE(6, 2 * 2);
+        testBoxGltf.buffers.CesiumTexturedBoxTest.extras._pipeline.source.writeUInt16LE(7, 2 * 3);
+        testBoxGltf.buffers.CesiumTexturedBoxTest.extras._pipeline.source.writeUInt16LE(6, 2 * 4);
+        testBoxGltf.buffers.CesiumTexturedBoxTest.extras._pipeline.source.writeUInt16LE(5, 2 * 5);
+
+        testBoxGltf.buffers.CesiumTexturedBoxTest.extras._pipeline.source.writeUInt16LE(4, 2 * 12);
+        testBoxGltf.buffers.CesiumTexturedBoxTest.extras._pipeline.source.writeUInt16LE(5, 2 * 13);
+        testBoxGltf.buffers.CesiumTexturedBoxTest.extras._pipeline.source.writeUInt16LE(6, 2 * 14);
+        testBoxGltf.buffers.CesiumTexturedBoxTest.extras._pipeline.source.writeUInt16LE(7, 2 * 15);
+        testBoxGltf.buffers.CesiumTexturedBoxTest.extras._pipeline.source.writeUInt16LE(6, 2 * 16);
+        testBoxGltf.buffers.CesiumTexturedBoxTest.extras._pipeline.source.writeUInt16LE(5, 2 * 17);
+
+        testBoxGltf.buffers.CesiumTexturedBoxTest.extras._pipeline.source.writeUInt16LE(4, 2 * 30);
+        testBoxGltf.buffers.CesiumTexturedBoxTest.extras._pipeline.source.writeUInt16LE(5, 2 * 31);
+        testBoxGltf.buffers.CesiumTexturedBoxTest.extras._pipeline.source.writeUInt16LE(6, 2 * 32);
+        testBoxGltf.buffers.CesiumTexturedBoxTest.extras._pipeline.source.writeUInt16LE(7, 2 * 33);
+        testBoxGltf.buffers.CesiumTexturedBoxTest.extras._pipeline.source.writeUInt16LE(6, 2 * 34);
+        testBoxGltf.buffers.CesiumTexturedBoxTest.extras._pipeline.source.writeUInt16LE(5, 2 * 35);
+
+        removeUnusedVertices(testBoxGltf);
+
+        expect(testBoxGltf.accessors.accessor_23.byteOffset).toEqual(0);
+        expect(testBoxGltf.accessors.accessor_23.count).toEqual(12);
+        expect(testBoxGltf.accessors.accessor_25.byteOffset).toEqual(144);
+        expect(testBoxGltf.accessors.accessor_25.count).toEqual(12);
+        expect(testBoxGltf.accessors.accessor_27.byteOffset).toEqual(288);
+        expect(testBoxGltf.accessors.accessor_27.count).toEqual(12);
+
+        expect(testBoxGltf.bufferViews.bufferView_29.byteOffset).toEqual(0);
+        expect(testBoxGltf.bufferViews.bufferView_29.byteLength).toEqual(72);
+        expect(testBoxGltf.bufferViews.bufferView_30.byteOffset).toEqual(72);
+        expect(testBoxGltf.bufferViews.bufferView_30.byteLength).toEqual(384);
+
+        expect(testBoxGltf.buffers.CesiumTexturedBoxTest.byteLength).toEqual(456);
+
+        var oldPositionBuffer = boxGltf.buffers.CesiumTexturedBoxTest.extras._pipeline.source.slice(72, 360);
+        var oldNormalBuffer = boxGltf.buffers.CesiumTexturedBoxTest.extras._pipeline.source.slice(360, 648);
+        var oldTextureBuffer = boxGltf.buffers.CesiumTexturedBoxTest.extras._pipeline.source.slice(648, 840);
+        
+        var newPositionBuffer = testBoxGltf.buffers.CesiumTexturedBoxTest.extras._pipeline.source.slice(72, 216);
+        var newNormalBuffer = testBoxGltf.buffers.CesiumTexturedBoxTest.extras._pipeline.source.slice(216, 360);
+        var newTextureBuffer = testBoxGltf.buffers.CesiumTexturedBoxTest.extras._pipeline.source.slice(360, 456);
+
+        expect(bufferEqual(newPositionBuffer, Buffer.concat([oldPositionBuffer.slice(48, 96), 
+            oldPositionBuffer.slice(144, 240)], 144))).toBe(true);
+
+        expect(bufferEqual(newNormalBuffer, Buffer.concat([oldNormalBuffer.slice(48, 96), 
+            oldNormalBuffer.slice(144, 240)], 144))).toBe(true);
+
+        expect(bufferEqual(newTextureBuffer, Buffer.concat([oldTextureBuffer.slice(32, 64), 
+            oldTextureBuffer.slice(96, 160)], 96))).toBe(true);
+    });
+
+    function createTestGltf() {
+        var testGltf = {
+            "accessors": {
+            },
+            "buffers": {
+                "buffer_0": {
+                    "uri": "data:,",
+                    "byteLength": 840,
+                    "extras": {
+                        "_pipeline": {
+                            "source": new Buffer(testBuffer)
+                        }
+                    }
+                },
+                "index_buffer": {
+                    "uri": "data:,",
+                    "byteLength": 840,
+                    "extras": {
+                        "_pipeline": {
+                            "source": new Buffer(indexBuffer)
+                        }
+                    }
+                }
+            },
+            "bufferViews": {
+                "index_bufferView": {
+                    "buffer": "index_buffer",
+                    "byteOffset": 0,
+                    "byteLength": 1680,
+                    "extras": {
+                        "_pipeline": {
+                        }
+                    }
+                }
+            },
+            "meshes": {
+                "mesh_0": {
+                    "primitives": []
+                }
             }
         };
 
-        removeUnusedVertices(testGltf);
+        for (var i = 0; i < arguments.length; i++) {
+            var offset = arguments[i][0];
+            var length = arguments[i][1];
 
-        expect(testGltf.buffers.buffer_1).not.toBeDefined();
-        expect(bufferEqual(testGltf.buffers.buffer_0.extras._pipeline.source, testBuffer.slice(120, 840))).toBe(true);
-        expect(testGltf.buffers.buffer_0.byteLength).toEqual(720);
-    });
+            var accessorId = 'accessor_' + i;
+            var indexAccessorId = 'index_accessor_' + i;
+            var bufferViewId = 'bufferView_' + i;
+            testGltf.bufferViews[bufferViewId] = {
+                "buffer": "buffer_0",
+                "byteOffset": offset,
+                "byteLength": length,
+                "extras": {
+                    "_pipeline": {}
+                }
+            }
+            
+            testGltf.accessors[accessorId] = {
+                "bufferView": bufferViewId,
+                "byteOffset": 0,
+                "componentType": 5121,
+                "count": length,
+                "type": "SCALAR",
+                "extras": {
+                    "_pipeline": {}
+                }
+            };
+
+            testGltf.accessors[indexAccessorId] = {
+                "bufferView": "index_bufferView",
+                "byteOffset": 0,
+                "componentType": 5123,
+                "count": length,
+                "type": "SCALAR",
+                "extras": {
+                    "_pipeline": {}
+                }
+            };
+
+            testGltf.meshes.mesh_0.primitives.push({
+                "attributes": {
+                    "attribute_0": accessorId
+                },
+                "indices": indexAccessorId,
+                "material": "Effect-Texture",
+                "mode": 4
+            });
+        }
+        return testGltf;
+    }
 });

--- a/specs/lib/removeUnusedVerticesSpec.js
+++ b/specs/lib/removeUnusedVerticesSpec.js
@@ -31,8 +31,6 @@ describe('removeUnusedVertices', function() {
         
         removeUnusedVertices(testGltf);
 
-        delete testGltf.buffers.buffer_0.extras._pipeline.offset;
-        delete testGltf.buffers.buffer_0.extras._pipeline.end;
         expect(bufferEqual(testGltf.buffers.buffer_0.extras._pipeline.source, testBuffer)).toBe(true);
     });
 
@@ -53,8 +51,6 @@ describe('removeUnusedVertices', function() {
 
         removeUnusedVertices(testGltf);
 
-        delete testGltf.buffers.buffer_0.extras._pipeline.offset;
-        delete testGltf.buffers.buffer_0.extras._pipeline.end;
         expect(bufferEqual(testGltf.buffers.buffer_0.extras._pipeline.source, testBuffer)).toBe(true);
     });
 
@@ -75,8 +71,6 @@ describe('removeUnusedVertices', function() {
 
         removeUnusedVertices(testGltf);
 
-        delete testGltf.buffers.buffer_0.extras._pipeline.offset;
-        delete testGltf.buffers.buffer_0.extras._pipeline.end;
         expect(bufferEqual(testGltf.buffers.buffer_0.extras._pipeline.source, testBuffer.slice(120))).toBe(true);
         expect(testGltf.buffers.buffer_0.byteLength).toEqual(720);
     });
@@ -98,8 +92,6 @@ describe('removeUnusedVertices', function() {
 
         removeUnusedVertices(testGltf);
 
-        delete testGltf.buffers.buffer_0.extras._pipeline.offset;
-        delete testGltf.buffers.buffer_0.extras._pipeline.end;
         expect(bufferEqual(testGltf.buffers.buffer_0.extras._pipeline.source, 
             Buffer.concat([testBuffer.slice(0, 360), testBuffer.slice(480)], 720))).toBe(true);
         expect(testGltf.buffers.buffer_0.byteLength).toEqual(720);
@@ -122,8 +114,6 @@ describe('removeUnusedVertices', function() {
 
         removeUnusedVertices(testGltf);
 
-        delete testGltf.buffers.buffer_0.extras._pipeline.offset;
-        delete testGltf.buffers.buffer_0.extras._pipeline.end;
         expect(bufferEqual(testGltf.buffers.buffer_0.extras._pipeline.source, testBuffer.slice(0, 720))).toBe(true);
         expect(testGltf.buffers.buffer_0.byteLength).toEqual(720);
     });
@@ -150,8 +140,6 @@ describe('removeUnusedVertices', function() {
 
         removeUnusedVertices(testGltf);
 
-        delete testGltf.buffers.buffer_0.extras._pipeline.offset;
-        delete testGltf.buffers.buffer_0.extras._pipeline.end;
         expect(bufferEqual(testGltf.buffers.buffer_0.extras._pipeline.source, 
             Buffer.concat([testBuffer.slice(120, 600), testBuffer.slice(720, 800)], 560))).toBe(true);
         expect(testGltf.buffers.buffer_0.byteLength).toEqual(560);
@@ -179,8 +167,6 @@ describe('removeUnusedVertices', function() {
 
         removeUnusedVertices(testGltf);
 
-        delete testGltf.buffers.buffer_0.extras._pipeline.offset;
-        delete testGltf.buffers.buffer_0.extras._pipeline.end;
         expect(bufferEqual(testGltf.buffers.buffer_0.extras._pipeline.source, Buffer.concat([testBuffer.slice(120, 240), testBuffer.slice(360, 600), testBuffer.slice(720, 800)], 440))).toBe(true);
         expect(testGltf.buffers.buffer_0.byteLength).toEqual(440);
     });
@@ -213,15 +199,9 @@ describe('removeUnusedVertices', function() {
 
         removeUnusedVertices(testGltf);
 
-        delete testGltf.buffers.buffer_0.extras._pipeline.offset;
-        delete testGltf.buffers.buffer_0.extras._pipeline.end;
-        delete testGltf.buffers.buffer_1.extras._pipeline.offset;
-        delete testGltf.buffers.buffer_1.extras._pipeline.end;
         expect(bufferEqual(testGltf.buffers.buffer_0.extras._pipeline.source, testBuffer.slice(120, 840))).toBe(true);
-        expect(testGltf.buffers.buffer_0.extras._pipeline.source).toEqual(testBuffer.slice(120, 840));
         expect(testGltf.buffers.buffer_0.byteLength).toEqual(720);
         expect(bufferEqual(testGltf.buffers.buffer_1.extras._pipeline.source, testBuffer_1.slice(0, 720))).toBe(true);
-        expect(testGltf.buffers.buffer_1.extras._pipeline.source).toEqual(testBuffer_1.slice(0, 720));
         expect(testGltf.buffers.buffer_1.byteLength).toEqual(720);
     });
 

--- a/specs/lib/removeUnusedVerticesSpec.js
+++ b/specs/lib/removeUnusedVerticesSpec.js
@@ -1,0 +1,249 @@
+'use strict';
+var clone = require('clone');
+var removeUnusedVertices = require('../../lib/removeUnusedVertices');
+
+describe('removeUnusedVertices', function() {
+    var testBuffer = new Buffer(840);
+    var gltf = {
+        "buffers": {
+            "buffer_0": {
+                "uri": "data:,",
+                "byteLength": 840,
+                "extras": {
+                    "_pipeline": {
+                        "source": testBuffer
+                    }
+                }
+            }
+        }
+    };
+
+    it('does not remove any data with a single buffer view', function() {
+        var testGltf = clone(gltf);
+        testGltf.bufferViews = {
+            "bufferView_0": {
+                "buffer": "buffer_0",
+                "byteOffset": 0,
+                "byteLength": 840
+            }
+        };
+        
+        removeUnusedVertices(testGltf);
+
+        delete testGltf.buffers.buffer_0.extras._pipeline.offset;
+        delete testGltf.buffers.buffer_0.extras._pipeline.end;
+        expect(testGltf.buffers).toEqual(gltf.buffers);
+    });
+
+    it('does not remove any data with overlapping buffer views', function() {
+        var testGltf = clone(gltf);
+        testGltf.bufferViews = {
+            "bufferView_0": {
+                "buffer": "buffer_0",
+                "byteOffset": 0,
+                "byteLength": 360
+            },
+            "bufferView_1": {
+                "buffer": "buffer_0",
+                "byteOffset": 240,
+                "byteLength": 600
+            }
+        };
+
+        removeUnusedVertices(testGltf);
+
+        delete testGltf.buffers.buffer_0.extras._pipeline.offset;
+        delete testGltf.buffers.buffer_0.extras._pipeline.end;
+        expect(testGltf.buffers).toEqual(gltf.buffers);
+    });
+
+    it('removes the beginning of a buffer', function() {
+        var testGltf = clone(gltf);
+        testGltf.bufferViews = {
+            "bufferView_0": {
+                "buffer": "buffer_0",
+                "byteOffset": 120,
+                "byteLength": 360
+            },
+            "bufferView_1": {
+                "buffer": "buffer_0",
+                "byteOffset": 240,
+                "byteLength": 600
+            }
+        };
+
+        removeUnusedVertices(testGltf);
+
+        delete testGltf.buffers.buffer_0.extras._pipeline.offset;
+        delete testGltf.buffers.buffer_0.extras._pipeline.end;
+        expect(testGltf.buffers.buffer_0.extras._pipeline.source).toEqual(testBuffer.slice(120));
+        expect(testGltf.buffers.buffer_0.byteLength).toEqual(720);
+    });
+
+    it('removes the middle of a buffer', function() {
+        var testGltf = clone(gltf);
+        testGltf.bufferViews = {
+            "bufferView_0": {
+                "buffer": "buffer_0",
+                "byteOffset": 0,
+                "byteLength": 360
+            },
+            "bufferView_1": {
+                "buffer": "buffer_0",
+                "byteOffset": 480,
+                "byteLength": 360
+            }
+        };
+
+        removeUnusedVertices(testGltf);
+
+        delete testGltf.buffers.buffer_0.extras._pipeline.offset;
+        delete testGltf.buffers.buffer_0.extras._pipeline.end;
+        expect(testGltf.buffers.buffer_0.extras._pipeline.source).toEqual(Buffer.concat([testBuffer.slice(0, 360), testBuffer.slice(480)], 720));
+        expect(testGltf.buffers.buffer_0.byteLength).toEqual(720);
+    });
+
+    it('removes the end of a buffer', function() {
+        var testGltf = clone(gltf);
+        testGltf.bufferViews = {
+            "bufferView_0": {
+                "buffer": "buffer_0",
+                "byteOffset": 0,
+                "byteLength": 360
+            },
+            "bufferView_1": {
+                "buffer": "buffer_0",
+                "byteOffset": 240,
+                "byteLength": 480
+            }
+        };
+
+        removeUnusedVertices(testGltf);
+
+        delete testGltf.buffers.buffer_0.extras._pipeline.offset;
+        delete testGltf.buffers.buffer_0.extras._pipeline.end;
+        expect(testGltf.buffers.buffer_0.extras._pipeline.source).toEqual(testBuffer.slice(0, 720));
+        expect(testGltf.buffers.buffer_0.byteLength).toEqual(720);
+    });
+
+    it('removes multiple parts of a buffer', function() {
+        var testGltf = clone(gltf);
+        testGltf.bufferViews = {
+            "bufferView_0": {
+                "buffer": "buffer_0",
+                "byteOffset": 120,
+                "byteLength": 240
+            },
+            "bufferView_1": {
+                "buffer": "buffer_0",
+                "byteOffset": 240,
+                "byteLength": 360
+            },
+            "bufferView_2": {
+                "buffer": "buffer_0",
+                "byteOffset": 720,
+                "byteLength": 80
+            }
+        };
+
+        removeUnusedVertices(testGltf);
+
+        delete testGltf.buffers.buffer_0.extras._pipeline.offset;
+        delete testGltf.buffers.buffer_0.extras._pipeline.end;
+        expect(testGltf.buffers.buffer_0.extras._pipeline.source).toEqual(Buffer.concat([testBuffer.slice(120, 600), testBuffer.slice(720, 800)], 560));
+        expect(testGltf.buffers.buffer_0.byteLength).toEqual(560);
+    });
+
+    it('removes multiple parts of a buffer', function() {
+        var testGltf = clone(gltf);
+        testGltf.bufferViews = {
+            "bufferView_0": {
+                "buffer": "buffer_0",
+                "byteOffset": 120,
+                "byteLength": 120
+            },
+            "bufferView_1": {
+                "buffer": "buffer_0",
+                "byteOffset": 360,
+                "byteLength": 240
+            },
+            "bufferView_2": {
+                "buffer": "buffer_0",
+                "byteOffset": 720,
+                "byteLength": 80
+            }
+        };
+
+        removeUnusedVertices(testGltf);
+
+        delete testGltf.buffers.buffer_0.extras._pipeline.offset;
+        delete testGltf.buffers.buffer_0.extras._pipeline.end;
+        expect(testGltf.buffers.buffer_0.extras._pipeline.source).toEqual(Buffer.concat([testBuffer.slice(120, 240), testBuffer.slice(360, 600), testBuffer.slice(720, 800)], 440));
+        expect(testGltf.buffers.buffer_0.byteLength).toEqual(440);
+    });
+
+    it('removes data from multiple buffers', function() {
+        var testGltf = clone(gltf);
+        var testBuffer_1 = new Buffer(840);
+        testGltf.buffers.buffer_1 = {
+            "uri": "data:,",
+            "byteLength": 840,
+            "extras": {
+                "_pipeline": {
+                    "source": testBuffer_1
+                }
+            }
+        };
+
+        testGltf.bufferViews = {
+            "bufferView_0": {
+                "buffer": "buffer_0",
+                "byteOffset": 120,
+                "byteLength": 720
+            },
+            "bufferView_1": {
+                "buffer": "buffer_1",
+                "byteOffset": 0,
+                "byteLength": 720
+            }
+        };
+
+        removeUnusedVertices(testGltf);
+
+        delete testGltf.buffers.buffer_0.extras._pipeline.offset;
+        delete testGltf.buffers.buffer_0.extras._pipeline.end;
+        delete testGltf.buffers.buffer_1.extras._pipeline.offset;
+        delete testGltf.buffers.buffer_1.extras._pipeline.end;
+        expect(testGltf.buffers.buffer_0.extras._pipeline.source).toEqual(testBuffer.slice(120, 840));
+        expect(testGltf.buffers.buffer_0.byteLength).toEqual(720);
+        expect(testGltf.buffers.buffer_1.extras._pipeline.source).toEqual(testBuffer_1.slice(0, 720));
+        expect(testGltf.buffers.buffer_1.byteLength).toEqual(720);
+    });
+
+    it('deletes an unreferenced buffer', function() {
+        var testGltf = clone(gltf);
+        testGltf.buffers.buffer_1 = {
+            "uri": "data:,",
+            "byteLength": 840,
+            "extras": {
+                "_pipeline": {
+                    "source": new Buffer(840)
+                }
+            }
+        };
+
+        testGltf.bufferViews = {
+            "bufferView_0": {
+                "buffer": "buffer_0",
+                "byteOffset": 120,
+                "byteLength": 720
+            }
+        };
+
+        removeUnusedVertices(testGltf);
+
+        expect(testGltf.buffers.buffer_1).not.toBeDefined();
+        expect(testGltf.buffers.buffer_0.extras._pipeline.source).toEqual(testBuffer.slice(120, 840));
+        expect(testGltf.buffers.buffer_0.byteLength).toEqual(720);
+    });
+});

--- a/specs/lib/removeUnusedVerticesSpec.js
+++ b/specs/lib/removeUnusedVerticesSpec.js
@@ -1,5 +1,6 @@
 'use strict';
 var clone = require('clone');
+var bufferEqual = require('buffer-equal');
 var removeUnusedVertices = require('../../lib/removeUnusedVertices');
 
 describe('removeUnusedVertices', function() {
@@ -32,7 +33,7 @@ describe('removeUnusedVertices', function() {
 
         delete testGltf.buffers.buffer_0.extras._pipeline.offset;
         delete testGltf.buffers.buffer_0.extras._pipeline.end;
-        expect(testGltf.buffers).toEqual(gltf.buffers);
+        expect(bufferEqual(testGltf.buffers.buffer_0.extras._pipeline.source, testBuffer)).toBe(true);
     });
 
     it('does not remove any data with overlapping buffer views', function() {
@@ -54,7 +55,7 @@ describe('removeUnusedVertices', function() {
 
         delete testGltf.buffers.buffer_0.extras._pipeline.offset;
         delete testGltf.buffers.buffer_0.extras._pipeline.end;
-        expect(testGltf.buffers).toEqual(gltf.buffers);
+        expect(bufferEqual(testGltf.buffers.buffer_0.extras._pipeline.source, testBuffer)).toBe(true);
     });
 
     it('removes the beginning of a buffer', function() {
@@ -76,7 +77,7 @@ describe('removeUnusedVertices', function() {
 
         delete testGltf.buffers.buffer_0.extras._pipeline.offset;
         delete testGltf.buffers.buffer_0.extras._pipeline.end;
-        expect(testGltf.buffers.buffer_0.extras._pipeline.source).toEqual(testBuffer.slice(120));
+        expect(bufferEqual(testGltf.buffers.buffer_0.extras._pipeline.source, testBuffer.slice(120))).toBe(true);
         expect(testGltf.buffers.buffer_0.byteLength).toEqual(720);
     });
 
@@ -99,7 +100,8 @@ describe('removeUnusedVertices', function() {
 
         delete testGltf.buffers.buffer_0.extras._pipeline.offset;
         delete testGltf.buffers.buffer_0.extras._pipeline.end;
-        expect(testGltf.buffers.buffer_0.extras._pipeline.source).toEqual(Buffer.concat([testBuffer.slice(0, 360), testBuffer.slice(480)], 720));
+        expect(bufferEqual(testGltf.buffers.buffer_0.extras._pipeline.source, 
+            Buffer.concat([testBuffer.slice(0, 360), testBuffer.slice(480)], 720))).toBe(true);
         expect(testGltf.buffers.buffer_0.byteLength).toEqual(720);
     });
 
@@ -122,7 +124,7 @@ describe('removeUnusedVertices', function() {
 
         delete testGltf.buffers.buffer_0.extras._pipeline.offset;
         delete testGltf.buffers.buffer_0.extras._pipeline.end;
-        expect(testGltf.buffers.buffer_0.extras._pipeline.source).toEqual(testBuffer.slice(0, 720));
+        expect(bufferEqual(testGltf.buffers.buffer_0.extras._pipeline.source, testBuffer.slice(0, 720))).toBe(true);
         expect(testGltf.buffers.buffer_0.byteLength).toEqual(720);
     });
 
@@ -150,7 +152,8 @@ describe('removeUnusedVertices', function() {
 
         delete testGltf.buffers.buffer_0.extras._pipeline.offset;
         delete testGltf.buffers.buffer_0.extras._pipeline.end;
-        expect(testGltf.buffers.buffer_0.extras._pipeline.source).toEqual(Buffer.concat([testBuffer.slice(120, 600), testBuffer.slice(720, 800)], 560));
+        expect(bufferEqual(testGltf.buffers.buffer_0.extras._pipeline.source, 
+            Buffer.concat([testBuffer.slice(120, 600), testBuffer.slice(720, 800)], 560))).toBe(true);
         expect(testGltf.buffers.buffer_0.byteLength).toEqual(560);
     });
 
@@ -214,8 +217,10 @@ describe('removeUnusedVertices', function() {
         delete testGltf.buffers.buffer_0.extras._pipeline.end;
         delete testGltf.buffers.buffer_1.extras._pipeline.offset;
         delete testGltf.buffers.buffer_1.extras._pipeline.end;
+        expect(bufferEqual(testGltf.buffers.buffer_0.extras._pipeline.source, testBuffer.slice(120, 840))).toBe(true);
         expect(testGltf.buffers.buffer_0.extras._pipeline.source).toEqual(testBuffer.slice(120, 840));
         expect(testGltf.buffers.buffer_0.byteLength).toEqual(720);
+        expect(bufferEqual(testGltf.buffers.buffer_1.extras._pipeline.source, testBuffer_1.slice(0, 720))).toBe(true);
         expect(testGltf.buffers.buffer_1.extras._pipeline.source).toEqual(testBuffer_1.slice(0, 720));
         expect(testGltf.buffers.buffer_1.byteLength).toEqual(720);
     });
@@ -243,7 +248,7 @@ describe('removeUnusedVertices', function() {
         removeUnusedVertices(testGltf);
 
         expect(testGltf.buffers.buffer_1).not.toBeDefined();
-        expect(testGltf.buffers.buffer_0.extras._pipeline.source).toEqual(testBuffer.slice(120, 840));
+        expect(bufferEqual(testGltf.buffers.buffer_0.extras._pipeline.source, testBuffer.slice(120, 840))).toBe(true);
         expect(testGltf.buffers.buffer_0.byteLength).toEqual(720);
     });
 });

--- a/specs/lib/removeUnusedVerticesSpec.js
+++ b/specs/lib/removeUnusedVerticesSpec.js
@@ -181,7 +181,7 @@ describe('removeUnusedVertices', function() {
 
         delete testGltf.buffers.buffer_0.extras._pipeline.offset;
         delete testGltf.buffers.buffer_0.extras._pipeline.end;
-        expect(testGltf.buffers.buffer_0.extras._pipeline.source).toEqual(Buffer.concat([testBuffer.slice(120, 240), testBuffer.slice(360, 600), testBuffer.slice(720, 800)], 440));
+        expect(bufferEqual(testGltf.buffers.buffer_0.extras._pipeline.source, Buffer.concat([testBuffer.slice(120, 240), testBuffer.slice(360, 600), testBuffer.slice(720, 800)], 440))).toBe(true);
         expect(testGltf.buffers.buffer_0.byteLength).toEqual(440);
     });
 


### PR DESCRIPTION
I think it's a good call to separate this into two stages, so this stage removes unused buffer data based on bufferViews, and the other stage will modify and split up bufferViews based on indices. Do you think I should keep both of these stages in the same file as private functions and just have two test files, or should I make a new lib file?