### PR TITLE
Fix clone spec issue.

### DIFF
--- a/specs/lib/gltfPipelineSpec.js
+++ b/specs/lib/gltfPipelineSpec.js
@@ -27,7 +27,7 @@ describe('gltfPipeline', function() {
             var gltfCopy = clone(gltf);
             processJSON(gltf, options, function (gltf) {
                 expect(gltf).toBeDefined();
-                expect(gltf).not.toEqual(gltfCopy);
+                expect(clone(gltf)).not.toEqual(gltfCopy);
                 done();
             });
         });
@@ -45,7 +45,7 @@ describe('gltfPipeline', function() {
             
             processJSON(gltf, options, function(gltf) {
                 expect(gltf).toBeDefined();
-                expect(gltf).not.toEqual(gltfCopy);
+                expect(clone(gltf)).not.toEqual(gltfCopy);
                 done();
             });
         });
@@ -58,7 +58,7 @@ describe('gltfPipeline', function() {
             gltfCopy = clone(gltf);
             processFile(gltfPath, options, function (gltf) {
                 expect(gltf).toBeDefined();
-                expect(gltf).not.toEqual(gltfCopy);
+                expect(clone(gltf)).not.toEqual(gltfCopy);
                 done();
             });
         });
@@ -70,7 +70,7 @@ describe('gltfPipeline', function() {
             var gltfCopy = clone(gltf);
             processFile(glbPath, options, function (gltf) {
                 expect(gltf).toBeDefined();
-                expect(gltf).not.toEqual(gltfCopy);
+                expect(clone(gltf)).not.toEqual(gltfCopy);
                 done();
             });
         });


### PR DESCRIPTION
Fix spec issue where clone was changing glTF files, rendering `not.toEqual` tests ineffective.

See comment in #80 

Surprisingly few occurrences where this came up.