### PR TITLE
Min and max must be enforced to prevent errors in quantized attributes

### DIFF
--- a/lib/quantizeAttributes.js
+++ b/lib/quantizeAttributes.js
@@ -110,7 +110,7 @@ function quantizeAttributes(gltf, options) {
                     value = source.readFloatLE(i + j * componentByteLength);
                     value = Math.min(value, max[j]);
                     value = Math.max(value, min[j]);
-                    var encoded = Math.round((value - min[j]) * range / (max[j] - min[j]))
+                    var encoded = Math.round((value - min[j]) * range / (max[j] - min[j]));
                     source.writeUInt16LE(encoded, i + j * 2);
                 }
                 num++;

--- a/lib/quantizeAttributes.js
+++ b/lib/quantizeAttributes.js
@@ -108,7 +108,9 @@ function quantizeAttributes(gltf, options) {
             for (i = offset; num < count; i+=byteStride) {
                 for (var j = 0; j < numberOfComponents; j++) {
                     value = source.readFloatLE(i + j * componentByteLength);
-                    var encoded = Math.round((value - min[j]) * range / (max[j] - min[j]));
+                    value = Math.min(value, max[j]);
+                    value = Math.max(value, min[j]);
+                    var encoded = Math.round((value - min[j]) * range / (max[j] - min[j]))
                     source.writeUInt16LE(encoded, i + j * 2);
                 }
                 num++;


### PR DESCRIPTION
I was converting some of the glTF sample models to test quantized attributes and the 2CylinderEngine model has an accessor max value that is slightly less than the actual max in the data.

This can cause out of bounds errors when writing into the buffer since the encoded value ends up being greater than 65535.