### PR TITLE
Normalize paths for tests

### DIFF
--- a/specs/lib/gltfPipelineSpec.js
+++ b/specs/lib/gltfPipelineSpec.js
@@ -83,7 +83,7 @@ describe('gltfPipeline', function() {
         });
         var options = {};
         processFileToDisk(gltfPath, outputPath, options, function() {
-            expect(spy.calls.first().args[0]).toEqual('output/output');
+            expect(path.normalize(spy.calls.first().args[0])).toEqual(path.normalize('output/output'));
             done();
         });
     });
@@ -95,7 +95,7 @@ describe('gltfPipeline', function() {
         var options = { 'createDirectory' : false };
         readGltf(gltfPath, function(gltf) {
             processJSONToDisk(gltf, outputPath, options, function() {
-                expect(spy.calls.first().args[0]).toEqual('./output/');
+                expect(path.normalize(spy.calls.first().args[0])).toEqual(path.normalize('./output/'));
                 done();
             });
         });


### PR DESCRIPTION
On Windows the gltfPipelineSpec tests fail because the path uses backslashes instead of forward slashes. Normalize the paths so this doesn't happen.