### PR TITLE
added image processing extras

### DIFF
--- a/lib/encodeImages.js
+++ b/lib/encodeImages.js
@@ -1,0 +1,52 @@
+'use strict';
+var Jimp = require('jimp');
+
+module.exports = encodeImages;
+var async = require('async');
+
+function encodeImages(gltfWithExtras, callback) {
+    var images = gltfWithExtras.images;
+    var imageIDs = Object.keys(images);
+    async.each(imageIDs, function(imageID, asyncCallback){
+        if (images.hasOwnProperty(imageID)) {
+            var image = images[imageID];
+            var pipelineExtras = image.extras._pipeline;
+            // re-encode the jimp image here to a buffer that can be put in source
+            var mime;
+            switch(pipelineExtras.extension) {
+                case '.png':
+                    mime = Jimp.MIME_PNG;
+                    break;
+                case '.jpeg':
+                    mime = Jimp.MIME_JPEG;
+                    break;
+                case '.jpg':
+                    mime = Jimp.MIME_JPEG;
+                    break;
+                case '.bmp':
+                    mime = Jimp.MIME_BMP;
+                    break;
+            }
+
+            pipelineExtras.jimpImage.getBuffer(mime, function(err, imageBuffer) {
+                if (err) {
+                    throw err;
+                }
+                pipelineExtras.source = imageBuffer;
+                asyncCallback();
+            });
+        }
+    }, function(err) {
+        if (err) {
+            if (callback) {
+                callback(err);
+            }
+            else{
+                throw err;
+            }
+        }
+        else if (callback) {
+            callback(gltfWithExtras);
+        }
+    });
+}

--- a/lib/encodeImages.js
+++ b/lib/encodeImages.js
@@ -1,11 +1,11 @@
 'use strict';
+var async = require('async');
 var Jimp = require('jimp');
 
 module.exports = encodeImages;
-var async = require('async');
 
-function encodeImages(gltfWithExtras, callback) {
-    var images = gltfWithExtras.images;
+function encodeImages(gltf, callback) {
+    var images = gltf.images;
     var imageIDs = Object.keys(images);
     async.each(imageIDs, function(imageID, asyncCallback){
         if (images.hasOwnProperty(imageID)) {
@@ -44,15 +44,8 @@ function encodeImages(gltfWithExtras, callback) {
         }
     }, function(err) {
         if (err) {
-            if (callback) {
-                callback(err);
-            }
-            else{
-                throw err;
-            }
+            throw err;
         }
-        else if (callback) {
-            callback(gltfWithExtras);
-        }
+        callback(gltf);
     });
 }

--- a/lib/encodeImages.js
+++ b/lib/encodeImages.js
@@ -11,30 +11,36 @@ function encodeImages(gltfWithExtras, callback) {
         if (images.hasOwnProperty(imageID)) {
             var image = images[imageID];
             var pipelineExtras = image.extras._pipeline;
-            // re-encode the jimp image here to a buffer that can be put in source
-            var mime;
-            switch(pipelineExtras.extension) {
-                case '.png':
-                    mime = Jimp.MIME_PNG;
-                    break;
-                case '.jpeg':
-                    mime = Jimp.MIME_JPEG;
-                    break;
-                case '.jpg':
-                    mime = Jimp.MIME_JPEG;
-                    break;
-                case '.bmp':
-                    mime = Jimp.MIME_BMP;
-                    break;
-            }
 
-            pipelineExtras.jimpImage.getBuffer(mime, function(err, imageBuffer) {
-                if (err) {
-                    throw err;
+            if (pipelineExtras.imageChanged) {
+                // re-encode the jimp image here to a buffer that can be put in source
+                var mime;
+                switch(pipelineExtras.extension) {
+                    case '.png':
+                        mime = Jimp.MIME_PNG;
+                        break;
+                    case '.jpeg':
+                        mime = Jimp.MIME_JPEG;
+                        break;
+                    case '.jpg':
+                        mime = Jimp.MIME_JPEG;
+                        break;
+                    case '.bmp':
+                        mime = Jimp.MIME_BMP;
+                        break;
                 }
-                pipelineExtras.source = imageBuffer;
+
+                pipelineExtras.jimpImage.getBuffer(mime, function(err, imageBuffer) {
+                    if (err) {
+                        throw err;
+                    }
+                    pipelineExtras.source = imageBuffer;
+                    asyncCallback();
+                });
+            }
+            else {
                 asyncCallback();
-            });
+            }
         }
     }, function(err) {
         if (err) {

--- a/lib/gltfPipeline.js
+++ b/lib/gltfPipeline.js
@@ -26,12 +26,12 @@ module.exports = {
 
 function processJSON(gltf, options, callback) {
     addPipelineExtras(gltf);
-    loadGltfUris(gltf, options.basePath, function(err, gltf) {
+    loadGltfUris(gltf, options, function(err, gltf) {
         if (err) {
             throw err;
         }
         processJSONWithExtras(gltf, options, callback);
-    }, options.imageProcess);
+    });
 }
 
 function processJSONWithExtras(gltfWithExtras, options, callback) {
@@ -60,7 +60,7 @@ function processJSONWithExtras(gltfWithExtras, options, callback) {
 }
 
 function processFile(inputPath, options, callback) {
-    readGltf(inputPath, function(gltf) {
+    readGltf(inputPath, options, function(gltf) {
         processJSONWithExtras(gltf, options, function(gltf) {
             callback(gltf);
         });

--- a/lib/gltfPipeline.js
+++ b/lib/gltfPipeline.js
@@ -13,6 +13,7 @@ var readGltf = require('./readGltf');
 var loadGltfUris = require('./loadGltfUris');
 var quantizeAttributes = require('./quantizeAttributes');
 var cacheOptimizeIndices = require('./cacheOptimizeIndices');
+var encodeImages = require('./encodeImages');
 var Cesium = require('cesium');
 var defaultValue = Cesium.defaultValue;
 
@@ -30,7 +31,7 @@ function processJSON(gltf, options, callback) {
             throw err;
         }
         processJSONWithExtras(gltf, options, callback);
-    });
+    }, options.imageProcess);
 }
 
 function processJSONWithExtras(gltfWithExtras, options, callback) {
@@ -50,7 +51,12 @@ function processJSONWithExtras(gltfWithExtras, options, callback) {
     if (options.quantize) {
         quantizeAttributes(gltfWithExtras);
     }
-    callback(gltfWithExtras);
+    if (options.imageProcess) {
+        encodeImages(gltfWithExtras, callback);
+    }
+    else {
+        callback(gltfWithExtras);
+    }
 }
 
 function processFile(inputPath, options, callback) {

--- a/lib/loadGltfUris.js
+++ b/lib/loadGltfUris.js
@@ -31,13 +31,13 @@ function loadGltfUris(gltf, options, callback) {
     }
 
     async.each(['buffers', 'images', 'shaders'], function(name, asyncCallback) {
-        loadURI(gltf, basePath, name, asyncCallback, imageProcess);
+        loadURI(gltf, basePath, name, imageProcess, asyncCallback);
     }, function(err) {
         wrappedCallback(err, gltf);
     });
 }
 
-function loadURI(gltf, basePath, name, callback, imageProcess) {
+function loadURI(gltf, basePath, name, imageProcess, callback) {
 
     var objects = gltf[name];
 

--- a/lib/loadGltfUris.js
+++ b/lib/loadGltfUris.js
@@ -12,9 +12,11 @@ var Jimp = require('jimp');
 
 module.exports = loadGltfUris;
 
-function loadGltfUris(gltf, basePath, callback, imageProcess) {
+function loadGltfUris(gltf, options, callback) {
     // if this will be an image processing pipeline, add a scratch Jimp image to gltf.extras._pipeline
     var wrappedCallback = callback;
+    var basePath = options.basePath;
+    var imageProcess = options.imageProcess;
 
     if (imageProcess) {
         wrappedCallback = function(err, gltf) {
@@ -146,6 +148,7 @@ function generateJimpImage(object, callback) {
             throw jimpErr;
         }
         pipelineExtras.jimpImage = image;
+        pipelineExtras.imageChanged = false;
         callback();
     });
 }

--- a/lib/loadGltfUris.js
+++ b/lib/loadGltfUris.js
@@ -8,18 +8,35 @@ var DeveloperError = Cesium.DeveloperError;
 var isDataUri = require('./isDataUri');
 var dataUriToBuffer = require('data-uri-to-buffer');
 var async = require('async');
+var Jimp = require('jimp');
 
 module.exports = loadGltfUris;
 
-function loadGltfUris(gltf, basePath, callback) {
+function loadGltfUris(gltf, basePath, callback, imageProcess) {
+    // if this will be an image processing pipeline, add a scratch Jimp image to gltf.extras._pipeline
+    var wrappedCallback = callback;
+
+    if (imageProcess) {
+        wrappedCallback = function(err, gltf) {
+            gltf.extras._pipeline.jimpScratch = new Jimp(1, 1, function(jimpErr, image) {
+                if (jimpErr) {
+                    throw jimpErr;
+                }
+                gltf.extras._pipeline.jimpScratch = image;
+                callback(err, gltf);
+            });
+        };
+    }
+
     async.each(['buffers', 'images', 'shaders'], function(name, asyncCallback) {
-        loadURI(gltf, basePath, name, asyncCallback);
+        loadURI(gltf, basePath, name, asyncCallback, imageProcess);
     }, function(err) {
-        callback(err, gltf);
+        wrappedCallback(err, gltf);
     });
 }
 
-function loadURI(gltf, basePath, name, callback) {
+function loadURI(gltf, basePath, name, callback, imageProcess) {
+
     var objects = gltf[name];
 
     //Iterate through each object and load its uri
@@ -50,10 +67,18 @@ function loadURI(gltf, basePath, name, callback) {
                             break;
                     }
                 }
-                
-                process.nextTick(function() {
-                    asyncCallback();
-                });
+
+                if (name === 'images' && imageProcess) {
+                    generateJimpImage(object, function() {
+                        process.nextTick(function() {
+                           asyncCallback();
+                        });
+                    });
+                } else {
+                    process.nextTick(function() {
+                        asyncCallback();
+                    });
+                }
             }
             else {
                 var uriPath = uri;
@@ -71,7 +96,11 @@ function loadURI(gltf, basePath, name, callback) {
                     else {
                         object.extras._pipeline.source = data;
                         object.extras._pipeline.extension = path.extname(uri);
-                        asyncCallback();
+                        if (name === 'images' && imageProcess) {
+                            generateJimpImage(object, asyncCallback);
+                        } else {
+                            asyncCallback();
+                        }
                     }
                 });
             }
@@ -104,4 +133,19 @@ function getImageDataUriFormat(uri) {
     }
 
     return '.' + extension[1];
+}
+
+//Generate a jimp image for png, jpeg, or bmp
+function generateJimpImage(object, callback) {
+    var pipelineExtras = object.extras._pipeline;
+    if (pipelineExtras.extension === '.gif') {
+        throw new DeveloperError('gltf pipeline image processing does not currently support gifs.');
+    }
+    Jimp.read(pipelineExtras.source, function(jimpErr, image) {
+        if (jimpErr) {
+            throw jimpErr;
+        }
+        pipelineExtras.jimpImage = image;
+        callback();
+    });
 }

--- a/lib/readGltf.js
+++ b/lib/readGltf.js
@@ -10,11 +10,15 @@ var DeveloperError = Cesium.DeveloperError;
 
 module.exports = readGltf;
 
-function readGltf(gltfPath, options, callback, imageProcess) {
+function readGltf(gltfPath, options, callback) {
     if (!defined(gltfPath)) {
         throw new DeveloperError('Input path is undefined.');
     }
-    
+
+    if (!defined(options.basePath)) {
+        options.basePath = path.dirname(gltfPath);
+    }
+
     var fileExtension = path.extname(gltfPath);
 
     if (fileExtension !== '.glb' && fileExtension !== '.gltf') {
@@ -39,6 +43,6 @@ function readGltf(gltfPath, options, callback, imageProcess) {
                 throw err;
             }
             callback(gltf);
-        }, imageProcess);
+        });
     });
 }

--- a/lib/readGltf.js
+++ b/lib/readGltf.js
@@ -10,14 +10,13 @@ var DeveloperError = Cesium.DeveloperError;
 
 module.exports = readGltf;
 
-function readGltf(gltfPath, callback, imageProcess) {
+function readGltf(gltfPath, options, callback, imageProcess) {
     if (!defined(gltfPath)) {
         throw new DeveloperError('Input path is undefined.');
     }
     
     var fileExtension = path.extname(gltfPath);
-    var filePath = path.dirname(gltfPath);
-    
+
     if (fileExtension !== '.glb' && fileExtension !== '.gltf') {
         throw new DeveloperError('Invalid glTF file.');
     }
@@ -35,7 +34,7 @@ function readGltf(gltfPath, callback, imageProcess) {
             gltf = JSON.parse(data);
             addPipelineExtras(gltf);
         }
-        loadGltfUris(gltf, filePath, function(err, gltf) {
+        loadGltfUris(gltf, options, function(err, gltf) {
             if (err) {
                 throw err;
             }

--- a/lib/readGltf.js
+++ b/lib/readGltf.js
@@ -10,7 +10,7 @@ var DeveloperError = Cesium.DeveloperError;
 
 module.exports = readGltf;
 
-function readGltf(gltfPath, callback) {
+function readGltf(gltfPath, callback, imageProcess) {
     if (!defined(gltfPath)) {
         throw new DeveloperError('Input path is undefined.');
     }
@@ -40,6 +40,6 @@ function readGltf(gltfPath, callback) {
                 throw err;
             }
             callback(gltf);
-        });
+        }, imageProcess);
     });
 }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "data-uri-to-buffer": "0.0.4",
     "datauri": "^1.0.0-alpha.5",
     "image-size": "^0.5.0",
+    "jimp": "^0.2.24",
     "mime": "^1.3.4",
     "mkdirp": "^0.5.1",
     "object-values": "^1.0.0",

--- a/specs/lib/cacheOptimizeIndicesSpec.js
+++ b/specs/lib/cacheOptimizeIndicesSpec.js
@@ -5,7 +5,6 @@ var readGltf = require('../../lib/readGltf');
 var readAccessor = require('../../lib/readAccessor');
 var writeAccessor = require('../../lib/writeAccessor');
 
-var basePath = './specs/data/boxTexturedUnoptimized/';
 var gltfPath = './specs/data/boxTexturedUnoptimized/CesiumTexturedBoxTest.gltf';
 var unoptimizedIndices = [ 3, 2, 1, 0, 1, 2, 7, 6, 5, 4, 5, 6, 8, 9, 10, 11, 10, 9, 12,
     13, 14, 15, 14, 13, 16, 17, 18, 19, 18, 17, 23, 22, 21, 20, 21, 22 ];

--- a/specs/lib/cacheOptimizeIndicesSpec.js
+++ b/specs/lib/cacheOptimizeIndicesSpec.js
@@ -5,6 +5,7 @@ var readGltf = require('../../lib/readGltf');
 var readAccessor = require('../../lib/readAccessor');
 var writeAccessor = require('../../lib/writeAccessor');
 
+var basePath = './specs/data/boxTexturedUnoptimized/';
 var gltfPath = './specs/data/boxTexturedUnoptimized/CesiumTexturedBoxTest.gltf';
 var unoptimizedIndices = [ 3, 2, 1, 0, 1, 2, 7, 6, 5, 4, 5, 6, 8, 9, 10, 11, 10, 9, 12,
     13, 14, 15, 14, 13, 16, 17, 18, 19, 18, 17, 23, 22, 21, 20, 21, 22 ];
@@ -14,7 +15,10 @@ var optimizedIndices = [ 0, 1, 2, 3, 2, 1, 4, 5, 6, 7, 6, 5, 8, 9, 10, 11, 10, 9
 
 describe('cacheOptimizeIndices', function() {
     it('reorders indices', function(done) {
-        readGltf(gltfPath, function(gltf) {
+        var options = {
+            basePath: basePath
+        };
+        readGltf(gltfPath, options, function(gltf) {
             addDefaults(gltf);
             var indexAccessorId = gltf.meshes[Object.keys(gltf.meshes)[0]].primitives[0].indices;
             var indexAccessor = gltf.accessors[indexAccessorId];

--- a/specs/lib/cacheOptimizeIndicesSpec.js
+++ b/specs/lib/cacheOptimizeIndicesSpec.js
@@ -15,9 +15,7 @@ var optimizedIndices = [ 0, 1, 2, 3, 2, 1, 4, 5, 6, 7, 6, 5, 8, 9, 10, 11, 10, 9
 
 describe('cacheOptimizeIndices', function() {
     it('reorders indices', function(done) {
-        var options = {
-            basePath: basePath
-        };
+        var options = {};
         readGltf(gltfPath, options, function(gltf) {
             addDefaults(gltf);
             var indexAccessorId = gltf.meshes[Object.keys(gltf.meshes)[0]].primitives[0].indices;

--- a/specs/lib/combinePrimitivesSpec.js
+++ b/specs/lib/combinePrimitivesSpec.js
@@ -14,9 +14,7 @@ var doubleBoxNotCombinedPath = './specs/data/combineObjects/doubleBoxNotCombined
 var fiveBoxPath = './specs/data/combineObjects/fiveBox.gltf';
 
 describe('combinePrimitives', function() {
-    var options = {
-        basePath: basePath
-    };
+    var options = {};
 
     it('does not affect single primitives', function(done){
         readGltf(boxPath, options, function(gltf) {

--- a/specs/lib/combinePrimitivesSpec.js
+++ b/specs/lib/combinePrimitivesSpec.js
@@ -8,7 +8,6 @@ var loadGltfUris = require('../../lib/loadGltfUris');
 var removePipelineExtras = require('../../lib/removePipelineExtras');
 
 var boxPath = './specs/data/combineObjects/box.gltf';
-var basePath = './specs/data/combineObjects/';
 var doubleBoxToCombinePath = './specs/data/combineObjects/doubleBoxToCombine.gltf';
 var doubleBoxNotCombinedPath = './specs/data/combineObjects/doubleBoxNotCombined.gltf';
 var fiveBoxPath = './specs/data/combineObjects/fiveBox.gltf';

--- a/specs/lib/combinePrimitivesSpec.js
+++ b/specs/lib/combinePrimitivesSpec.js
@@ -8,13 +8,18 @@ var loadGltfUris = require('../../lib/loadGltfUris');
 var removePipelineExtras = require('../../lib/removePipelineExtras');
 
 var boxPath = './specs/data/combineObjects/box.gltf';
+var basePath = './specs/data/combineObjects/';
 var doubleBoxToCombinePath = './specs/data/combineObjects/doubleBoxToCombine.gltf';
 var doubleBoxNotCombinedPath = './specs/data/combineObjects/doubleBoxNotCombined.gltf';
 var fiveBoxPath = './specs/data/combineObjects/fiveBox.gltf';
 
 describe('combinePrimitives', function(){
+    var options = {
+        basePath: basePath
+    };
+
     it('does not affect single primitives', function(){
-        readGltf(boxPath, function(gltf) {
+        readGltf(boxPath, options, function(gltf) {
             var box = gltf;
             var stringBox = JSON.stringify(box);
             combinePrimitives(box);
@@ -23,7 +28,7 @@ describe('combinePrimitives', function(){
     });
 
     it('does not combine two primitives', function(){
-        readGltf(doubleBoxNotCombinedPath, function(gltf){
+        readGltf(doubleBoxNotCombinedPath, options, function(gltf){
             var doubleBoxNotCombined = gltf;
             var stringDoubleBoxNotCombined = JSON.stringify(doubleBoxNotCombined);
             combinePrimitives(doubleBoxNotCombined);
@@ -32,7 +37,7 @@ describe('combinePrimitives', function(){
 
         });
 
-        readGltf(doubleBoxToCombinePath, function(gltf){
+        readGltf(doubleBoxToCombinePath, options, function(gltf){
             var oneAttribute = gltf;
 
             oneAttribute.meshes.meshTest.primitives[0].attributes = {
@@ -42,7 +47,7 @@ describe('combinePrimitives', function(){
             expect(oneAttribute.meshes.meshTest.primitives.length).toEqual(2);
         });
 
-        readGltf(doubleBoxToCombinePath, function(gltf){
+        readGltf(doubleBoxToCombinePath, options, function(gltf){
             var differentAttributes = gltf;
             differentAttributes.meshes.meshTest.primitives[0].attributes = {
                 "NORMAL": 'accessor_60',
@@ -55,7 +60,7 @@ describe('combinePrimitives', function(){
     });
 
     it('combines two primitives', function(){
-        readGltf(doubleBoxToCombinePath, function(gltf){
+        readGltf(doubleBoxToCombinePath, options, function(gltf){
             var doubleBoxToCombine = gltf;
 
             combinePrimitives(doubleBoxToCombine);
@@ -96,7 +101,7 @@ describe('combinePrimitives', function(){
     });
 
     it('combines some primitives', function(){
-        readGltf(fiveBoxPath, function(gltf){
+        readGltf(fiveBoxPath, options, function(gltf){
             var fiveBox = gltf;
             combinePrimitives(fiveBox);
             expect(fiveBox.meshes.meshTest.primitives.length).toEqual(3);
@@ -120,7 +125,7 @@ describe('combinePrimitives', function(){
     });
 
     it('throws an error', function() {
-        readGltf(doubleBoxToCombinePath, function(gltf) {
+        readGltf(doubleBoxToCombinePath, options, function(gltf) {
             var typeError = gltf;
             typeError.accessors.accessor_29.type = 'VEC3';
             expect(function () {
@@ -128,7 +133,7 @@ describe('combinePrimitives', function(){
             }).toThrow();
         });
 
-        readGltf(doubleBoxToCombinePath, function(gltf){
+        readGltf(doubleBoxToCombinePath, options, function(gltf){
             var componentTypeError = gltf;
             componentTypeError.accessors.accessor_29.componentType = 5126;
             expect(function () {

--- a/specs/lib/encodeImagesSpec.js
+++ b/specs/lib/encodeImagesSpec.js
@@ -1,0 +1,64 @@
+'use strict';
+var fs = require('fs');
+var bufferEqual = require('buffer-equal');
+var encodeImages = require('../../lib/encodeImages');
+var loadGltfUris = require('../../lib/loadGltfUris');
+var dataUriToBuffer = require('data-uri-to-buffer');
+var imageUri = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAIAAABLbSncAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAADTSURBVBhXAcgAN/8B49/cCAQAyukB2vAB+vz/Ig7+QR0B+PwAAezj3LDfAqnZ/wMB/xwPBwUEAiMK91Uj/gLN6wGj1fs9IyEwGxoUCPotFQC75g7rASECvd/6KxwkVCHFUiTX9P4Xq9L8ZjUD+vWyAaHK+CUX+pujFBYRH1NR2vUAANrLX8zXyAJCHOWnsj3d7frR4+XLymz24Y6ZuKI7LGUE/vcBEAglAQTR/P/9nbmV8fUAYURiTjRqAeXi6AgFDMDWptPiwP///isdPEIsXvr8+Tj0Y5s8qCp8AAAAAElFTkSuQmCC';
+var basePath = './specs/data/boxTexturedUnoptimized/';
+var clone = require('clone');
+var Jimp = require('jimp');
+
+describe('encodeImages', function() {
+    var imageData;
+    var imageBuffer = dataUriToBuffer(imageUri);
+
+    var gltf = {
+        "images": {
+            "Image0001": {
+                "uri": imageUri
+            },
+            "Image0002": {
+                "uri": imageUri
+            }
+        },
+        "extras": {
+            "_pipeline": {}
+        }
+    };
+
+    it('re-encodes any jimp images and replaces the existing source', function(done) {
+        var gltfClone = clone(gltf);
+
+        loadGltfUris(gltfClone, basePath, function() {
+            var pipelineExtras0001 = gltfClone.images.Image0001.extras._pipeline;
+            var jimpImage001 = pipelineExtras0001.jimpImage;
+            jimpImage001.resize(10, 10, Jimp.RESIZE_BEZIER);
+
+            var pipelineExtras0002 = gltfClone.images.Image0002.extras._pipeline;
+            var jimpImage002 = pipelineExtras0002.jimpImage;
+
+            encodeImages(gltfClone, function() {
+                expect(jimpImage001.bitmap.width).toEqual(10);
+                expect(jimpImage001.bitmap.height).toEqual(10);
+
+                expect(jimpImage002.bitmap.width).toEqual(8);
+                expect(jimpImage002.bitmap.height).toEqual(8);
+
+                expect(bufferEqual(pipelineExtras0001.source, imageBuffer)).not.toBe(true);
+                expect(bufferEqual(pipelineExtras0002.source, imageBuffer)).not.toBe(true);
+
+                // expect the buffers to still be readable by jimp (valid image buffer)
+                Jimp.read(pipelineExtras0001.source, function(jimpErr, image) {
+                    expect(image.bitmap.height).toEqual(10);
+                    expect(jimpImage001.bitmap.height).toEqual(10);
+                    Jimp.read(pipelineExtras0002.source, function(jimpErr, image) {
+                        expect(image.bitmap.height).toEqual(8);
+                        expect(jimpImage002.bitmap.height).toEqual(8);
+                        done();
+                    });
+                });
+            });
+        }, true);
+    });
+});

--- a/specs/lib/encodeImagesSpec.js
+++ b/specs/lib/encodeImagesSpec.js
@@ -10,7 +10,6 @@ var clone = require('clone');
 var Jimp = require('jimp');
 
 describe('encodeImages', function() {
-    var imageData;
     var imageBuffer = dataUriToBuffer(imageUri);
     var options = {
         basePath: basePath,
@@ -43,7 +42,7 @@ describe('encodeImages', function() {
                 expect(bufferEqual(pipelineExtras0002.source, imageBuffer)).toBe(true);
                 done();
             });
-        }, true);
+        });
     });
 
     it('re-encodes any jimp images and replaces the existing source', function(done) {
@@ -80,6 +79,6 @@ describe('encodeImages', function() {
                     });
                 });
             });
-        }, true);
+        });
     });
 });

--- a/specs/lib/gltfPipelineSpec.js
+++ b/specs/lib/gltfPipelineSpec.js
@@ -1,11 +1,9 @@
 'use strict';
 var fs = require('fs');
 var path = require('path');
-var bufferEqual = require('buffer-equal');
 var clone = require('clone');
 var gltfPipeline = require('../../lib/gltfPipeline');
 var processJSON = gltfPipeline.processJSON;
-var processJSONWithExtras = gltfPipeline.processJSONWithExtras;
 var processJSONToDisk = gltfPipeline.processJSONToDisk;
 var processFile = gltfPipeline.processFile;
 var processFileToDisk = gltfPipeline.processFileToDisk;

--- a/specs/lib/gltfPipelineSpec.js
+++ b/specs/lib/gltfPipelineSpec.js
@@ -16,7 +16,6 @@ var writeBinaryGltf = require('../../lib/writeBinaryGltf');
 var writeSource = require('../../lib/writeSource');
 var writeGltf = require('../../lib/writeGltf');
 
-var basePath = './specs/data/boxTexturedUnoptimized/';
 var gltfPath = './specs/data/boxTexturedUnoptimized/CesiumTexturedBoxTest.gltf';
 var gltfEmbeddedPath = './specs/data/boxTexturedUnoptimized/CesiumTexturedBoxTestEmbedded.gltf';
 var glbPath = './specs/data/boxTexturedUnoptimized/CesiumTexturedBoxTest.glb';
@@ -24,9 +23,7 @@ var outputPath = './output/';
 
 describe('gltfPipeline', function() {
     it('optimizes a gltf JSON with embedded resources', function(done) {
-        var options = {
-            basePath: basePath
-        };
+        var options = {};
         readGltf(gltfEmbeddedPath, options, function(gltf) {
             var gltfCopy = clone(gltf);
             processJSON(gltf, options, function (gltf) {
@@ -57,9 +54,7 @@ describe('gltfPipeline', function() {
 
     it('optimizes a glTF file', function(done) {
         var gltfCopy;
-        var options = {
-            basePath: basePath
-        };
+        var options = {};
         readGltf(gltfPath, options, function(gltf) {
             gltfCopy = clone(gltf);
             processFile(gltfPath, options, function (gltf) {
@@ -71,9 +66,7 @@ describe('gltfPipeline', function() {
     });
 
     it('optimizes a glb file', function(done) {
-        var options = {
-            basePath: basePath
-        };
+        var options = {};
         readGltf(glbPath, options, function(gltf) {
             var gltfCopy = clone(gltf);
             processFile(glbPath, options, function (gltf) {
@@ -88,9 +81,7 @@ describe('gltfPipeline', function() {
         var spy = spyOn(fs, 'writeFile').and.callFake(function(file, data, callback) {
             callback();
         });
-        var options = {
-            basePath: basePath
-        };
+        var options = {};
         processFileToDisk(gltfPath, outputPath, options, function() {
             expect(path.normalize(spy.calls.first().args[0])).toEqual(path.normalize('output/output'));
             done();
@@ -102,8 +93,7 @@ describe('gltfPipeline', function() {
             callback();
         });
         var options = {
-            basePath: basePath,
-            'binary' : true
+            binary : true
         };
         processFileToDisk(gltfPath, outputPath, options, function() {
             expect(path.normalize(spy.calls.first().args[0])).toEqual(path.normalize('output/output.glb'));
@@ -116,8 +106,7 @@ describe('gltfPipeline', function() {
             callback();
         });
         var options = {
-            createDirectory : false,
-            basePath : path.dirname(gltfPath)
+            createDirectory : false
         };
         readGltf(gltfPath, options, function(gltf) {
             processJSONToDisk(gltf, outputPath, options, function() {
@@ -129,7 +118,6 @@ describe('gltfPipeline', function() {
 
     it('will add image processing extras if this is a pipeline with image processing', function(done) {
         var options = {
-            basePath: basePath,
             imageProcess: true
         };
         readGltf(gltfEmbeddedPath, options, function(gltf) {

--- a/specs/lib/loadBufferUrisSpec.js
+++ b/specs/lib/loadBufferUrisSpec.js
@@ -8,6 +8,9 @@ var basePath = './specs/data/boxTexturedUnoptimized/';
 
 describe('loadBufferUris', function() {
     var bufferData;
+    var options = {
+        basePath: basePath
+    };
 
     beforeAll(function(done) {
         fs.readFile(bufferPath, function (err, data) {
@@ -28,7 +31,7 @@ describe('loadBufferUris', function() {
             }
         };
         
-        loadGltfUris(gltf, basePath, function(err, gltf) {
+        loadGltfUris(gltf, options, function(err, gltf) {
             expect(gltf.buffers.CesiumTexturedBoxTest.extras._pipeline.source).toBeDefined();
             expect(bufferEqual(gltf.buffers.CesiumTexturedBoxTest.extras._pipeline.source, bufferData)).toBe(true);
             expect(gltf.buffers.CesiumTexturedBoxTest.extras._pipeline.extension).toEqual('.bin');
@@ -45,7 +48,7 @@ describe('loadBufferUris', function() {
             }
         };
         
-        loadGltfUris(gltf, basePath, function(err, gltf) {
+        loadGltfUris(gltf, options, function(err, gltf) {
             expect(gltf.buffers.CesiumTexturedBoxTest.extras._pipeline.source).toBeDefined();
             expect(bufferEqual(gltf.buffers.CesiumTexturedBoxTest.extras._pipeline.source, bufferData)).toBe(true);
             expect(gltf.buffers.CesiumTexturedBoxTest.extras._pipeline.extension).toEqual('.bin');
@@ -65,7 +68,7 @@ describe('loadBufferUris', function() {
             }
         };
         
-        loadGltfUris(gltf, basePath, function(err, gltf) {
+        loadGltfUris(gltf, options, function(err, gltf) {
             expect(gltf.buffers.embeddedBox.extras._pipeline.source).toBeDefined();
             expect(bufferEqual(gltf.buffers.embeddedBox.extras._pipeline.source, bufferData)).toBe(true);
             expect(gltf.buffers.externalBox.extras._pipeline.source).toBeDefined();
@@ -83,7 +86,7 @@ describe('loadBufferUris', function() {
             }
         };
 
-        loadGltfUris(gltf, basePath, function(err, gltf) {
+        loadGltfUris(gltf, options, function(err, gltf) {
             expect(err).toBeDefined();
             done();
         });

--- a/specs/lib/loadImageUrisSpec.js
+++ b/specs/lib/loadImageUrisSpec.js
@@ -90,4 +90,48 @@ describe('loadImageUris', function() {
             done();
         });
     });
+
+    it('does not load a jimp of the image if imageProcess is undefined', function(done) {
+        var gltf = {
+            "images": {
+                "Image0001": {
+                    "uri": imageUri
+                }
+            },
+            "extras": {
+                "_pipeline": {}
+            }
+        };
+
+        loadGltfUris(gltf, basePath, function(err, gltf) {
+            expect(gltf.images.Image0001.extras._pipeline.jimpImage).not.toBeDefined();
+            done();
+        });
+    });
+
+    it('adds jimpScratch and loads a jimp of the image if imageProcess is true', function(done) {
+        var gltf = {
+            "images": {
+                "Image0001": {
+                    "uri": imageUri
+                }
+            },
+            "extras": {
+                "_pipeline": {}
+            }
+        };
+
+        loadGltfUris(gltf, basePath, function(err, gltf) {
+            var jimpImage = gltf.images.Image0001.extras._pipeline.jimpImage;
+            expect(jimpImage).toBeDefined();
+            expect(jimpImage.bitmap.width).toEqual(8);
+            expect(jimpImage.bitmap.height).toEqual(8);
+
+            var jimpScratch = gltf.extras._pipeline.jimpScratch;
+            expect(jimpScratch).toBeDefined();
+            expect(jimpScratch.bitmap.width).toEqual(1);
+            expect(jimpScratch.bitmap.height).toEqual(1);
+            done();
+        }, true);
+    });
 });

--- a/specs/lib/loadImageUrisSpec.js
+++ b/specs/lib/loadImageUrisSpec.js
@@ -8,6 +8,9 @@ var basePath = './specs/data/boxTexturedUnoptimized/';
 
 describe('loadImageUris', function() {
     var imageData;
+    var options = {
+        basePath: basePath
+    };
 
     beforeAll(function(done) {
         fs.readFile(imagePath, function (err, data) {
@@ -28,7 +31,7 @@ describe('loadImageUris', function() {
             }
         };
 
-        loadGltfUris(gltf, basePath, function(err, gltf) {
+        loadGltfUris(gltf, options, function(err, gltf) {
             expect(gltf.images.Image0001.extras._pipeline.source).toBeDefined();
             expect(bufferEqual(gltf.images.Image0001.extras._pipeline.source, imageData)).toBe(true);
             expect(gltf.images.Image0001.extras._pipeline.extension).toEqual('.png');
@@ -45,7 +48,7 @@ describe('loadImageUris', function() {
             }
         };
 
-        loadGltfUris(gltf, basePath, function(err, gltf) {
+        loadGltfUris(gltf, options, function(err, gltf) {
             expect(gltf.images.Image0001.extras._pipeline.source).toBeDefined();
             expect(bufferEqual(gltf.images.Image0001.extras._pipeline.source, imageData)).toBe(true);
             expect(gltf.images.Image0001.extras._pipeline.extension).toEqual('.png');
@@ -65,7 +68,7 @@ describe('loadImageUris', function() {
             }
         };
         
-        loadGltfUris(gltf, basePath, function(err, gltf) {
+        loadGltfUris(gltf, options, function(err, gltf) {
             expect(gltf.images.embeddedImage0001.extras._pipeline.source).toBeDefined();
             expect(bufferEqual(gltf.images.embeddedImage0001.extras._pipeline.source, imageData)).toBe(true);
             expect(gltf.images.embeddedImage0001.extras._pipeline.extension).toEqual('.png');
@@ -85,7 +88,7 @@ describe('loadImageUris', function() {
             }
         };
 
-        loadGltfUris(gltf, basePath, function(err, gltf) {
+        loadGltfUris(gltf, options, function(err, gltf) {
             expect(err).toBeDefined();
             done();
         });
@@ -103,7 +106,7 @@ describe('loadImageUris', function() {
             }
         };
 
-        loadGltfUris(gltf, basePath, function(err, gltf) {
+        loadGltfUris(gltf, options, function(err, gltf) {
             expect(gltf.images.Image0001.extras._pipeline.jimpImage).not.toBeDefined();
             done();
         });
@@ -121,8 +124,15 @@ describe('loadImageUris', function() {
             }
         };
 
-        loadGltfUris(gltf, basePath, function(err, gltf) {
-            var jimpImage = gltf.images.Image0001.extras._pipeline.jimpImage;
+        var imageProcessOptions = {
+            basePath: basePath,
+            imageProcess: true
+        };
+
+        loadGltfUris(gltf, imageProcessOptions, function(err, gltf) {
+            var pipelineExtras = gltf.images.Image0001.extras._pipeline;
+            expect(pipelineExtras.imageChanged).toEqual(false);
+            var jimpImage = pipelineExtras.jimpImage;
             expect(jimpImage).toBeDefined();
             expect(jimpImage.bitmap.width).toEqual(8);
             expect(jimpImage.bitmap.height).toEqual(8);

--- a/specs/lib/loadShaderUrisSpec.js
+++ b/specs/lib/loadShaderUrisSpec.js
@@ -9,6 +9,9 @@ var basePath = './specs/data/boxTexturedUnoptimized/';
 describe('loadShaderUris', function() {
     var fragmentShaderData;
     var fragmentShaderUri;
+    var options = {
+        basePath: basePath
+    };
 
     beforeAll(function(done) {
         fs.readFile(fragmentShaderPath, function (err, data) {
@@ -31,7 +34,7 @@ describe('loadShaderUris', function() {
             }
         };
 
-        loadGltfUris(gltf, basePath, function(err, gltf) {
+        loadGltfUris(gltf, options, function(err, gltf) {
             expect(gltf.shaders.CesiumTexturedBoxTest0FS.extras._pipeline.source).toBeDefined();
             expect(bufferEqual(gltf.shaders.CesiumTexturedBoxTest0FS.extras._pipeline.source, fragmentShaderData)).toBe(true);
             expect(gltf.shaders.CesiumTexturedBoxTest0FS.extras._pipeline.extension).toEqual('.glsl');
@@ -49,7 +52,7 @@ describe('loadShaderUris', function() {
             }
         };
         
-        loadGltfUris(gltf, basePath, function(err, gltf) {
+        loadGltfUris(gltf, options, function(err, gltf) {
             expect(gltf.shaders.box0FS.extras._pipeline.source).toBeDefined();
             expect(bufferEqual(gltf.shaders.box0FS.extras._pipeline.source, fragmentShaderData)).toBe(true);
             expect(gltf.shaders.box0FS.extras._pipeline.extension).toEqual('.glsl');
@@ -71,7 +74,7 @@ describe('loadShaderUris', function() {
             }
         };
         
-        loadGltfUris(gltf, basePath, function(err, gltf) {
+        loadGltfUris(gltf, options, function(err, gltf) {
             expect(gltf.shaders.externalBox0FS.extras._pipeline.source).toBeDefined();
             expect(bufferEqual(gltf.shaders.embeddedBox0FS.extras._pipeline.source, fragmentShaderData)).toBe(true);
             expect(gltf.shaders.externalBox0FS.extras._pipeline.extension).toEqual('.glsl');
@@ -89,7 +92,7 @@ describe('loadShaderUris', function() {
             }
         };
 
-        loadGltfUris(gltf, basePath, function(err, gltf) {
+        loadGltfUris(gltf, options, function(err, gltf) {
             expect(err).toBeDefined();
             done();
         });

--- a/specs/lib/readAccessorSpec.js
+++ b/specs/lib/readAccessorSpec.js
@@ -14,7 +14,6 @@ var addPipelineExtras = require('../../lib/addPipelineExtras');
 var readAccessor = require('../../lib/readAccessor');
 var readGltf = require('../../lib/readGltf');
 
-var basePath = './specs/data/boxTexturedUnoptimized/';
 var gltfPath = './specs/data/boxTexturedUnoptimized/CesiumTexturedBoxTest.gltf';
 
 describe('readAccessor', function() {

--- a/specs/lib/readAccessorSpec.js
+++ b/specs/lib/readAccessorSpec.js
@@ -14,13 +14,17 @@ var addPipelineExtras = require('../../lib/addPipelineExtras');
 var readAccessor = require('../../lib/readAccessor');
 var readGltf = require('../../lib/readGltf');
 
+var basePath = './specs/data/boxTexturedUnoptimized/';
 var gltfPath = './specs/data/boxTexturedUnoptimized/CesiumTexturedBoxTest.gltf';
 
 describe('readAccessor', function() {
     var boxGltf;
+    var options = {
+      basePath: basePath
+    };
 
     beforeAll(function(done) {
-        readGltf(gltfPath, function(gltf) {
+        readGltf(gltfPath, options, function(gltf) {
             boxGltf = gltf;
             done();
         });

--- a/specs/lib/readAccessorSpec.js
+++ b/specs/lib/readAccessorSpec.js
@@ -19,9 +19,7 @@ var gltfPath = './specs/data/boxTexturedUnoptimized/CesiumTexturedBoxTest.gltf';
 
 describe('readAccessor', function() {
     var boxGltf;
-    var options = {
-      basePath: basePath
-    };
+    var options = {};
 
     beforeAll(function(done) {
         readGltf(gltfPath, options, function(gltf) {
@@ -33,8 +31,8 @@ describe('readAccessor', function() {
 
     function testContainmentAndFit(min, max, attributes) {
         // check if the data in values is bounded by min and max precisely
-        var minInValues = Array(min.length).fill(Number.POSITIVE_INFINITY);
-        var maxInValues = Array(max.length).fill(Number.NEGATIVE_INFINITY);
+        var minInValues = new Array(min.length).fill(Number.POSITIVE_INFINITY);
+        var maxInValues = new Array(max.length).fill(Number.NEGATIVE_INFINITY);
         var attributeToArray;
         var scratchArray = [];
 
@@ -76,7 +74,7 @@ describe('readAccessor', function() {
                 maxInValues[j] = Math.max(maxInValues[j], values[j]);
             }
         }
-        for (var i = 0; i < min.length; i++) {
+        for (i = 0; i < min.length; i++) {
             if (!CesiumMath.equalsEpsilon(minInValues[i], min[i], CesiumMath.EPSILON7)) {
                 return false;
             }
@@ -107,7 +105,7 @@ describe('readAccessor', function() {
         }
 
         // check if the data from accessors with min/max information fits the min/max boundary
-        for (var accessorID in accessorIDtoMinMax) {
+        for (accessorID in accessorIDtoMinMax) {
             if (accessorIDtoMinMax.hasOwnProperty(accessorID)) {
                 if (accessorIDtoData.hasOwnProperty(accessorID)) {
                     var minMax = accessorIDtoMinMax[accessorID];

--- a/specs/lib/readGltfSpec.js
+++ b/specs/lib/readGltfSpec.js
@@ -1,20 +1,25 @@
 'use strict';
 var readGltf = require('../../lib/readGltf');
 
+var basePath = './specs/data/boxTexturedUnoptimized/';
 var gltfPath = './specs/data/boxTexturedUnoptimized/CesiumTexturedBoxTest.gltf';
 var glbPath = './specs/data/boxTexturedUnoptimized/CesiumTexturedBoxTest.glb';
 var invalidPath = './specs/data/boxTexturedUnoptimized/README.md';
 
 describe('readGltf', function() {
+    var options = {
+        basePath: basePath
+    };
+
     it('parses a .gltf input path, checks that a gltf JSON is defined', function(done) {
-        readGltf(gltfPath, function(gltf) {
+        readGltf(gltfPath, options, function(gltf) {
             expect(gltf).toBeDefined();
             done();
         });
     });
 
     it('parses a .glb input path, checks that a gltf JSON is defined', function(done) {
-        readGltf(glbPath, function(gltf) {
+        readGltf(glbPath, options, function(gltf) {
             expect(gltf).toBeDefined();
             done();
         });

--- a/specs/lib/readGltfSpec.js
+++ b/specs/lib/readGltfSpec.js
@@ -7,9 +7,7 @@ var glbPath = './specs/data/boxTexturedUnoptimized/CesiumTexturedBoxTest.glb';
 var invalidPath = './specs/data/boxTexturedUnoptimized/README.md';
 
 describe('readGltf', function() {
-    var options = {
-        basePath: basePath
-    };
+    var options = {};
 
     it('parses a .gltf input path, checks that a gltf JSON is defined', function(done) {
         readGltf(gltfPath, options, function(gltf) {

--- a/specs/lib/readGltfSpec.js
+++ b/specs/lib/readGltfSpec.js
@@ -1,7 +1,6 @@
 'use strict';
 var readGltf = require('../../lib/readGltf');
 
-var basePath = './specs/data/boxTexturedUnoptimized/';
 var gltfPath = './specs/data/boxTexturedUnoptimized/CesiumTexturedBoxTest.gltf';
 var glbPath = './specs/data/boxTexturedUnoptimized/CesiumTexturedBoxTest.glb';
 var invalidPath = './specs/data/boxTexturedUnoptimized/README.md';

--- a/specs/lib/writeBinaryGltfSpec.js
+++ b/specs/lib/writeBinaryGltfSpec.js
@@ -30,7 +30,11 @@ describe('writeBinaryGltf', function() {
             if (err) {
                 throw err;
             }
-            loadGltfUris(removeUnused(JSON.parse(data)), path.dirname(gltfPath), function(err, gltf) {
+            var options = {
+                basePath: path.dirname(gltfPath)
+            };
+
+            loadGltfUris(removeUnused(JSON.parse(data)), options, function(err, gltf) {
                 if (err) {
                     throw err;
                 }


### PR DESCRIPTION
In anticipation of ambient occlusion and other future image processing stages, I added extras for use with jimp (https://www.npmjs.com/package/jimp) in the form of a gltf-level scratch `Jimp` image and `Jimp` copies of all the existing images, stored as `jimpImage` in `extras._pipeline.`

Since this won't be used for every pipeline configuration, I tried to make it as optional as possible.

I also added relevant specs.