### PR TITLE
Fix bug where gltfPipeline was not writingSources in all cases 

### DIFF
--- a/lib/gltfPipeline.js
+++ b/lib/gltfPipeline.js
@@ -34,7 +34,7 @@ function writeSources(gltf, outputPath, options, callback) {
     var embedImage = options.embedImage;
     var basePath = path.dirname(outputPath);
     async.each(['buffers', 'images', 'shaders'], function(name) {
-        writeSource(gltf, basePath, name, embed, embedImage, callback)
+        writeSource(gltf, basePath, name, embed, embedImage, callback);
     });
 }
 

--- a/lib/gltfPipeline.js
+++ b/lib/gltfPipeline.js
@@ -29,23 +29,26 @@ module.exports = {
     processFileToDisk : processFileToDisk
 };
 
-function writeSources(gltf, outputPath, options, callback) {
-    var embed = options.embed;
-    var embedImage = options.embedImage;
-    var basePath = path.dirname(outputPath);
-    async.each(['buffers', 'images', 'shaders'], function(name) {
-        writeSource(gltf, basePath, name, embed, embedImage, callback);
+function writeSources(gltf, callback) {
+    var embed = true;
+    var embedImage = true;
+    async.each(['buffers', 'images', 'shaders'], function(name, asyncCallback) {
+        writeSource(gltf, undefined, name, embed, embedImage, asyncCallback);
+    }, function() {
+        callback();
     });
 }
 
-function processJSON(gltf, outputPath, options, callback) {
+function processJSON(gltf, options, callback) {
     addPipelineExtras(gltf);
     loadGltfUris(gltf, options, function(err, gltf) {
         if (err) {
             throw err;
         }
         processJSONWithExtras(gltf, options, function(gltf) {
-            writeSources(gltf, outputPath, options, callback(gltf));
+            writeSources(gltf, function() {
+                callback(gltf);
+            });
         });
     });
 }
@@ -77,10 +80,12 @@ function processJSONWithExtras(gltfWithExtras, options, callback) {
     }
 }
 
-function processFile(inputPath, outputPath, options, callback) {
+function processFile(inputPath, options, callback) {
     readGltf(inputPath, options, function(gltf) {
         processJSONWithExtras(gltf, options, function(gltf) {
-            writeSources(gltf, outputPath, options, callback(gltf));
+            writeSources(gltf, function() {
+                callback(gltf);
+            });
         });
     });
 }
@@ -116,6 +121,7 @@ function processFileToDisk(inputPath, outputPath, options, callback) {
         });
     });
 }
+
 function printStats(stats) {
     process.stdout.write('Nodes removed: ' + stats.numberRemoved.nodes + '\n');
     process.stdout.write('Skins removed: ' + stats.numberRemoved.skins + '\n');

--- a/lib/gltfPipeline.js
+++ b/lib/gltfPipeline.js
@@ -1,4 +1,6 @@
 'use strict';
+var path = require('path');
+var async = require('async');
 var addDefaults = require('./addDefaults');
 var addPipelineExtras = require('./addPipelineExtras');
 var removeUnused = require('./removeUnused');
@@ -16,6 +18,7 @@ var loadGltfUris = require('./loadGltfUris');
 var quantizeAttributes = require('./quantizeAttributes');
 var cacheOptimizeIndices = require('./cacheOptimizeIndices');
 var encodeImages = require('./encodeImages');
+var writeSource = require('./writeSource');
 var Cesium = require('cesium');
 var defaultValue = Cesium.defaultValue;
 
@@ -26,13 +29,24 @@ module.exports = {
     processFileToDisk : processFileToDisk
 };
 
-function processJSON(gltf, options, callback) {
+function writeSources(gltf, outputPath, options, callback) {
+    var embed = options.embed;
+    var embedImage = options.embedImage;
+    var basePath = path.dirname(outputPath);
+    async.each(['buffers', 'images', 'shaders'], function(name) {
+        writeSource(gltf, basePath, name, embed, embedImage, callback)
+    });
+}
+
+function processJSON(gltf, outputPath, options, callback) {
     addPipelineExtras(gltf);
     loadGltfUris(gltf, options, function(err, gltf) {
         if (err) {
             throw err;
         }
-        processJSONWithExtras(gltf, options, callback);
+        processJSONWithExtras(gltf, options, function(gltf) {
+            writeSources(gltf, outputPath, options, callback(gltf));
+        });
     });
 }
 
@@ -63,10 +77,10 @@ function processJSONWithExtras(gltfWithExtras, options, callback) {
     }
 }
 
-function processFile(inputPath, options, callback) {
+function processFile(inputPath, outputPath, options, callback) {
     readGltf(inputPath, options, function(gltf) {
         processJSONWithExtras(gltf, options, function(gltf) {
-            callback(gltf);
+            writeSources(gltf, outputPath, options, callback(gltf));
         });
     });
 }
@@ -84,17 +98,24 @@ function writeFile(gltf, outputPath, options, callback) {
 }
 
 function processJSONToDisk(gltf, outputPath, options, callback) {
-    processJSON(gltf, options, function(gltf) {
-        writeFile(gltf, outputPath, options, callback);
+    addPipelineExtras(gltf);
+    loadGltfUris(gltf, options, function(err, gltf) {
+        if (err) {
+            throw err;
+        }
+        processJSONWithExtras(gltf, options, function(gltf) {
+            writeFile(gltf, outputPath, options, callback);
+        });
     });
 }
 
 function processFileToDisk(inputPath, outputPath, options, callback) {
-    processFile(inputPath, options, function(gltf) {
-        writeFile(gltf, outputPath, options, callback);
+    readGltf(inputPath, options, function(gltf) {
+        processJSONWithExtras(gltf, options, function(gltf) {
+            writeFile(gltf, outputPath, options, callback);
+        });
     });
 }
-
 function printStats(stats) {
     process.stdout.write('Nodes removed: ' + stats.numberRemoved.nodes + '\n');
     process.stdout.write('Skins removed: ' + stats.numberRemoved.skins + '\n');

--- a/lib/gltfPipeline.js
+++ b/lib/gltfPipeline.js
@@ -1,5 +1,4 @@
 'use strict';
-var path = require('path');
 var async = require('async');
 var addDefaults = require('./addDefaults');
 var addPipelineExtras = require('./addPipelineExtras');

--- a/lib/writeGltf.js
+++ b/lib/writeGltf.js
@@ -9,7 +9,7 @@ var removePipelineExtras = require('./removePipelineExtras');
 module.exports = writeGltf;
 
 function writeGltf(gltf, outputPath, embed, embedImage, createDirectory, callback) {
-    //Create the output directory if specified
+    // Create the output directory if specified
     if (createDirectory) {
         outputPath = path.join(path.dirname(outputPath), 'output', path.basename(outputPath));
         mkdirp.sync(path.dirname(outputPath));

--- a/lib/writeSource.js
+++ b/lib/writeSource.js
@@ -24,7 +24,7 @@ function writeSource(gltf, basePath, name, embed, embedImage, callback) {
                 var extension = object.extras._pipeline.extension;
 
                 // Write the source object as a data or file uri depending on the embed flag
-                if (embed && (embedImage || name !== 'images') || basePath === undefined) {
+                if (embed && (embedImage || name !== 'images') || !defined(basePath)) {
                     var sourceDataUri = new dataUri();
                     if (name === 'shaders') {
                         sourceDataUri.format('.txt', source);

--- a/lib/writeSource.js
+++ b/lib/writeSource.js
@@ -14,7 +14,7 @@ module.exports = writeSource;
 function writeSource(gltf, basePath, name, embed, embedImage, callback) {
     var objects = gltf[name];
 
-    //Iterate through each object and write out its uri
+    // Iterate through each object and write out its uri
     if (defined(objects)) {
         var ids = Object.keys(objects);
         async.each(ids, function(id, asyncCallback) {
@@ -24,7 +24,7 @@ function writeSource(gltf, basePath, name, embed, embedImage, callback) {
                 var extension = object.extras._pipeline.extension;
 
                 // Write the source object as a data or file uri depending on the embed flag
-                if (embed && (embedImage || name !== 'images')) {
+                if (embed && (embedImage || name !== 'images') || basePath === undefined) {
                     var sourceDataUri = new dataUri();
                     if (name === 'shaders') {
                         sourceDataUri.format('.txt', source);

--- a/specs/lib/gltfPipelineSpec.js
+++ b/specs/lib/gltfPipelineSpec.js
@@ -24,7 +24,7 @@ describe('gltfPipeline', function() {
         var options = {};
         readGltf(gltfEmbeddedPath, options, function(gltf) {
             var gltfCopy = clone(gltf);
-            processJSON(gltf, options, function (gltf) {
+            processJSON(gltf, outputPath, options, function (gltf) {
                 expect(gltf).toBeDefined();
                 expect(clone(gltf)).not.toEqual(gltfCopy);
                 done();
@@ -42,7 +42,7 @@ describe('gltfPipeline', function() {
             var gltfCopy = clone(gltfCopy); 
             addPipelineExtras(gltf);
             
-            processJSON(gltf, options, function(gltf) {
+            processJSON(gltf, outputPath, options, function(gltf) {
                 expect(gltf).toBeDefined();
                 expect(clone(gltf)).not.toEqual(gltfCopy);
                 done();
@@ -55,7 +55,7 @@ describe('gltfPipeline', function() {
         var options = {};
         readGltf(gltfPath, options, function(gltf) {
             gltfCopy = clone(gltf);
-            processFile(gltfPath, options, function (gltf) {
+            processFile(gltfPath, outputPath, options, function (gltf) {
                 expect(gltf).toBeDefined();
                 expect(clone(gltf)).not.toEqual(gltfCopy);
                 done();
@@ -67,7 +67,7 @@ describe('gltfPipeline', function() {
         var options = {};
         readGltf(glbPath, options, function(gltf) {
             var gltfCopy = clone(gltf);
-            processFile(glbPath, options, function (gltf) {
+            processFile(glbPath, outputPath, options, function (gltf) {
                 expect(gltf).toBeDefined();
                 expect(clone(gltf)).not.toEqual(gltfCopy);
                 done();
@@ -114,13 +114,47 @@ describe('gltfPipeline', function() {
         });
     });
 
+    it('will write sources from JSON', function(done) {
+        var spy = spyOn(fs, 'writeFile').and.callFake(function(file, data, callback) {
+            callback();
+        });
+        var options = {
+            createDirectory : false,
+            embed : false
+        };
+        readGltf(gltfPath, options, function(gltf) {
+            processJSON(gltf, outputPath, options, function() {
+                process.nextTick(function() {
+                    expect(spy.calls.count()).toEqual(4);
+                    done();
+                });
+            });
+        });
+    });
+
+    it('will write sources from file', function(done) {
+        var spy = spyOn(fs, 'writeFile').and.callFake(function(file, data, callback) {
+            callback();
+        });
+        var options = {
+            createDirectory : false,
+            embed : false
+        };
+        processFile(gltfPath, outputPath, options, function() {
+            process.nextTick(function () {
+                expect(spy.calls.count()).toEqual(4);
+                done();
+            });
+        });
+        
+    });
+
     it('will add image processing extras if this is a pipeline with image processing', function(done) {
         var options = {
             imageProcess: true
         };
         readGltf(gltfEmbeddedPath, options, function(gltf) {
-            var gltfCopy = clone(gltf);
-            processJSON(gltf, options, function (gltf) {
+            processJSON(gltf, outputPath, options, function (gltf) {
                 expect(gltf).toBeDefined();
                 var images = gltf.images;
                 for (var imageID in images) {

--- a/specs/lib/gltfPipelineSpec.js
+++ b/specs/lib/gltfPipelineSpec.js
@@ -104,7 +104,7 @@ describe('gltfPipeline', function() {
             callback();
         });
         var options = {
-            createDirectory : false,
+            createDirectory : false
         };
         readGltf(gltfPath, options, function(gltf) {
             var options = { basePath : path.dirname(gltfPath) };
@@ -118,10 +118,10 @@ describe('gltfPipeline', function() {
     it('will write sources from JSON', function(done) {
         var options = {};
         readGltf(gltfPath, options, function (gltf) {
-            var initialSource = gltf['buffers'].CesiumTexturedBoxTest.extras._pipeline.source;
+            var initialUri = gltf['buffers'].CesiumTexturedBoxTest.uri;
             processJSON(gltf, options, function () {
-                var finalSource = gltf['buffers'].CesiumTexturedBoxTest.extras._pipeline.source;
-                expect(initialSource).not.toEqual(finalSource);
+                var finalUri = gltf['buffers'].CesiumTexturedBoxTest.uri;
+                expect(initialUri).not.toEqual(finalUri);
                 done();
             });
         });
@@ -130,10 +130,10 @@ describe('gltfPipeline', function() {
     it('will write sources from file', function(done) {
         var options = {};
         readGltf(gltfPath, options, function (gltf) {
-            var initialSource = gltf['buffers'].CesiumTexturedBoxTest.extras._pipeline.source;
+            var initialUri = gltf['buffers'].CesiumTexturedBoxTest.uri;
             processFile(gltfPath, options, function (gltfFinal) {
-                var finalSource = gltfFinal['buffers'].CesiumTexturedBoxTest.extras._pipeline.source;
-                expect(initialSource).not.toEqual(finalSource);
+                var finalUri = gltfFinal['buffers'].CesiumTexturedBoxTest.uri;
+                expect(initialUri).not.toEqual(finalUri);
                 done();
             });
         });
@@ -141,7 +141,7 @@ describe('gltfPipeline', function() {
 
     it('will add image processing extras if this is a pipeline with image processing', function(done) {
         var options = {
-            imageProcess : true,
+            imageProcess : true
         };
         readGltf(gltfEmbeddedPath, options, function(gltf) {
             processJSON(gltf, options, function (gltf) {

--- a/specs/lib/gltfPipelineSpec.js
+++ b/specs/lib/gltfPipelineSpec.js
@@ -24,7 +24,7 @@ describe('gltfPipeline', function() {
         var options = {};
         readGltf(gltfEmbeddedPath, options, function(gltf) {
             var gltfCopy = clone(gltf);
-            processJSON(gltf, outputPath, options, function (gltf) {
+            processJSON(gltf, options, function (gltf) {
                 expect(gltf).toBeDefined();
                 expect(clone(gltf)).not.toEqual(gltfCopy);
                 done();
@@ -42,7 +42,7 @@ describe('gltfPipeline', function() {
             var gltfCopy = clone(gltfCopy); 
             addPipelineExtras(gltf);
             
-            processJSON(gltf, outputPath, options, function(gltf) {
+            processJSON(gltf, options, function(gltf) {
                 expect(gltf).toBeDefined();
                 expect(clone(gltf)).not.toEqual(gltfCopy);
                 done();
@@ -55,7 +55,7 @@ describe('gltfPipeline', function() {
         var options = {};
         readGltf(gltfPath, options, function(gltf) {
             gltfCopy = clone(gltf);
-            processFile(gltfPath, outputPath, options, function (gltf) {
+            processFile(gltfPath, options, function (gltf) {
                 expect(gltf).toBeDefined();
                 expect(clone(gltf)).not.toEqual(gltfCopy);
                 done();
@@ -67,7 +67,7 @@ describe('gltfPipeline', function() {
         var options = {};
         readGltf(glbPath, options, function(gltf) {
             var gltfCopy = clone(gltf);
-            processFile(glbPath, outputPath, options, function (gltf) {
+            processFile(glbPath, options, function (gltf) {
                 expect(gltf).toBeDefined();
                 expect(clone(gltf)).not.toEqual(gltfCopy);
                 done();
@@ -104,57 +104,47 @@ describe('gltfPipeline', function() {
             callback();
         });
         var options = {
-            createDirectory : false
+            createDirectory : false,
         };
         readGltf(gltfPath, options, function(gltf) {
+            var options = { basePath : path.dirname(gltfPath) };
             processJSONToDisk(gltf, outputPath, options, function() {
-                expect(path.normalize(spy.calls.first().args[0])).toEqual(path.normalize('./output/'));
+                expect(path.normalize(spy.calls.first().args[0])).toEqual(path.normalize('output/output'));
                 done();
             });
         });
     });
 
     it('will write sources from JSON', function(done) {
-        var spy = spyOn(fs, 'writeFile').and.callFake(function(file, data, callback) {
-            callback();
-        });
-        var options = {
-            createDirectory : false,
-            embed : false
-        };
-        readGltf(gltfPath, options, function(gltf) {
-            processJSON(gltf, outputPath, options, function() {
-                process.nextTick(function() {
-                    expect(spy.calls.count()).toEqual(4);
-                    done();
-                });
+        var options = {};
+        readGltf(gltfPath, options, function (gltf) {
+            var initialSource = gltf['buffers'].CesiumTexturedBoxTest.extras._pipeline.source;
+            processJSON(gltf, options, function () {
+                var finalSource = gltf['buffers'].CesiumTexturedBoxTest.extras._pipeline.source;
+                expect(initialSource).not.toEqual(finalSource);
+                done();
             });
         });
     });
 
     it('will write sources from file', function(done) {
-        var spy = spyOn(fs, 'writeFile').and.callFake(function(file, data, callback) {
-            callback();
-        });
-        var options = {
-            createDirectory : false,
-            embed : false
-        };
-        processFile(gltfPath, outputPath, options, function() {
-            process.nextTick(function () {
-                expect(spy.calls.count()).toEqual(4);
+        var options = {};
+        readGltf(gltfPath, options, function (gltf) {
+            var initialSource = gltf['buffers'].CesiumTexturedBoxTest.extras._pipeline.source;
+            processFile(gltfPath, options, function (gltfFinal) {
+                var finalSource = gltfFinal['buffers'].CesiumTexturedBoxTest.extras._pipeline.source;
+                expect(initialSource).not.toEqual(finalSource);
                 done();
             });
         });
-        
     });
 
     it('will add image processing extras if this is a pipeline with image processing', function(done) {
         var options = {
-            imageProcess: true
+            imageProcess : true,
         };
         readGltf(gltfEmbeddedPath, options, function(gltf) {
-            processJSON(gltf, outputPath, options, function (gltf) {
+            processJSON(gltf, options, function (gltf) {
                 expect(gltf).toBeDefined();
                 var images = gltf.images;
                 for (var imageID in images) {

--- a/specs/lib/gltfPipelineSpec.js
+++ b/specs/lib/gltfPipelineSpec.js
@@ -117,7 +117,7 @@ describe('gltfPipeline', function() {
 
     it('will write sources from JSON', function(done) {
         var options = {};
-        readGltf(gltfPath, options, function (gltf) {
+        readGltf(gltfEmbeddedPath, options, function (gltf) {
             var initialUri = gltf['buffers'].CesiumTexturedBoxTest.uri;
             processJSON(gltf, options, function () {
                 var finalUri = gltf['buffers'].CesiumTexturedBoxTest.uri;
@@ -129,9 +129,9 @@ describe('gltfPipeline', function() {
 
     it('will write sources from file', function(done) {
         var options = {};
-        readGltf(gltfPath, options, function (gltf) {
+        readGltf(gltfEmbeddedPath, options, function (gltf) {
             var initialUri = gltf['buffers'].CesiumTexturedBoxTest.uri;
-            processFile(gltfPath, options, function (gltfFinal) {
+            processFile(gltfEmbeddedPath, options, function (gltfFinal) {
                 var finalUri = gltfFinal['buffers'].CesiumTexturedBoxTest.uri;
                 expect(initialUri).not.toEqual(finalUri);
                 done();


### PR DESCRIPTION
Addresses #93 

`gltfPipeline` now writeSources properly when using `processJSON` or `processFile`. Had to move some logic around which caused a bit more copy-pasted code instead of just reusing the `processJSON` method as we were before, but it was only a few lines so it should be fine.