### PR TITLE
Debugging support for tests

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,6 +2,8 @@
 
 var jshint = require('gulp-jshint');
 var gulp = require('gulp');
+var Jasmine = require('jasmine');
+var JasmineSpecReporter = require('jasmine-spec-reporter');
 
 var jsHintFiles = ['index.js', 'bin/*.js', 'lib/*.js', 'specs/*.js', '!node_modules/**', '!build/**', '!coverage/**'];
 
@@ -21,5 +23,15 @@ gulp.task('jsHint-watch', function() {
             .pipe(jshint.extract('auto'))
             .pipe(jshint())
             .pipe(jshint.reporter('jshint-stylish'));
+    });
+});
+
+gulp.task('test', function (done) {
+    var jasmine = new Jasmine();
+    jasmine.loadConfigFile('spec/support/jasmine.json');
+    jasmine.addReporter(new JasmineSpecReporter());
+    jasmine.execute();
+    jasmine.onComplete(function() {
+        done();
     });
 });

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "jasmine": "jasmine",
     "coverage": "istanbul cover -x **/specs/** ./node_modules/jasmine/bin/jasmine.js",
     "build": "browserify index.js --standalone gltfPipeline -o build/gltf-pipeline.js",
-    "test": "npm run jsHint && npm run coverage",
+    "test": "gulp test && npm run jsHint && npm run coverage",
     "coveralls": "cat ./coverage/lcov.info | ./node_modules/.bin/coveralls"
   },
   "directories": {
@@ -51,6 +51,7 @@
     "gulp-jshint": "2.0.0",
     "istanbul": "^0.4.1",
     "jasmine": "^2.4.1",
+    "jasmine-spec-reporter": "^2.4.0",
     "jshint": "2.8.0",
     "jshint-stylish": "2.1.0"
   }


### PR DESCRIPTION
Added a gulp task for running / debugging unit tests. In the gulp pane in Webstorm right-click `test` and select `Debug 'test'`. This should respond to any breakpoints set.