### PR TITLE
Naive AO is ready for a first look!

### DIFF
--- a/bin/gltf-pipeline.js
+++ b/bin/gltf-pipeline.js
@@ -16,7 +16,13 @@ if (process.argv.length < 3 || defined(argv.h) || defined(argv.help)) {
         '  -b --binary, write binary glTF file.\n' +
         '  -s --separate, writes out separate geometry/animation data files, shader files and textures instead of embedding them in the glTF file.\n' +
         '  -t --separateImage, write out separate textures, but embed geometry/animation data files, and shader files.\n' +
-        '  -q, quantize the attributes of this model.\n';
+        '  -q, quantize the attributes of this model.\n' +
+        '  --ao_diffuse, bake ambient occlusion into the diffuse texture.\n' +
+        '  --ao_separate, bake ambient occlusion into a separate texture and modify the shader to use it.\n' +
+        '  --ao_scene, specify which scene to bake AO for.\n' +
+        '  --ao_rayDepth, ray distance for raytraced ambient occlusion.\n' +
+        '  --ao_resolution, resolution along one dimension for each AO texture.\n' +
+        '  --ao_samples, sample count for ambient occlusion\n';
     process.stdout.write(help);
     return;
 }
@@ -31,6 +37,12 @@ var binary = defaultValue(defaultValue(argv.b, argv.binary), false);
 var separate = defaultValue(defaultValue(argv.s, argv.separate), false);
 var separateImage = defaultValue(defaultValue(argv.t, argv.separateImage), false);
 var quantize = defaultValue(defaultValue(argv.q, argv.quantize), false);
+
+var ao_diffuse = defaultValue(argv.ao_diffuse, false);
+var ao_scene = argv.ao_scene;
+var ao_rayDepth = defaultValue(argv.ao_rayDepth, 1.0);
+var ao_resolution = defaultValue(argv.ao_resolution, 128);
+var ao_samples = defaultValue(argv.ao_samples, 16);
 
 if (!defined(gltfPath)) {
     throw new DeveloperError('Input path is undefined.');
@@ -49,7 +61,13 @@ var options = {
     binary : binary,
     embed : !separate,
     embedImage : !separateImage,
-    quantize : quantize
+    quantize : quantize,
+    ao_diffuse : ao_diffuse,
+    ao_scene : ao_scene,
+    ao_rayDepth : ao_rayDepth,
+    ao_resolution : ao_resolution,
+    ao_samples : ao_samples,
+    imageProcess : ao_diffuse
 };
 
 processFileToDisk(gltfPath, outputPath, options);

--- a/bin/gltf-pipeline.js
+++ b/bin/gltf-pipeline.js
@@ -18,7 +18,6 @@ if (process.argv.length < 3 || defined(argv.h) || defined(argv.help)) {
         '  -t --separateImage, write out separate textures, but embed geometry/animation data files, and shader files.\n' +
         '  -q, quantize the attributes of this model.\n' +
         '  --ao_diffuse, bake ambient occlusion into the diffuse texture.\n' +
-        '  --ao_separate, bake ambient occlusion into a separate texture and modify the shader to use it.\n' +
         '  --ao_scene, specify which scene to bake AO for.\n' +
         '  --ao_rayDepth, ray distance for raytraced ambient occlusion.\n' +
         '  --ao_resolution, resolution along one dimension for each AO texture.\n' +
@@ -38,11 +37,13 @@ var separate = defaultValue(defaultValue(argv.s, argv.separate), false);
 var separateImage = defaultValue(defaultValue(argv.t, argv.separateImage), false);
 var quantize = defaultValue(defaultValue(argv.q, argv.quantize), false);
 
-var ao_diffuse = defaultValue(argv.ao_diffuse, false);
-var ao_scene = argv.ao_scene;
-var ao_rayDepth = defaultValue(argv.ao_rayDepth, 1.0);
-var ao_resolution = defaultValue(argv.ao_resolution, 128);
-var ao_samples = defaultValue(argv.ao_samples, 16);
+var aoOptions = {
+    runAO : defaultValue(argv.ao_diffuse, false),
+    scene : argv.ao_scene,
+    rayDepth : defaultValue(argv.ao_rayDepth, 1.0),
+    resolution : defaultValue(argv.ao_resolution, 128),
+    numberSamples : defaultValue(argv.ao_samples, 16)
+};
 
 if (!defined(gltfPath)) {
     throw new DeveloperError('Input path is undefined.');
@@ -62,12 +63,8 @@ var options = {
     embed : !separate,
     embedImage : !separateImage,
     quantize : quantize,
-    ao_diffuse : ao_diffuse,
-    ao_scene : ao_scene,
-    ao_rayDepth : ao_rayDepth,
-    ao_resolution : ao_resolution,
-    ao_samples : ao_samples,
-    imageProcess : ao_diffuse
+    aoOptions : aoOptions,
+    imageProcess : aoOptions.runAO
 };
 
 processFileToDisk(gltfPath, outputPath, options);

--- a/bin/gltf-pipeline.js
+++ b/bin/gltf-pipeline.js
@@ -37,13 +37,15 @@ var separate = defaultValue(defaultValue(argv.s, argv.separate), false);
 var separateImage = defaultValue(defaultValue(argv.t, argv.separateImage), false);
 var quantize = defaultValue(defaultValue(argv.q, argv.quantize), false);
 
-var aoOptions = {
-    runAO : defaultValue(argv.ao_diffuse, false),
-    scene : argv.ao_scene,
-    rayDepth : defaultValue(argv.ao_rayDepth, 1.0),
-    resolution : defaultValue(argv.ao_resolution, 128),
-    numberSamples : defaultValue(argv.ao_samples, 16)
-};
+var aoOptions;
+if (argv.ao_diffuse) {
+    aoOptions = {
+        scene : argv.ao_scene,
+        rayDepth : defaultValue(argv.ao_rayDepth, 1.0),
+        resolution : defaultValue(argv.ao_resolution, 128),
+        numberSamples : defaultValue(argv.ao_samples, 16)
+    };
+}
 
 if (!defined(gltfPath)) {
     throw new DeveloperError('Input path is undefined.');
@@ -64,7 +66,7 @@ var options = {
     embedImage : !separateImage,
     quantize : quantize,
     aoOptions : aoOptions,
-    imageProcess : aoOptions.runAO
+    imageProcess : defined(aoOptions)
 };
 
 processFileToDisk(gltfPath, outputPath, options);

--- a/lib/NodeHelpers.js
+++ b/lib/NodeHelpers.js
@@ -13,7 +13,8 @@ module.exports = {
     computeFlatTransformScene: computeFlatTransformScene,
     getLocalMatrix4: getLocalMatrix4,
     getAllNodesInScene: getAllNodesInScene,
-    depthFirstTraversal: depthFirstTraversal
+    depthFirstTraversal: depthFirstTraversal,
+    forEachPrimitive: forEachPrimitive
 };
 
 var cartesian3Scratch1 = new Cartesian3();
@@ -38,7 +39,7 @@ function flattenTransform(parameters, node, parent) {
 function computeFlatTransformScene(scene, nodes) {
     var rootNodeIDs = scene.nodes;
     var parameters = {
-      matrix4Scratch: matrix4Scratch
+        matrix4Scratch: matrix4Scratch
     };
     for (var id in rootNodeIDs) {
         if (rootNodeIDs.hasOwnProperty(id)) {
@@ -129,4 +130,21 @@ function getLocalMatrix4(node, result) {
     rotation.w = rotationArray[3];
 
     return Matrix4.fromTranslationQuaternionRotationScale(translation, rotation, scale, result);
+}
+
+// primitiveFunction should expect primitive, a meshPrimitiveID, and some parameters
+function forEachPrimitive(gltf, primitiveFunction, parameters) {
+    var meshes = gltf.meshes;
+    for (var meshID in meshes) {
+        if (meshes.hasOwnProperty(meshID)) {
+            var primitives = meshes[meshID].primitives;
+            for (var primitiveID in primitives) {
+                if (primitives.hasOwnProperty(primitiveID)) {
+                    var primitive = primitives[primitiveID];
+                    var meshPrimitiveID = meshID + "_" + primitiveID;
+                    primitiveFunction(primitive, meshPrimitiveID, parameters);
+                }
+            }
+        }
+    }
 }

--- a/lib/NodeHelpers.js
+++ b/lib/NodeHelpers.js
@@ -132,32 +132,43 @@ function getLocalMatrix4(node, result) {
     return Matrix4.fromTranslationQuaternionRotationScale(translation, rotation, scale, result);
 }
 
+var packedParametersScratch = {
+    meshes : undefined,
+    parameters : undefined,
+    primitiveFunction : undefined
+};
+
 // Perform an operation on each primitive in a scene.
 // PrimitiveFunction should expect primitive, a meshPrimitiveID, some parameters, and the node itself
-// Requires parameters to contain gltf.meshes and the primitive function.
-function forEachPrimitiveInScene(gltf, scene, parameters) {
+function forEachPrimitiveInScene(gltf, scene, primitiveFunction, parameters) {
     var rootNodeNames = scene.nodes;
     var allNodes = gltf.nodes;
+    packedParametersScratch.meshes = gltf.meshes;
+    packedParametersScratch.parameters = parameters;
+    packedParametersScratch.primitiveFunction = primitiveFunction;
     for (var nodeID in rootNodeNames) {
         if (rootNodeNames.hasOwnProperty(nodeID)) {
             var rootNodeName = rootNodeNames[nodeID];
-            depthFirstTraversal(allNodes[rootNodeName], allNodes, forEachPrimitiveInNode, parameters);
+            depthFirstTraversal(allNodes[rootNodeName], allNodes, forEachPrimitiveInNode, packedParametersScratch);
         }
     }
 }
 
-function forEachPrimitiveInNode(parameters, node) {
+function forEachPrimitiveInNode(packedParameters, node) {
+    var meshes = packedParameters.meshes;
+    var parameters = packedParameters.parameters;
+    var primitiveFunction = packedParameters.primitiveFunction;
+
     var meshIDs = node.meshes;
-    for (var meshIndex in meshIDs) {
-        if (meshIDs.hasOwnProperty(meshIndex)) {
-            var meshID = meshIDs[meshIndex];
-            var meshData = parameters.meshes[meshID];
-            var primitives = meshData.primitives;
-            for (var primitiveID in primitives) {
-                if (primitives.hasOwnProperty(primitiveID)) {
-                    parameters.primitiveFunction(primitives[primitiveID], meshID + '_' + primitiveID, parameters, node);
-                }
-            }
+    if (!defined(meshIDs)) {
+        return;
+    }
+    for (var i = 0; i < meshIDs.length; i++) {
+        var meshID = meshIDs[i];
+        var meshData = meshes[meshID];
+        var primitives = meshData.primitives;
+        for (var j = 0; j < primitives.length; j++) {
+            primitiveFunction(primitives[j], meshID + '_' + j, parameters, node);
         }
     }
 }

--- a/lib/NodeHelpers.js
+++ b/lib/NodeHelpers.js
@@ -14,7 +14,7 @@ module.exports = {
     getLocalMatrix4: getLocalMatrix4,
     getAllNodesInScene: getAllNodesInScene,
     depthFirstTraversal: depthFirstTraversal,
-    forEachPrimitive: forEachPrimitive
+    forEachPrimitiveInScene: forEachPrimitiveInScene
 };
 
 var cartesian3Scratch1 = new Cartesian3();
@@ -132,17 +132,30 @@ function getLocalMatrix4(node, result) {
     return Matrix4.fromTranslationQuaternionRotationScale(translation, rotation, scale, result);
 }
 
-// primitiveFunction should expect primitive, a meshPrimitiveID, and some parameters
-function forEachPrimitive(gltf, primitiveFunction, parameters) {
-    var meshes = gltf.meshes;
-    for (var meshID in meshes) {
-        if (meshes.hasOwnProperty(meshID)) {
-            var primitives = meshes[meshID].primitives;
+// Perform an operation on each primitive in a scene.
+// PrimitiveFunction should expect primitive, a meshPrimitiveID, some parameters, and the node itself
+// Requires parameters to contain gltf.meshes and the primitive function.
+function forEachPrimitiveInScene(gltf, scene, parameters) {
+    var rootNodeNames = scene.nodes;
+    var allNodes = gltf.nodes;
+    for (var nodeID in rootNodeNames) {
+        if (rootNodeNames.hasOwnProperty(nodeID)) {
+            var rootNodeName = rootNodeNames[nodeID];
+            depthFirstTraversal(allNodes[rootNodeName], allNodes, forEachPrimitiveInNode, parameters);
+        }
+    }
+}
+
+function forEachPrimitiveInNode(parameters, node) {
+    var meshIDs = node.meshes;
+    for (var meshIndex in meshIDs) {
+        if (meshIDs.hasOwnProperty(meshIndex)) {
+            var meshID = meshIDs[meshIndex];
+            var meshData = parameters.meshes[meshID];
+            var primitives = meshData.primitives;
             for (var primitiveID in primitives) {
                 if (primitives.hasOwnProperty(primitiveID)) {
-                    var primitive = primitives[primitiveID];
-                    var meshPrimitiveID = meshID + "_" + primitiveID;
-                    primitiveFunction(primitive, meshPrimitiveID, parameters);
+                    parameters.primitiveFunction(primitives[primitiveID], meshID + '_' + primitiveID, parameters, node);
                 }
             }
         }

--- a/lib/bakeAmbientOcclusion.js
+++ b/lib/bakeAmbientOcclusion.js
@@ -10,6 +10,7 @@ var Cartesian3 = Cesium.Cartesian3;
 var Matrix3 = Cesium.Matrix3;
 var Matrix4 = Cesium.Matrix4;
 var Quaternion = Cesium.Quaternion;
+var WebGLConstants = Cesium.WebGLConstants;
 var Jimp = require('jimp');
 
 var Ray = Cesium.Ray;
@@ -33,29 +34,28 @@ var quaternionScratch = new Quaternion();
 var matrix3Scratch = new Matrix3();
 
 function bakeAmbientOcclusion(gltf, options) {
-    // requires each mesh to occur only once in the scene
+    // Requires each mesh to occur only once in the scene
     var sceneID = defaultValue(options.scene, gltf.scene);
     if (!defined(sceneID)) {
         sceneID = Object.keys(gltf.scenes)[0];
     }
     var scene = gltf.scenes[sceneID];
 
-    // generate triangle soup
+    // Generate triangle soup
     var raytracerScene = generateRaytracerScene(gltf, scene, options);
 
+    // Raytrace to a new texture for each primitive
     var parameters = {
-        meshes: gltf.meshes,
         raytracerScene: raytracerScene,
-        resolution: options.resolution,
-        primitiveFunction: raytracePrimitiveTexels
+        resolution: options.resolution
     };
+    NodeHelpers.forEachPrimitiveInScene(gltf, scene, raytracePrimitiveTexels, parameters);
 
-    // raytrace to a new texture for each primitive
-    NodeHelpers.forEachPrimitiveInScene(gltf, scene, parameters);
-
-    ////////// add to the gltf //////////
+    // Add to the gltf
     bakeToDiffuse(gltf, scene, options.resolution, raytracerScene);
 }
+
+////////// adding to the gltf //////////
 
 function bakeToDiffuse(gltf, scene, resolution, raytracerScene) {
     // find material with a diffuse texture parameter to clone as needed
@@ -94,13 +94,11 @@ function bakeToDiffuse(gltf, scene, resolution, raytracerScene) {
         exampleImageID: exampleImageID,
         resolution: resolution,
         gltf: gltf,
-        meshes: gltf.meshes,
-        raytracerScene: raytracerScene,
-        primitiveFunction: addAoToImage
+        raytracerScene: raytracerScene
     };
 
     // Bake AO for each primitive in the scene
-    NodeHelpers.forEachPrimitiveInScene(gltf, scene, parameters);
+    NodeHelpers.forEachPrimitiveInScene(gltf, scene, addAoToImage, parameters);
 }
 
 function addAoToImage(primitive, meshPrimitiveID, parameters) {
@@ -131,7 +129,7 @@ function addAoToImage(primitive, meshPrimitiveID, parameters) {
 }
 
 function postProcessAO(aoBuffer, dataResolution, goalResolution, jimpAO) {
-    // copy the data over to the jimp
+    // Copy the data over to the jimp
     var value = 0.0;
     jimpAO.resize(dataResolution, dataResolution);
     for (var x = 0; x < dataResolution; x++) {
@@ -141,7 +139,7 @@ function postProcessAO(aoBuffer, dataResolution, goalResolution, jimpAO) {
             jimpAO.bitmap.data[(dataResolution * y + x) * 4 + 3] = value;
         }
     }
-    // resize the data to match the goal resolution
+    // Resize the data to match the goal resolution
     jimpAO.resize(goalResolution, goalResolution, Jimp.RESIZE_BEZIER);
 }
 
@@ -183,18 +181,18 @@ function ensureImageUniqueness(gltf, primitive, meshPrimitiveID, state) {
     var allTextures = gltf.textures;
     var allImages = gltf.images;
 
-    // generate some new IDs
+    // Generate some new IDs
     var newMaterialID = meshPrimitiveID + '_AO_material';
     var newTextureID = meshPrimitiveID + '_AO_texture';
     var newImageID = meshPrimitiveID + '_AO_image';
 
-    // grab the existing material
+    // Grab the existing material
     var materialID = primitive.material;
     var material = allMaterials[materialID];
     var values = material.values;
     var diffuse = values.diffuse;
 
-    // check if the material has a diffuse texture material. if not,
+    // Check if the material has a diffuse texture material. if not,
     // - clone the example material
     // - clone the example texture
     // - clone the example image. resize to resolution and set to diffuse color, if any
@@ -260,7 +258,7 @@ function ensureImageUniqueness(gltf, primitive, meshPrimitiveID, state) {
 ////////// loading //////////
 
 function generateRaytracerScene(gltf, scene, options) {
-    // set up data we need for sampling. generate "triangle soup" over the whole scene.
+    // Set up data we need for sampling. generate "triangle soup" over the whole scene.
     var accessors = gltf.accessors;
 
     // read all accessors in one go to avoid repeated read-and-conversion
@@ -288,23 +286,26 @@ function generateRaytracerScene(gltf, scene, options) {
     NodeHelpers.computeFlatTransformScene(scene, gltf.nodes);
 
     var parameters = {
-        meshes: gltf.meshes,
         resolution: options.resolution,
-        raytracerScene: raytracerScene,
-        primitiveFunction: processPrimitive
+        raytracerScene: raytracerScene
     };
 
-    NodeHelpers.forEachPrimitiveInScene(gltf, scene, parameters);
+    NodeHelpers.forEachPrimitiveInScene(gltf, scene, processPrimitive, parameters);
 
     return raytracerScene;
 }
 
 function processPrimitive(primitive, meshPrimitiveID, parameters, node) {
+    // AO only works with triangles
+    if (defined(primitive.mode) && primitive.mode !== WebGLConstants.TRIANGLES) {
+        throw new DeveloperError('In stage bakeAmbientOcclusion: baking AO only supports triangle primitives.');
+    }
+
     var raytracerScene = parameters.raytracerScene;
     var bufferDataByAccessor = raytracerScene.bufferDataByAccessor;
     var indices = bufferDataByAccessor[primitive.indices].data;
     var positions = bufferDataByAccessor[primitive.attributes.POSITION].data;
-    var numTriangles = indices.length / 3;
+    var numberTriangles = indices.length / 3;
     var transform = node.extras._pipeline.flatTransform;
 
     var resolution = parameters.resolution;
@@ -316,7 +317,7 @@ function processPrimitive(primitive, meshPrimitiveID, parameters, node) {
     };
 
     // Read each triangle's Cartesian3s using the index buffer
-    for (var i = 0; i < numTriangles; i++) {
+    for (var i = 0; i < numberTriangles; i++) {
         var index0 = indices[i * 3];
         var index1 = indices[i * 3 + 1];
         var index2 = indices[i * 3 + 2];
@@ -338,6 +339,8 @@ function processPrimitive(primitive, meshPrimitiveID, parameters, node) {
         raytracerScene.triangleSoup.push(triangle);
     }
 }
+
+////////// rendering //////////
 
 function raytracePrimitiveTexels(primitive, meshPrimitiveID, parameters, node) {
     var raytracerScene = parameters.raytracerScene;
@@ -443,7 +446,7 @@ function computeAmbientOcclusionAt(position, normal, numberSamples, sqrtNumberSa
 }
 
 function naiveRaytrace(triangleSoup, ray, nearCull) {
-    // check ray against every triangle in the soup. return the nearest intersection.
+    // Check ray against every triangle in the soup. return the nearest intersection.
     var minIntersect = Number.POSITIVE_INFINITY;
     for (var triangleSoupIndex = 0; triangleSoupIndex < triangleSoup.length; triangleSoupIndex++) {
         var positions = triangleSoup[triangleSoupIndex].positions;
@@ -464,7 +467,7 @@ function generateJitteredRay(position, normal, sampleNumber, sqrtNumberSamples) 
     var s = (sampleNumber % sqrtNumberSamples) * cellWidth + (Math.random() / sqrtNumberSamples);
     var t = Math.floor(sampleNumber / sqrtNumberSamples) * cellWidth + (Math.random() / sqrtNumberSamples);
 
-    // generate ray on a y-up hemisphere with cosine weighting (more rays around the normal)
+    // Generate ray on a y-up hemisphere with cosine weighting (more rays around the normal)
     var u = 2.0 * Math.PI * s;
     var v = Math.sqrt(1.0 - t);
 
@@ -473,7 +476,7 @@ function generateJitteredRay(position, normal, sampleNumber, sqrtNumberSamples) 
     randomDirection.y = t;
     randomDirection.z = v * Math.sin(u);
 
-    // orient with texel's normal in world space
+    // Orient with texel's normal in world space
     var theta = Math.acos(normal.y); // dot product of normal with y-up is normal.y
     var axis = Cartesian3.cross(randomDirection, normal, cartesian3Scratch1);
     var rotation = Quaternion.fromAxisAngle(axis, theta, quaternionScratch);
@@ -484,7 +487,7 @@ function generateJitteredRay(position, normal, sampleNumber, sqrtNumberSamples) 
     return scratchRay;
 }
 
-// borrowed straight from Cesium/Source/Core/IntersectionTests
+// Borrowed straight from Cesium/Source/Core/IntersectionTests
 var scratchEdge0 = new Cartesian3();
 var scratchEdge1 = new Cartesian3();
 var scratchPVec = new Cartesian3();

--- a/lib/bakeAmbientOcclusion.js
+++ b/lib/bakeAmbientOcclusion.js
@@ -46,17 +46,18 @@ function bakeAmbientOcclusion(gltf, options) {
     var parameters = {
         meshes: gltf.meshes,
         raytracerScene: raytracerScene,
-        resolution: options.resolution
+        resolution: options.resolution,
+        primitiveFunction: raytracePrimitiveTexels
     };
 
     // raytrace to a new texture for each primitive
-    NodeHelpers.forEachPrimitive(gltf, raytracePrimitiveTexels, parameters);
+    NodeHelpers.forEachPrimitiveInScene(gltf, scene, parameters);
 
     ////////// add to the gltf //////////
-    bakeToDiffuse(gltf, options.resolution, raytracerScene);
+    bakeToDiffuse(gltf, scene, options.resolution, raytracerScene);
 }
 
-function bakeToDiffuse(gltf, resolution, raytracerScene) {
+function bakeToDiffuse(gltf, scene, resolution, raytracerScene) {
     // find material with a diffuse texture parameter to clone as needed
     var materials = gltf.materials;
     var textures = gltf.textures;
@@ -93,11 +94,13 @@ function bakeToDiffuse(gltf, resolution, raytracerScene) {
         exampleImageID: exampleImageID,
         resolution: resolution,
         gltf: gltf,
-        raytracerScene: raytracerScene
+        meshes: gltf.meshes,
+        raytracerScene: raytracerScene,
+        primitiveFunction: addAoToImage
     };
 
-    // Bake AO for each primitive
-    NodeHelpers.forEachPrimitive(gltf, addAoToImage, parameters);
+    // Bake AO for each primitive in the scene
+    NodeHelpers.forEachPrimitiveInScene(gltf, scene, parameters);
 }
 
 function addAoToImage(primitive, meshPrimitiveID, parameters) {
@@ -279,7 +282,7 @@ function generateRaytracerScene(gltf, scene, options) {
         nearCull: 0.5 / options.resolution
     };
 
-    // TODO: currently assuming each primitive appears in the scene once. this is not true. figure out what to do.
+    // TODO: currently assuming each primitive appears in the scene once. figure out what to do when this is not true.
 
     // Generate all the world transform matrices
     NodeHelpers.computeFlatTransformScene(scene, gltf.nodes);
@@ -287,56 +290,30 @@ function generateRaytracerScene(gltf, scene, options) {
     var parameters = {
         meshes: gltf.meshes,
         resolution: options.resolution,
-        raytracerScene: raytracerScene
+        raytracerScene: raytracerScene,
+        primitiveFunction: processPrimitive
     };
 
-    // Generate triangle soup over the whole scene
-    var rootNodeNames = scene.nodes;
-    var allNodes = gltf.nodes;
-    for (var nodeID in rootNodeNames) {
-        if (rootNodeNames.hasOwnProperty(nodeID)) {
-            var rootNodeName = rootNodeNames[nodeID];
-            NodeHelpers.depthFirstTraversal(allNodes[rootNodeName], allNodes, addNodeToSoup, parameters);
-        }
-    }
+    NodeHelpers.forEachPrimitiveInScene(gltf, scene, parameters);
 
     return raytracerScene;
 }
 
-function addNodeToSoup(parameters, node) {
-    var transform = node.extras._pipeline.flatTransform;
-    var mesheIDs = node.meshes;
-    for (var meshIndex in mesheIDs) {
-        if (mesheIDs.hasOwnProperty(meshIndex)) {
-            var meshID = mesheIDs[meshIndex];
-            var meshData = parameters.meshes[meshID];
-            var primitives = meshData.primitives;
-            for (var primitiveID in primitives) {
-                if (primitives.hasOwnProperty(primitiveID)) {
-                    processPrimitive(parameters, meshID + '_' + primitiveID, primitives[primitiveID], transform);
-                }
-            }
-        }
-    }
-}
-
-function processPrimitive(parameters, meshPrimitiveID, primitive, transform) {
+function processPrimitive(primitive, meshPrimitiveID, parameters, node) {
     var raytracerScene = parameters.raytracerScene;
     var bufferDataByAccessor = raytracerScene.bufferDataByAccessor;
     var indices = bufferDataByAccessor[primitive.indices].data;
     var positions = bufferDataByAccessor[primitive.attributes.POSITION].data;
     var numTriangles = indices.length / 3;
-    primitive.extras._pipeline.transform = transform;
+    var transform = node.extras._pipeline.flatTransform;
 
     var resolution = parameters.resolution;
 
-    var aoBuffer = {
+    raytracerScene.aoBufferByPrimitive[meshPrimitiveID] = {
         resolution: resolution,
         samples: new Array(resolution * resolution).fill(0.0),
-        count: new Array(resolution * resolution).fill(0.0)
+        count: new Array(resolution * resolution).fill(0)
     };
-
-    raytracerScene.aoBufferByPrimitive[meshPrimitiveID] = aoBuffer;
 
     // Read each triangle's Cartesian3s using the index buffer
     for (var i = 0; i < numTriangles; i++) {
@@ -362,9 +339,7 @@ function processPrimitive(parameters, meshPrimitiveID, primitive, transform) {
     }
 }
 
-////////// computing AO //////////
-
-function raytracePrimitiveTexels(primitive, meshPrimitiveID, parameters) {
+function raytracePrimitiveTexels(primitive, meshPrimitiveID, parameters, node) {
     var raytracerScene = parameters.raytracerScene;
     var bufferDataByAccessor = raytracerScene.bufferDataByAccessor;
     var indices = bufferDataByAccessor[primitive.indices].data;
@@ -372,12 +347,13 @@ function raytracePrimitiveTexels(primitive, meshPrimitiveID, parameters) {
     var normals = bufferDataByAccessor[primitive.attributes.NORMAL].data;
     var uvs = bufferDataByAccessor[primitive.attributes.TEXCOORD_0].data;
     var numTriangles = indices.length / 3;
-    var transform = primitive.extras._pipeline.transform;
+    var transform = node.extras._pipeline.flatTransform;
     var inverse = new Matrix4();
     inverse = Matrix4.inverse(transform, inverse);
 
     var triangleSoup = raytracerScene.triangleSoup;
     var numberSamples = raytracerScene.numberSamples;
+    var sqrtNumberSamples = Math.floor(Math.sqrt(numberSamples));
     var aoBuffer = raytracerScene.aoBufferByPrimitive[meshPrimitiveID];
     var resolution = parameters.resolution;
 
@@ -387,14 +363,6 @@ function raytracePrimitiveTexels(primitive, meshPrimitiveID, parameters) {
         var index0 = indices[i * 3];
         var index1 = indices[i * 3 + 1];
         var index2 = indices[i * 3 + 2];
-
-        var position0 = Cartesian3.clone(positions[index0]);
-        var position1 = Cartesian3.clone(positions[index1]);
-        var position2 = Cartesian3.clone(positions[index2]);
-
-        var normal0 = normals[index0];
-        var normal1 = normals[index1];
-        var normal2 = normals[index2];
 
         var uv0 = uvs[index0];
         var uv1 = uvs[index1];
@@ -437,8 +405,8 @@ function raytracePrimitiveTexels(primitive, meshPrimitiveID, parameters) {
                 // Use this barycentric coordinate to compute the local space position and normal on the triangle
                 var texelPosition = cartesian3Scratch2;
                 var texelNormal = cartesian3Scratch3;
-                sumBarycentric(barycentric, position0, position1, position2, cartesian3Scratch4, texelPosition);
-                sumBarycentric(barycentric, normal0, normal1, normal2, cartesian3Scratch4, texelNormal);
+                sumBarycentric(barycentric, positions[index0], positions[index1], positions[index2], cartesian3Scratch4, texelPosition);
+                sumBarycentric(barycentric, normals[index0], normals[index1], normals[index2], cartesian3Scratch4, texelNormal);
 
                 // Transform to world space
                 Matrix4.multiplyByPoint(transform, texelPosition, texelPosition);
@@ -450,7 +418,7 @@ function raytracePrimitiveTexels(primitive, meshPrimitiveID, parameters) {
                 var aoBufferIndex = Math.floor(uStep / pixelWidth) + Math.floor(vStep / pixelWidth) * resolution;
 
                 // Raytrace
-                computeAmbientOcclusionAt(texelPosition, texelNormal, numberSamples,
+                computeAmbientOcclusionAt(texelPosition, texelNormal, numberSamples, sqrtNumberSamples,
                     triangles, raytracerScene.nearCull,
                     raytracerScene.rayDepth, aoBuffer, aoBufferIndex);
 
@@ -461,10 +429,9 @@ function raytracePrimitiveTexels(primitive, meshPrimitiveID, parameters) {
     }
 }
 
-function computeAmbientOcclusionAt(position, normal, numberSamples,
+function computeAmbientOcclusionAt(position, normal, numberSamples, sqrtNumberSamples,
     triangles, nearCull, rayDepth, aoBuffer, aoBufferIndex) {
     for (var j = 0; j < numberSamples; j++) {
-        var sqrtNumberSamples = Math.floor(Math.sqrt(numberSamples));
         var sampleRay = generateJitteredRay(position, normal, j, sqrtNumberSamples);
         aoBuffer.count[aoBufferIndex]++;
         var nearestIntersect = naiveRaytrace(triangles, sampleRay, nearCull);

--- a/lib/bakeAmbientOcclusion.js
+++ b/lib/bakeAmbientOcclusion.js
@@ -33,27 +33,25 @@ var quaternionScratch = new Quaternion();
 var matrix3Scratch = new Matrix3();
 
 function bakeAmbientOcclusion(gltf, options) {
-    if (defined(options) && options.runAO) {
-        // Requires each mesh to occur only once in the scene
-        var sceneID = defaultValue(options.scene, gltf.scene);
-        if (!defined(sceneID)) {
-            sceneID = Object.keys(gltf.scenes)[0];
-        }
-        var scene = gltf.scenes[sceneID];
-
-        // Generate triangle soup
-        var raytracerScene = generateRaytracerScene(gltf, scene, options);
-
-        // Raytrace to a new texture for each primitive
-        var parameters = {
-            raytracerScene: raytracerScene,
-            resolution: options.resolution
-        };
-        NodeHelpers.forEachPrimitiveInScene(gltf, scene, raytracePrimitiveTexels, parameters);
-
-        // Add to the gltf
-        bakeToDiffuse(gltf, scene, options.resolution, raytracerScene);
+    // Requires each mesh to occur only once in the scene
+    var sceneID = defaultValue(options.scene, gltf.scene);
+    if (!defined(sceneID)) {
+        sceneID = Object.keys(gltf.scenes)[0];
     }
+    var scene = gltf.scenes[sceneID];
+
+    // Generate triangle soup
+    var raytracerScene = generateRaytracerScene(gltf, scene, options);
+
+    // Raytrace to a new texture for each primitive
+    var parameters = {
+        raytracerScene: raytracerScene,
+        resolution: options.resolution
+    };
+    NodeHelpers.forEachPrimitiveInScene(gltf, scene, raytracePrimitiveTexels, parameters);
+
+    // Add to the gltf
+    bakeToDiffuse(gltf, scene, options.resolution, raytracerScene);
 }
 
 ////////// adding to the gltf //////////

--- a/lib/bakeAmbientOcclusion.js
+++ b/lib/bakeAmbientOcclusion.js
@@ -1,22 +1,21 @@
 'use strict';
 var Cesium = require('cesium');
-var CesiumMath = Cesium.Math;
-var clone = require('clone');
-var defined = Cesium.defined;
-var defaultValue = Cesium.defaultValue;
-var DeveloperError = Cesium.DeveloperError;
+var baryCentricCoordinates = Cesium.barycentricCoordinates;
 var Cartesian2 = Cesium.Cartesian2;
 var Cartesian3 = Cesium.Cartesian3;
+var CesiumMath = Cesium.Math;
+var defaultValue = Cesium.defaultValue;
+var defined = Cesium.defined;
+var DeveloperError = Cesium.DeveloperError;
 var Matrix3 = Cesium.Matrix3;
 var Matrix4 = Cesium.Matrix4;
 var Quaternion = Cesium.Quaternion;
-var WebGLConstants = Cesium.WebGLConstants;
-var Jimp = require('jimp');
-
 var Ray = Cesium.Ray;
-var baryCentricCoordinates = Cesium.barycentricCoordinates;
-var readAccessor = require('./readAccessor');
+var WebGLConstants = Cesium.WebGLConstants;
+var clone = require('clone');
+var Jimp = require('jimp');
 var NodeHelpers = require('./NodeHelpers');
+var readAccessor = require('./readAccessor');
 
 module.exports = {
     bakeAmbientOcclusion: bakeAmbientOcclusion,
@@ -34,25 +33,27 @@ var quaternionScratch = new Quaternion();
 var matrix3Scratch = new Matrix3();
 
 function bakeAmbientOcclusion(gltf, options) {
-    // Requires each mesh to occur only once in the scene
-    var sceneID = defaultValue(options.scene, gltf.scene);
-    if (!defined(sceneID)) {
-        sceneID = Object.keys(gltf.scenes)[0];
+    if (defined(options) && options.runAO) {
+        // Requires each mesh to occur only once in the scene
+        var sceneID = defaultValue(options.scene, gltf.scene);
+        if (!defined(sceneID)) {
+            sceneID = Object.keys(gltf.scenes)[0];
+        }
+        var scene = gltf.scenes[sceneID];
+
+        // Generate triangle soup
+        var raytracerScene = generateRaytracerScene(gltf, scene, options);
+
+        // Raytrace to a new texture for each primitive
+        var parameters = {
+            raytracerScene: raytracerScene,
+            resolution: options.resolution
+        };
+        NodeHelpers.forEachPrimitiveInScene(gltf, scene, raytracePrimitiveTexels, parameters);
+
+        // Add to the gltf
+        bakeToDiffuse(gltf, scene, options.resolution, raytracerScene);
     }
-    var scene = gltf.scenes[sceneID];
-
-    // Generate triangle soup
-    var raytracerScene = generateRaytracerScene(gltf, scene, options);
-
-    // Raytrace to a new texture for each primitive
-    var parameters = {
-        raytracerScene: raytracerScene,
-        resolution: options.resolution
-    };
-    NodeHelpers.forEachPrimitiveInScene(gltf, scene, raytracePrimitiveTexels, parameters);
-
-    // Add to the gltf
-    bakeToDiffuse(gltf, scene, options.resolution, raytracerScene);
 }
 
 ////////// adding to the gltf //////////
@@ -70,7 +71,7 @@ function bakeToDiffuse(gltf, scene, resolution, raytracerScene) {
         if (materials.hasOwnProperty(materialID)) {
             var material = materials[materialID];
             if (defined(material.values) && defined(material.values.diffuse)) {
-                if (typeof material.values.diffuse === "string") {
+                if (typeof material.values.diffuse === 'string') {
                     exampleMaterialID = materialID;
                     exampleTextureID = material.values.diffuse;
                     exampleImageID = textures[exampleTextureID].source;
@@ -136,7 +137,7 @@ function postProcessAO(aoBuffer, dataResolution, goalResolution, jimpAO) {
         for (var y = 0; y < dataResolution; y++) {
             var dataIdx = dataResolution * y + x;
             value = 255.0 * (aoBuffer.samples[dataIdx] / aoBuffer.count[dataIdx]);
-            jimpAO.bitmap.data[(dataResolution * y + x) * 4 + 3] = value;
+            jimpAO.bitmap.data[dataIdx * 4 + 3] = value;
         }
     }
     // Resize the data to match the goal resolution
@@ -351,8 +352,9 @@ function raytracePrimitiveTexels(primitive, meshPrimitiveID, parameters, node) {
     var uvs = bufferDataByAccessor[primitive.attributes.TEXCOORD_0].data;
     var numTriangles = indices.length / 3;
     var transform = node.extras._pipeline.flatTransform;
-    var inverse = new Matrix4();
-    inverse = Matrix4.inverse(transform, inverse);
+    var inverseTranspose = new Matrix4();
+    inverseTranspose = Matrix4.transpose(transform, inverseTranspose);
+    inverseTranspose = Matrix4.inverse(inverseTranspose, inverseTranspose);
 
     var triangleSoup = raytracerScene.triangleSoup;
     var numberSamples = raytracerScene.numberSamples;
@@ -413,7 +415,7 @@ function raytracePrimitiveTexels(primitive, meshPrimitiveID, parameters, node) {
 
                 // Transform to world space
                 Matrix4.multiplyByPoint(transform, texelPosition, texelPosition);
-                Matrix4.multiplyByPointAsVector(transform, texelNormal, texelNormal);
+                Matrix4.multiplyByPointAsVector(inverseTranspose, texelNormal, texelNormal);
                 Cartesian3.normalize(texelNormal, texelNormal);
 
                 var triangles = triangleSoup;

--- a/lib/bakeAmbientOcclusion.js
+++ b/lib/bakeAmbientOcclusion.js
@@ -20,12 +20,14 @@ var NodeHelpers = require('./NodeHelpers');
 module.exports = {
     bakeAmbientOcclusion: bakeAmbientOcclusion,
     generateRaytracerScene: generateRaytracerScene,
-    generateOcclusionData: generateOcclusionData
+    computeAmbientOcclusionAt: computeAmbientOcclusionAt
 };
 
 var scratchRay = new Ray();
 var cartesian3Scratch1 = new Cartesian3();
 var cartesian3Scratch2 = new Cartesian3();
+var cartesian3Scratch3 = new Cartesian3();
+var cartesian3Scratch4 = new Cartesian3();
 var cartesian2Scratch = new Cartesian2();
 var quaternionScratch = new Quaternion();
 var matrix3Scratch = new Matrix3();
@@ -38,11 +40,17 @@ function bakeAmbientOcclusion(gltf, options) {
     }
     var scene = gltf.scenes[sceneID];
 
-    // generate triangle soup and texelPoints to sample from
+    // generate triangle soup
     var raytracerScene = generateRaytracerScene(gltf, scene, options);
 
+    var parameters = {
+        meshes: gltf.meshes,
+        raytracerScene: raytracerScene,
+        resolution: options.resolution
+    };
+
     // raytrace to a new texture for each primitive
-    generateOcclusionData(raytracerScene);
+    NodeHelpers.forEachPrimitive(gltf, raytracePrimitiveTexels, parameters);
 
     ////////// add to the gltf //////////
     bakeToDiffuse(gltf, options.resolution, raytracerScene);
@@ -237,7 +245,7 @@ function ensureImageUniqueness(gltf, primitive, meshPrimitiveID, state) {
             allMaterials, allTextures, allImages);
         texture.source = newImageID;
     } else {
-        // if nothing was cloned, mark this material, texture, and image as seen
+        // If nothing was cloned, mark this material, texture, and image as seen
         materialsSeen[materialID] = true;
         texturesSeen[textureID] = true;
         imagesSeen[imageID] = true;
@@ -249,11 +257,7 @@ function ensureImageUniqueness(gltf, primitive, meshPrimitiveID, state) {
 ////////// loading //////////
 
 function generateRaytracerScene(gltf, scene, options) {
-    // generates an array of points to sample from
-    // TODO: figure out which extras to use/which pre-stages are needed
-    // TODO: only read from accessors that are normals, positions, indices, uvs?
-    // TODO: scenes can have semioverlapping sets of primitives. handle this for texelPoint generation
-
+    // set up data we need for sampling. generate "triangle soup" over the whole scene.
     var accessors = gltf.accessors;
 
     // read all accessors in one go to avoid repeated read-and-conversion
@@ -271,24 +275,22 @@ function generateRaytracerScene(gltf, scene, options) {
         numberSamples: defaultValue(options.numberSamples, 16),
         rayDepth: defaultValue(options.rayDepth, 1.0), // TODO: compute dynamic default ray depth?
         triangleSoup: [],
-        texelPoints: [],
         aoBufferByPrimitive: {},
         nearCull: 0.5 / options.resolution
     };
 
-    // generate triangle soup over the whole scene
-    // generate texelPoints over each primitive
     // TODO: currently assuming each primitive appears in the scene once. this is not true. figure out what to do.
-    // traverse the scene and dump each node's mesh's primitive into the soup
-    // generate all the world transform matrices
+
+    // Generate all the world transform matrices
     NodeHelpers.computeFlatTransformScene(scene, gltf.nodes);
 
     var parameters = {
         meshes: gltf.meshes,
-        raytracerScene: raytracerScene,
-        resolution: options.resolution
+        resolution: options.resolution,
+        raytracerScene: raytracerScene
     };
 
+    // Generate triangle soup over the whole scene
     var rootNodeNames = scene.nodes;
     var allNodes = gltf.nodes;
     for (var nodeID in rootNodeNames) {
@@ -303,12 +305,12 @@ function generateRaytracerScene(gltf, scene, options) {
 
 function addNodeToSoup(parameters, node) {
     var transform = node.extras._pipeline.flatTransform;
-    var meshes = node.meshes;
-    for (var meshIndex in meshes) {
-        if (meshes.hasOwnProperty(meshIndex)) {
-            var meshID = meshes[meshIndex];
-            var mesh = parameters.meshes[meshID];
-            var primitives = mesh.primitives;
+    var mesheIDs = node.meshes;
+    for (var meshIndex in mesheIDs) {
+        if (mesheIDs.hasOwnProperty(meshIndex)) {
+            var meshID = mesheIDs[meshIndex];
+            var meshData = parameters.meshes[meshID];
+            var primitives = meshData.primitives;
             for (var primitiveID in primitives) {
                 if (primitives.hasOwnProperty(primitiveID)) {
                     processPrimitive(parameters, meshID + '_' + primitiveID, primitives[primitiveID], transform);
@@ -323,12 +325,8 @@ function processPrimitive(parameters, meshPrimitiveID, primitive, transform) {
     var bufferDataByAccessor = raytracerScene.bufferDataByAccessor;
     var indices = bufferDataByAccessor[primitive.indices].data;
     var positions = bufferDataByAccessor[primitive.attributes.POSITION].data;
-    var normals = bufferDataByAccessor[primitive.attributes.NORMAL].data;
-    var uvs = bufferDataByAccessor[primitive.attributes.TEXCOORD_0].data;
     var numTriangles = indices.length / 3;
-    var inverse = new Matrix4();
-    inverse = Matrix4.inverse(transform, inverse);
-
+    primitive.extras._pipeline.transform = transform;
 
     var resolution = parameters.resolution;
 
@@ -340,7 +338,7 @@ function processPrimitive(parameters, meshPrimitiveID, primitive, transform) {
 
     raytracerScene.aoBufferByPrimitive[meshPrimitiveID] = aoBuffer;
 
-    // read each triangle's Cartesian3s using the index buffer
+    // Read each triangle's Cartesian3s using the index buffer
     for (var i = 0; i < numTriangles; i++) {
         var index0 = indices[i * 3];
         var index1 = indices[i * 3 + 1];
@@ -350,74 +348,7 @@ function processPrimitive(parameters, meshPrimitiveID, primitive, transform) {
         var position1 = Cartesian3.clone(positions[index1]);
         var position2 = Cartesian3.clone(positions[index2]);
 
-        var normal0 = normals[index0];
-        var normal1 = normals[index1];
-        var normal2 = normals[index2];
-
-        // generate texelPoints for this triangle
-        var uv0 = uvs[index0];
-        var uv1 = uvs[index1];
-        var uv2 = uvs[index2];
-
-        // figure out the pixel width in UV space of this primitive's AO texture
-        // TODO: borrow from conservative rasterization: http://http.developer.nvidia.com/GPUGems2/gpugems2_chapter42.html
-        var pixelWidth = 1.0 / resolution;
-        var uMin = Math.min(uv0.x, uv1.x, uv2.x);
-        var vMin = Math.min(uv0.y, uv1.y, uv2.y);
-        var uMax = Math.max(uv0.x, uv1.x, uv2.x);
-        var vMax = Math.max(uv0.y, uv1.y, uv2.y);
-
-        // perform a pixel march.
-        // 0.0, 0.0 to width, width is the bottom left pixel
-        // 1.0-width, 1.0-width to 1.0, 1.0 is the top right pixel
-        var halfWidth = pixelWidth / 2.0;
-        uMin = Math.floor(uMin / pixelWidth) * pixelWidth + halfWidth;
-        vMin = Math.floor(vMin / pixelWidth) * pixelWidth + halfWidth;
-        uMax = Math.floor(uMax / pixelWidth) * pixelWidth + halfWidth;
-        vMax = Math.floor(vMax / pixelWidth) * pixelWidth + halfWidth;
-
-        var barycentric = cartesian3Scratch2;
-
-        var uStep = uMin;
-        while(uStep < uMax) {
-            var vStep = vMin;
-            while(vStep < vMax) {
-                // TODO: incorporate option for sub-pixel samples
-                // use the triangle's uv coordinates to compute this texel's barycentric coordinates on the triangle
-                cartesian2Scratch.x = uStep;
-                cartesian2Scratch.y = vStep;
-                barycentric = baryCentricCoordinates(cartesian2Scratch, uv0, uv1, uv2, barycentric);
-
-                // not in triangle
-                if (barycentric.x < 0.0 || barycentric.y < 0.0 || barycentric.z < 0.0) {
-                    vStep += pixelWidth;
-                    continue;
-                }
-
-                // use this barycentric coordinate to compute the local space position and normal on the triangle
-                var texelPosition = new Cartesian3();
-                var texelNormal = new Cartesian3();
-                sumBarycentric(barycentric, position0, position1, position2, cartesian3Scratch1, texelPosition);
-                sumBarycentric(barycentric, normal0, normal1, normal2, cartesian3Scratch1, texelNormal);
-
-                // transform to world space
-                Matrix4.multiplyByPoint(transform, texelPosition, texelPosition);
-                Matrix4.multiplyByPointAsVector(transform, texelNormal, texelNormal);
-                Cartesian3.normalize(texelNormal, texelNormal);
-
-                var texelPoint = {
-                    position: texelPosition,
-                    normal: texelNormal,
-                    index : Math.floor(uStep / pixelWidth) + Math.floor(vStep / pixelWidth) * resolution,
-                    buffer: aoBuffer
-                };
-                raytracerScene.texelPoints.push(texelPoint);
-                vStep += pixelWidth;
-            }
-            uStep += pixelWidth;
-        }
-
-        // generate a world space triangle geometry for the soup
+        // Generate a world space triangle geometry for the soup
         Matrix4.multiplyByPoint(transform, position0, position0);
         Matrix4.multiplyByPoint(transform, position1, position1);
         Matrix4.multiplyByPoint(transform, position2, position2);
@@ -433,29 +364,113 @@ function processPrimitive(parameters, meshPrimitiveID, primitive, transform) {
 
 ////////// computing AO //////////
 
-function generateOcclusionData(raytracerScene) {
+function raytracePrimitiveTexels(primitive, meshPrimitiveID, parameters) {
+    var raytracerScene = parameters.raytracerScene;
+    var bufferDataByAccessor = raytracerScene.bufferDataByAccessor;
+    var indices = bufferDataByAccessor[primitive.indices].data;
+    var positions = bufferDataByAccessor[primitive.attributes.POSITION].data;
+    var normals = bufferDataByAccessor[primitive.attributes.NORMAL].data;
+    var uvs = bufferDataByAccessor[primitive.attributes.TEXCOORD_0].data;
+    var numTriangles = indices.length / 3;
+    var transform = primitive.extras._pipeline.transform;
+    var inverse = new Matrix4();
+    inverse = Matrix4.inverse(transform, inverse);
+
     var triangleSoup = raytracerScene.triangleSoup;
-    var texelPoints = raytracerScene.texelPoints;
     var numberSamples = raytracerScene.numberSamples;
-    var sqrtNumberSamples = Math.floor(Math.sqrt(numberSamples));
+    var aoBuffer = raytracerScene.aoBufferByPrimitive[meshPrimitiveID];
+    var resolution = parameters.resolution;
 
-    // for each texelPoint in the raytracerScene:
-    for (var i = 0; i < texelPoints.length; i++) {
-        var texelPoint = texelPoints[i];
-        // pick a relevant triangle storage structure and texture to render to
-        var triangles = triangleSoup;
-        var aoBuffer = texelPoint.buffer;
-        var aoBufferIndex = texelPoint.index;
+    // For each position on a triangle corresponding to a texel center,
+    // raytrace ambient occlusion.
+    for (var i = 0; i < numTriangles; i++) {
+        var index0 = indices[i * 3];
+        var index1 = indices[i * 3 + 1];
+        var index2 = indices[i * 3 + 2];
 
-        // for each of N rays:
-        for (var j = 0; j < numberSamples; j++) {
-            var sampleRay = generateJitteredRay(texelPoint, j, sqrtNumberSamples);
-            aoBuffer.count[aoBufferIndex]++;
-            var nearestIntersect = naiveRaytrace(triangles, sampleRay, raytracerScene.nearCull);
+        var position0 = Cartesian3.clone(positions[index0]);
+        var position1 = Cartesian3.clone(positions[index1]);
+        var position2 = Cartesian3.clone(positions[index2]);
 
-            if (nearestIntersect < raytracerScene.rayDepth) {
-                aoBuffer.samples[aoBufferIndex] += 1.0;
+        var normal0 = normals[index0];
+        var normal1 = normals[index1];
+        var normal2 = normals[index2];
+
+        var uv0 = uvs[index0];
+        var uv1 = uvs[index1];
+        var uv2 = uvs[index2];
+
+        var uMin = Math.min(uv0.x, uv1.x, uv2.x);
+        var vMin = Math.min(uv0.y, uv1.y, uv2.y);
+        var uMax = Math.max(uv0.x, uv1.x, uv2.x);
+        var vMax = Math.max(uv0.y, uv1.y, uv2.y);
+
+        // Perform a pixel march over the
+        // 0.0, 0.0 to width, width is the bottom left pixel
+        // 1.0-width, 1.0-width to 1.0, 1.0 is the top right pixel
+        // TODO: borrow from conservative rasterization: http://http.developer.nvidia.com/GPUGems2/gpugems2_chapter42.html
+        var pixelWidth = 1.0 / resolution;
+        var halfWidth = pixelWidth / 2.0;
+        uMin = Math.floor(uMin / pixelWidth) * pixelWidth + halfWidth;
+        vMin = Math.floor(vMin / pixelWidth) * pixelWidth + halfWidth;
+        uMax = Math.floor(uMax / pixelWidth) * pixelWidth + halfWidth;
+        vMax = Math.floor(vMax / pixelWidth) * pixelWidth + halfWidth;
+
+        var barycentric = cartesian3Scratch1;
+
+        var uStep = uMin;
+        while(uStep < uMax) {
+            var vStep = vMin;
+            while(vStep < vMax) {
+                // TODO: incorporate option for sub-pixel samples
+                // Use the triangle's uv coordinates to compute this texel's barycentric coordinates on the triangle
+                cartesian2Scratch.x = uStep;
+                cartesian2Scratch.y = vStep;
+                barycentric = baryCentricCoordinates(cartesian2Scratch, uv0, uv1, uv2, barycentric);
+
+                // Not in triangle
+                if (barycentric.x < 0.0 || barycentric.y < 0.0 || barycentric.z < 0.0) {
+                    vStep += pixelWidth;
+                    continue;
+                }
+
+                // Use this barycentric coordinate to compute the local space position and normal on the triangle
+                var texelPosition = cartesian3Scratch2;
+                var texelNormal = cartesian3Scratch3;
+                sumBarycentric(barycentric, position0, position1, position2, cartesian3Scratch4, texelPosition);
+                sumBarycentric(barycentric, normal0, normal1, normal2, cartesian3Scratch4, texelNormal);
+
+                // Transform to world space
+                Matrix4.multiplyByPoint(transform, texelPosition, texelPosition);
+                Matrix4.multiplyByPointAsVector(transform, texelNormal, texelNormal);
+                Cartesian3.normalize(texelNormal, texelNormal);
+
+                var triangles = triangleSoup;
+
+                var aoBufferIndex = Math.floor(uStep / pixelWidth) + Math.floor(vStep / pixelWidth) * resolution;
+
+                // Raytrace
+                computeAmbientOcclusionAt(texelPosition, texelNormal, numberSamples,
+                    triangles, raytracerScene.nearCull,
+                    raytracerScene.rayDepth, aoBuffer, aoBufferIndex);
+
+                vStep += pixelWidth;
             }
+            uStep += pixelWidth;
+        }
+    }
+}
+
+function computeAmbientOcclusionAt(position, normal, numberSamples,
+    triangles, nearCull, rayDepth, aoBuffer, aoBufferIndex) {
+    for (var j = 0; j < numberSamples; j++) {
+        var sqrtNumberSamples = Math.floor(Math.sqrt(numberSamples));
+        var sampleRay = generateJitteredRay(position, normal, j, sqrtNumberSamples);
+        aoBuffer.count[aoBufferIndex]++;
+        var nearestIntersect = naiveRaytrace(triangles, sampleRay, nearCull);
+
+        if (nearestIntersect < rayDepth) {
+            aoBuffer.samples[aoBufferIndex] += 1.0;
         }
     }
 }
@@ -473,7 +488,7 @@ function naiveRaytrace(triangleSoup, ray, nearCull) {
     return minIntersect;
 }
 
-function generateJitteredRay(texelPoint, sampleNumber, sqrtNumberSamples) {
+function generateJitteredRay(position, normal, sampleNumber, sqrtNumberSamples) {
     // Stratified (jittered) Sampling with javascript's own rand function
     // Based on notes here: http://graphics.ucsd.edu/courses/cse168_s14/ucsd/CSE168_11_Random.pdf
 
@@ -491,24 +506,26 @@ function generateJitteredRay(texelPoint, sampleNumber, sqrtNumberSamples) {
     randomDirection.y = t;
     randomDirection.z = v * Math.sin(u);
 
-    // orient with texelPoint normal
-    var normal = texelPoint.normal;
+    // orient with texel's normal in world space
     var theta = Math.acos(normal.y); // dot product of normal with y-up is normal.y
     var axis = Cartesian3.cross(randomDirection, normal, cartesian3Scratch1);
     var rotation = Quaternion.fromAxisAngle(axis, theta, quaternionScratch);
     var matrix = Matrix3.fromQuaternion(rotation, matrix3Scratch);
-    
-    scratchRay.origin = texelPoint.position;
+
+    scratchRay.origin = position;
     scratchRay.direction = Matrix3.multiplyByVector(matrix, randomDirection, scratchRay.direction);
     return scratchRay;
 }
 
 // borrowed straight from Cesium/Source/Core/IntersectionTests
+var scratchEdge0 = new Cartesian3();
+var scratchEdge1 = new Cartesian3();
 var scratchPVec = new Cartesian3();
 var scratchTVec = new Cartesian3();
 var scratchQVec = new Cartesian3();
 
 function rayTriangle(ray, p0, p1, p2, cullBackFaces) {
+    //>>includeStart('debug', pragmas.debug);
     if (!defined(ray)) {
         throw new DeveloperError('ray is required.');
     }
@@ -521,9 +538,7 @@ function rayTriangle(ray, p0, p1, p2, cullBackFaces) {
     if (!defined(p2)) {
         throw new DeveloperError('p2 is required.');
     }
-
-    var scratchEdge0 = cartesian3Scratch1;
-    var scratchEdge1 = cartesian3Scratch2;
+    //>>includeEnd('debug');
 
     cullBackFaces = defaultValue(cullBackFaces, false);
 
@@ -588,6 +603,9 @@ function rayTriangle(ray, p0, p1, p2, cullBackFaces) {
 }
 
 function sumBarycentric(barycentric, vector0, vector1, vector2, scratch, result) {
+    result.x = 0.0;
+    result.y = 0.0;
+    result.z = 0.0;
     Cartesian3.multiplyByScalar(vector0, barycentric.x, scratch);
     Cartesian3.add(result, scratch, result);
     Cartesian3.multiplyByScalar(vector1, barycentric.y, scratch);

--- a/lib/bakeAmbientOcclusion.js
+++ b/lib/bakeAmbientOcclusion.js
@@ -1,0 +1,598 @@
+'use strict';
+var Cesium = require('cesium');
+var CesiumMath = Cesium.Math;
+var clone = require('clone');
+var defined = Cesium.defined;
+var defaultValue = Cesium.defaultValue;
+var DeveloperError = Cesium.DeveloperError;
+var Cartesian2 = Cesium.Cartesian2;
+var Cartesian3 = Cesium.Cartesian3;
+var Matrix3 = Cesium.Matrix3;
+var Matrix4 = Cesium.Matrix4;
+var Quaternion = Cesium.Quaternion;
+var Jimp = require('jimp');
+
+var Ray = Cesium.Ray;
+var baryCentricCoordinates = Cesium.barycentricCoordinates;
+var readAccessor = require('./readAccessor');
+var NodeHelpers = require('./NodeHelpers');
+
+module.exports = {
+    bakeAmbientOcclusion: bakeAmbientOcclusion,
+    generateRaytracerScene: generateRaytracerScene,
+    generateOcclusionData: generateOcclusionData
+};
+
+var scratchRay = new Ray();
+var cartesian3Scratch1 = new Cartesian3();
+var cartesian3Scratch2 = new Cartesian3();
+var cartesian2Scratch = new Cartesian2();
+var quaternionScratch = new Quaternion();
+var matrix3Scratch = new Matrix3();
+
+function bakeAmbientOcclusion(gltf, options) {
+    // requires each mesh to occur only once in the scene
+    var sceneID = defaultValue(options.scene, gltf.scene);
+    if (!defined(sceneID)) {
+        sceneID = Object.keys(gltf.scenes)[0];
+    }
+    var scene = gltf.scenes[sceneID];
+
+    // generate triangle soup and texelPoints to sample from
+    var raytracerScene = generateRaytracerScene(gltf, scene, options);
+
+    // raytrace to a new texture for each primitive
+    generateOcclusionData(raytracerScene);
+
+    ////////// add to the gltf //////////
+    bakeToDiffuse(gltf, options.resolution, raytracerScene);
+}
+
+function bakeToDiffuse(gltf, resolution, raytracerScene) {
+    // find material with a diffuse texture parameter to clone as needed
+    var materials = gltf.materials;
+    var textures = gltf.textures;
+
+    var exampleMaterialID;
+    var exampleTextureID;
+    var exampleImageID;
+
+    for (var materialID in materials) {
+        if (materials.hasOwnProperty(materialID)) {
+            var material = materials[materialID];
+            if (defined(material.values) && defined(material.values.diffuse)) {
+                if (typeof material.values.diffuse === "string") {
+                    exampleMaterialID = materialID;
+                    exampleTextureID = material.values.diffuse;
+                    exampleImageID = textures[exampleTextureID].source;
+                    break;
+                }
+            }
+        }
+    }
+
+    if (!defined(exampleMaterialID)) {
+        throw new DeveloperError('In stage bakeAmbientOcclusion: could not find any materials with a diffuse texture.');
+    }
+
+    // Build a hash of materials, textures, and images we've seen so far to ensure uniqueness
+    var parameters = {
+        materialsSeen: {},
+        texturesSeen: {},
+        imagesSeen: {},
+        exampleMaterialID: exampleMaterialID,
+        exampleTextureID: exampleTextureID,
+        exampleImageID: exampleImageID,
+        resolution: resolution,
+        gltf: gltf,
+        raytracerScene: raytracerScene
+    };
+
+    // Bake AO for each primitive
+    NodeHelpers.forEachPrimitive(gltf, addAoToImage, parameters);
+}
+
+function addAoToImage(primitive, meshPrimitiveID, parameters) {
+    // Enforce material/texture/image uniqueness
+    var gltf = parameters.gltf;
+    var diffuseImage = ensureImageUniqueness(gltf, primitive, meshPrimitiveID, parameters);
+    diffuseImage.extras._pipeline.imageChanged = true;
+    var diffuseImageJimp = diffuseImage.extras._pipeline.jimpImage;
+    var goalResolution = diffuseImageJimp.bitmap.width;
+
+    // Post process the AO
+    var jimpAO = gltf.extras._pipeline.jimpScratch;
+    var aoBuffer = parameters.raytracerScene.aoBufferByPrimitive[meshPrimitiveID];
+    postProcessAO(aoBuffer, parameters.resolution, goalResolution, jimpAO);
+
+    // Modify the diffuse image with AO
+    for (var x = 0; x < goalResolution; x++) {
+        for (var y = 0; y < goalResolution; y++) {
+            var idx = (goalResolution * y + x) * 4;
+            var aoValue = 1.0 - (jimpAO.bitmap.data[idx + 3] / 255.0);
+
+            // darken each channel by the ao value
+            diffuseImageJimp.bitmap.data[idx] *= aoValue;
+            diffuseImageJimp.bitmap.data[idx + 1] *= aoValue;
+            diffuseImageJimp.bitmap.data[idx + 2] *= aoValue;
+        }
+    }
+}
+
+function postProcessAO(aoBuffer, dataResolution, goalResolution, jimpAO) {
+    // copy the data over to the jimp
+    var value = 0.0;
+    jimpAO.resize(dataResolution, dataResolution);
+    for (var x = 0; x < dataResolution; x++) {
+        for (var y = 0; y < dataResolution; y++) {
+            var dataIdx = dataResolution * y + x;
+            value = 255.0 * (aoBuffer.samples[dataIdx] / aoBuffer.count[dataIdx]);
+            jimpAO.bitmap.data[(dataResolution * y + x) * 4 + 3] = value;
+        }
+    }
+    // resize the data to match the goal resolution
+    jimpAO.resize(goalResolution, goalResolution, Jimp.RESIZE_BEZIER);
+}
+
+function cloneAndSetup(newMateralID, newTextureID, newImageID,
+                      oldMateralID, oldTextureID, oldImageID,
+                      materials, textures, images) {
+    var newImage;
+    var newTexture;
+    var newMaterial;
+
+    if (defined(newImageID)) {
+        var oldImage = images[oldImageID];
+        newImage = clone(oldImage);
+        newImage.extras._pipeline.jimpImage = oldImage.extras._pipeline.jimpImage.clone();
+        images[newImageID] = newImage;
+    }
+    if (defined(newTextureID)) {
+        var oldTexture = textures[oldTextureID];
+        newTexture = clone(oldTexture);
+        newTexture.source = newImageID;
+        textures[newTextureID] = newTexture;
+    } else {
+        return;
+    }
+    if (defined(newMateralID)) {
+        newMaterial = clone(materials[oldMateralID]);
+        newMaterial.texture = newTextureID;
+        materials[newMateralID] = newMaterial;
+    }
+}
+
+// Check and modify the given material to ensure every primitive gets a unique material, texture, and image
+function ensureImageUniqueness(gltf, primitive, meshPrimitiveID, state) {
+    var materialsSeen = state.materialsSeen;
+    var texturesSeen = state.texturesSeen;
+    var imagesSeen = state.imagesSeen;
+
+    var allMaterials = gltf.materials;
+    var allTextures = gltf.textures;
+    var allImages = gltf.images;
+
+    // generate some new IDs
+    var newMaterialID = meshPrimitiveID + '_AO_material';
+    var newTextureID = meshPrimitiveID + '_AO_texture';
+    var newImageID = meshPrimitiveID + '_AO_image';
+
+    // grab the existing material
+    var materialID = primitive.material;
+    var material = allMaterials[materialID];
+    var values = material.values;
+    var diffuse = values.diffuse;
+
+    // check if the material has a diffuse texture material. if not,
+    // - clone the example material
+    // - clone the example texture
+    // - clone the example image. resize to resolution and set to diffuse color, if any
+    if (!defined(diffuse) || typeof diffuse !== 'string') {
+        cloneAndSetup(
+            newMaterialID, newTextureID, newImageID,
+            state.exampleMaterialID, state.exampleTextureID, state.exampleImageID,
+            allMaterials, allTextures, allImages);
+
+        var color = defaultValue(diffuse, [1.0, 1.0, 1.0, 1.0]);
+        for (var i = 0; i < 4; i++) {
+            diffuse[i] *= 255;
+        }
+        var newJimpImage = allImages[newImageID].extras._pipeline.jimpImage;
+
+        var resolution = state.resolution;
+        newJimpImage.resize(resolution, resolution);
+        var hexColor = Jimp.rgbaToInt(color[0], color[1], color[2], color[3]);
+        for (var x = 0; x < resolution; x++) {
+            for (var y = 0; y < resolution; y++) {
+                newJimpImage.setPixelColor(x, y, hexColor);
+            }
+        }
+        primitive.material = newMaterialID;
+        return allImages[newImageID];
+    }
+
+    var textureID = diffuse;
+    var imageID = allTextures[textureID].source;
+
+    if (materialsSeen.hasOwnProperty(materialID)) {
+        // Check if the material is unique. If not, clone material, texture, and image
+        cloneAndSetup(
+            newMaterialID, newTextureID, newImageID,
+            materialID, textureID, imageID,
+            allMaterials, allTextures, allImages);
+        primitive.material = newMaterialID;
+    } else if(texturesSeen.hasOwnProperty(textureID)) {
+        // Check if the texture is unique. If not clone the texture and the image.
+        cloneAndSetup(
+            undefined, newTextureID, newImageID,
+            materialID, textureID, imageID,
+            allMaterials, allTextures, allImages);
+        values.diffuse = newTextureID;
+    } else if(imagesSeen.hasOwnProperty(imageID)) {
+        // Check if the image is unique. if not, clone the image.
+        var texture = allTextures[textureID];
+        cloneAndSetup(
+            undefined, undefined, newImageID,
+            materialID, textureID, imageID,
+            allMaterials, allTextures, allImages);
+        texture.source = newImageID;
+    } else {
+        // if nothing was cloned, mark this material, texture, and image as seen
+        materialsSeen[materialID] = true;
+        texturesSeen[textureID] = true;
+        imagesSeen[imageID] = true;
+        newImageID = imageID;
+    }
+    return allImages[newImageID];
+}
+
+////////// loading //////////
+
+function generateRaytracerScene(gltf, scene, options) {
+    // generates an array of points to sample from
+    // TODO: figure out which extras to use/which pre-stages are needed
+    // TODO: only read from accessors that are normals, positions, indices, uvs?
+    // TODO: scenes can have semioverlapping sets of primitives. handle this for texelPoint generation
+
+    var accessors = gltf.accessors;
+
+    // read all accessors in one go to avoid repeated read-and-conversion
+    var bufferDataByAccessor = {};
+
+    for (var accessorID in accessors) {
+        if (accessors.hasOwnProperty(accessorID)) {
+            var accessor = accessors[accessorID];
+            bufferDataByAccessor[accessorID] = readAccessor(gltf, accessor);
+        }
+    }
+
+    var raytracerScene = {
+        bufferDataByAccessor: bufferDataByAccessor,
+        numberSamples: defaultValue(options.numberSamples, 16),
+        rayDepth: defaultValue(options.rayDepth, 1.0), // TODO: compute dynamic default ray depth?
+        triangleSoup: [],
+        texelPoints: [],
+        aoBufferByPrimitive: {},
+        nearCull: 0.5 / options.resolution
+    };
+
+    // generate triangle soup over the whole scene
+    // generate texelPoints over each primitive
+    // TODO: currently assuming each primitive appears in the scene once. this is not true. figure out what to do.
+    // traverse the scene and dump each node's mesh's primitive into the soup
+    // generate all the world transform matrices
+    NodeHelpers.computeFlatTransformScene(scene, gltf.nodes);
+
+    var parameters = {
+        meshes: gltf.meshes,
+        raytracerScene: raytracerScene,
+        resolution: options.resolution
+    };
+
+    var rootNodeNames = scene.nodes;
+    var allNodes = gltf.nodes;
+    for (var nodeID in rootNodeNames) {
+        if (rootNodeNames.hasOwnProperty(nodeID)) {
+            var rootNodeName = rootNodeNames[nodeID];
+            NodeHelpers.depthFirstTraversal(allNodes[rootNodeName], allNodes, addNodeToSoup, parameters);
+        }
+    }
+
+    return raytracerScene;
+}
+
+function addNodeToSoup(parameters, node) {
+    var transform = node.extras._pipeline.flatTransform;
+    var meshes = node.meshes;
+    for (var meshIndex in meshes) {
+        if (meshes.hasOwnProperty(meshIndex)) {
+            var meshID = meshes[meshIndex];
+            var mesh = parameters.meshes[meshID];
+            var primitives = mesh.primitives;
+            for (var primitiveID in primitives) {
+                if (primitives.hasOwnProperty(primitiveID)) {
+                    processPrimitive(parameters, meshID + '_' + primitiveID, primitives[primitiveID], transform);
+                }
+            }
+        }
+    }
+}
+
+function processPrimitive(parameters, meshPrimitiveID, primitive, transform) {
+    var raytracerScene = parameters.raytracerScene;
+    var bufferDataByAccessor = raytracerScene.bufferDataByAccessor;
+    var indices = bufferDataByAccessor[primitive.indices].data;
+    var positions = bufferDataByAccessor[primitive.attributes.POSITION].data;
+    var normals = bufferDataByAccessor[primitive.attributes.NORMAL].data;
+    var uvs = bufferDataByAccessor[primitive.attributes.TEXCOORD_0].data;
+    var numTriangles = indices.length / 3;
+    var inverse = new Matrix4();
+    inverse = Matrix4.inverse(transform, inverse);
+
+
+    var resolution = parameters.resolution;
+
+    var aoBuffer = {
+        resolution: resolution,
+        samples: new Array(resolution * resolution).fill(0.0),
+        count: new Array(resolution * resolution).fill(0.0)
+    };
+
+    raytracerScene.aoBufferByPrimitive[meshPrimitiveID] = aoBuffer;
+
+    // read each triangle's Cartesian3s using the index buffer
+    for (var i = 0; i < numTriangles; i++) {
+        var index0 = indices[i * 3];
+        var index1 = indices[i * 3 + 1];
+        var index2 = indices[i * 3 + 2];
+
+        var position0 = Cartesian3.clone(positions[index0]);
+        var position1 = Cartesian3.clone(positions[index1]);
+        var position2 = Cartesian3.clone(positions[index2]);
+
+        var normal0 = normals[index0];
+        var normal1 = normals[index1];
+        var normal2 = normals[index2];
+
+        // generate texelPoints for this triangle
+        var uv0 = uvs[index0];
+        var uv1 = uvs[index1];
+        var uv2 = uvs[index2];
+
+        // figure out the pixel width in UV space of this primitive's AO texture
+        // TODO: borrow from conservative rasterization: http://http.developer.nvidia.com/GPUGems2/gpugems2_chapter42.html
+        var pixelWidth = 1.0 / resolution;
+        var uMin = Math.min(uv0.x, uv1.x, uv2.x);
+        var vMin = Math.min(uv0.y, uv1.y, uv2.y);
+        var uMax = Math.max(uv0.x, uv1.x, uv2.x);
+        var vMax = Math.max(uv0.y, uv1.y, uv2.y);
+
+        // perform a pixel march.
+        // 0.0, 0.0 to width, width is the bottom left pixel
+        // 1.0-width, 1.0-width to 1.0, 1.0 is the top right pixel
+        var halfWidth = pixelWidth / 2.0;
+        uMin = Math.floor(uMin / pixelWidth) * pixelWidth + halfWidth;
+        vMin = Math.floor(vMin / pixelWidth) * pixelWidth + halfWidth;
+        uMax = Math.floor(uMax / pixelWidth) * pixelWidth + halfWidth;
+        vMax = Math.floor(vMax / pixelWidth) * pixelWidth + halfWidth;
+
+        var barycentric = cartesian3Scratch2;
+
+        var uStep = uMin;
+        while(uStep < uMax) {
+            var vStep = vMin;
+            while(vStep < vMax) {
+                // TODO: incorporate option for sub-pixel samples
+                // use the triangle's uv coordinates to compute this texel's barycentric coordinates on the triangle
+                cartesian2Scratch.x = uStep;
+                cartesian2Scratch.y = vStep;
+                barycentric = baryCentricCoordinates(cartesian2Scratch, uv0, uv1, uv2, barycentric);
+
+                // not in triangle
+                if (barycentric.x < 0.0 || barycentric.y < 0.0 || barycentric.z < 0.0) {
+                    vStep += pixelWidth;
+                    continue;
+                }
+
+                // use this barycentric coordinate to compute the local space position and normal on the triangle
+                var texelPosition = new Cartesian3();
+                var texelNormal = new Cartesian3();
+                sumBarycentric(barycentric, position0, position1, position2, cartesian3Scratch1, texelPosition);
+                sumBarycentric(barycentric, normal0, normal1, normal2, cartesian3Scratch1, texelNormal);
+
+                // transform to world space
+                Matrix4.multiplyByPoint(transform, texelPosition, texelPosition);
+                Matrix4.multiplyByPointAsVector(transform, texelNormal, texelNormal);
+                Cartesian3.normalize(texelNormal, texelNormal);
+
+                var texelPoint = {
+                    position: texelPosition,
+                    normal: texelNormal,
+                    index : Math.floor(uStep / pixelWidth) + Math.floor(vStep / pixelWidth) * resolution,
+                    buffer: aoBuffer
+                };
+                raytracerScene.texelPoints.push(texelPoint);
+                vStep += pixelWidth;
+            }
+            uStep += pixelWidth;
+        }
+
+        // generate a world space triangle geometry for the soup
+        Matrix4.multiplyByPoint(transform, position0, position0);
+        Matrix4.multiplyByPoint(transform, position1, position1);
+        Matrix4.multiplyByPoint(transform, position2, position2);
+
+        var triangle = {
+            positions: [
+                position0, position1, position2
+            ]
+        };
+        raytracerScene.triangleSoup.push(triangle);
+    }
+}
+
+////////// computing AO //////////
+
+function generateOcclusionData(raytracerScene) {
+    var triangleSoup = raytracerScene.triangleSoup;
+    var texelPoints = raytracerScene.texelPoints;
+    var numberSamples = raytracerScene.numberSamples;
+    var sqrtNumberSamples = Math.floor(Math.sqrt(numberSamples));
+
+    // for each texelPoint in the raytracerScene:
+    for (var i = 0; i < texelPoints.length; i++) {
+        var texelPoint = texelPoints[i];
+        // pick a relevant triangle storage structure and texture to render to
+        var triangles = triangleSoup;
+        var aoBuffer = texelPoint.buffer;
+        var aoBufferIndex = texelPoint.index;
+
+        // for each of N rays:
+        for (var j = 0; j < numberSamples; j++) {
+            var sampleRay = generateJitteredRay(texelPoint, j, sqrtNumberSamples);
+            aoBuffer.count[aoBufferIndex]++;
+            var nearestIntersect = naiveRaytrace(triangles, sampleRay, raytracerScene.nearCull);
+
+            if (nearestIntersect < raytracerScene.rayDepth) {
+                aoBuffer.samples[aoBufferIndex] += 1.0;
+            }
+        }
+    }
+}
+
+function naiveRaytrace(triangleSoup, ray, nearCull) {
+    // check ray against every triangle in the soup. return the nearest intersection.
+    var minIntersect = Number.POSITIVE_INFINITY;
+    for (var triangleSoupIndex = 0; triangleSoupIndex < triangleSoup.length; triangleSoupIndex++) {
+        var positions = triangleSoup[triangleSoupIndex].positions;
+        var distance = rayTriangle(ray, positions[0], positions[1], positions[2], false);
+        if (defined(distance) && distance > nearCull) {
+            minIntersect = Math.min(distance, minIntersect);
+        }
+    }
+    return minIntersect;
+}
+
+function generateJitteredRay(texelPoint, sampleNumber, sqrtNumberSamples) {
+    // Stratified (jittered) Sampling with javascript's own rand function
+    // Based on notes here: http://graphics.ucsd.edu/courses/cse168_s14/ucsd/CSE168_11_Random.pdf
+
+    // Produces samples based on a grid of dimension sqrtNumberSamples x sqrtNumberSamples
+    var cellWidth = 1.0 / sqrtNumberSamples;
+    var s = (sampleNumber % sqrtNumberSamples) * cellWidth + (Math.random() / sqrtNumberSamples);
+    var t = Math.floor(sampleNumber / sqrtNumberSamples) * cellWidth + (Math.random() / sqrtNumberSamples);
+
+    // generate ray on a y-up hemisphere with cosine weighting (more rays around the normal)
+    var u = 2.0 * Math.PI * s;
+    var v = Math.sqrt(1.0 - t);
+
+    var randomDirection = scratchRay.direction;
+    randomDirection.x = v * Math.cos(u);
+    randomDirection.y = t;
+    randomDirection.z = v * Math.sin(u);
+
+    // orient with texelPoint normal
+    var normal = texelPoint.normal;
+    var theta = Math.acos(normal.y); // dot product of normal with y-up is normal.y
+    var axis = Cartesian3.cross(randomDirection, normal, cartesian3Scratch1);
+    var rotation = Quaternion.fromAxisAngle(axis, theta, quaternionScratch);
+    var matrix = Matrix3.fromQuaternion(rotation, matrix3Scratch);
+    
+    scratchRay.origin = texelPoint.position;
+    scratchRay.direction = Matrix3.multiplyByVector(matrix, randomDirection, scratchRay.direction);
+    return scratchRay;
+}
+
+// borrowed straight from Cesium/Source/Core/IntersectionTests
+var scratchPVec = new Cartesian3();
+var scratchTVec = new Cartesian3();
+var scratchQVec = new Cartesian3();
+
+function rayTriangle(ray, p0, p1, p2, cullBackFaces) {
+    if (!defined(ray)) {
+        throw new DeveloperError('ray is required.');
+    }
+    if (!defined(p0)) {
+        throw new DeveloperError('p0 is required.');
+    }
+    if (!defined(p1)) {
+        throw new DeveloperError('p1 is required.');
+    }
+    if (!defined(p2)) {
+        throw new DeveloperError('p2 is required.');
+    }
+
+    var scratchEdge0 = cartesian3Scratch1;
+    var scratchEdge1 = cartesian3Scratch2;
+
+    cullBackFaces = defaultValue(cullBackFaces, false);
+
+    var origin = ray.origin;
+    var direction = ray.direction;
+
+    var edge0 = Cartesian3.subtract(p1, p0, scratchEdge0);
+    var edge1 = Cartesian3.subtract(p2, p0, scratchEdge1);
+
+    var p = Cartesian3.cross(direction, edge1, scratchPVec);
+    var det = Cartesian3.dot(edge0, p);
+
+    var tvec;
+    var q;
+
+    var u;
+    var v;
+    var t;
+
+    if (cullBackFaces) {
+        if (det < CesiumMath.EPSILON6) {
+            return undefined;
+        }
+
+        tvec = Cartesian3.subtract(origin, p0, scratchTVec);
+        u = Cartesian3.dot(tvec, p);
+        if (u < 0.0 || u > det) {
+            return undefined;
+        }
+
+        q = Cartesian3.cross(tvec, edge0, scratchQVec);
+
+        v = Cartesian3.dot(direction, q);
+        if (v < 0.0 || u + v > det) {
+            return undefined;
+        }
+
+        t = Cartesian3.dot(edge1, q) / det;
+    } else {
+        if (Math.abs(det) < CesiumMath.EPSILON6) {
+            return undefined;
+        }
+        var invDet = 1.0 / det;
+
+        tvec = Cartesian3.subtract(origin, p0, scratchTVec);
+        u = Cartesian3.dot(tvec, p) * invDet;
+        if (u < 0.0 || u > 1.0) {
+            return undefined;
+        }
+
+        q = Cartesian3.cross(tvec, edge0, scratchQVec);
+
+        v = Cartesian3.dot(direction, q) * invDet;
+        if (v < 0.0 || u + v > 1.0) {
+            return undefined;
+        }
+
+        t = Cartesian3.dot(edge1, q) * invDet;
+    }
+
+    return t;
+}
+
+function sumBarycentric(barycentric, vector0, vector1, vector2, scratch, result) {
+    Cartesian3.multiplyByScalar(vector0, barycentric.x, scratch);
+    Cartesian3.add(result, scratch, result);
+    Cartesian3.multiplyByScalar(vector1, barycentric.y, scratch);
+    Cartesian3.add(result, scratch, result);
+    Cartesian3.multiplyByScalar(vector2, barycentric.z, scratch);
+    Cartesian3.add(result, scratch, result);
+    return result;
+}

--- a/lib/gltfPipeline.js
+++ b/lib/gltfPipeline.js
@@ -18,6 +18,7 @@ var cacheOptimizeIndices = require('./cacheOptimizeIndices');
 var encodeImages = require('./encodeImages');
 var Cesium = require('cesium');
 var defaultValue = Cesium.defaultValue;
+var defined = Cesium.defined;
 var bakeAmbientOcclusion = require('./bakeAmbientOcclusion').bakeAmbientOcclusion;
 
 module.exports = {
@@ -53,7 +54,10 @@ function processJSONWithExtras(gltfWithExtras, options, callback) {
     convertDagToTree(gltfWithExtras);
     combineMeshes(gltfWithExtras);
     combinePrimitives(gltfWithExtras);
-    bakeAmbientOcclusion(gltfWithExtras, options.aoOptions);
+
+    if (defined(options.aoOptions)) {
+        bakeAmbientOcclusion(gltfWithExtras, options.aoOptions);
+    }
 
     // Merging duplicate vertices again to prevent repeat data in newly combined primitives
     mergeDuplicateVertices(gltfWithExtras);

--- a/lib/gltfPipeline.js
+++ b/lib/gltfPipeline.js
@@ -53,17 +53,7 @@ function processJSONWithExtras(gltfWithExtras, options, callback) {
     convertDagToTree(gltfWithExtras);
     combineMeshes(gltfWithExtras);
     combinePrimitives(gltfWithExtras);
-
-    // run the AO stage
-    if (options.ao_diffuse) {
-        var aoOptions = {
-            scene: options.ao_scene,
-            rayDepth: options.ao_rayDepth,
-            numberSamples: options.ao_samples,
-            resolution: options.ao_resolution
-        };
-        bakeAmbientOcclusion(gltfWithExtras, aoOptions);
-    }
+    bakeAmbientOcclusion(gltfWithExtras, options.aoOptions);
 
     // Merging duplicate vertices again to prevent repeat data in newly combined primitives
     mergeDuplicateVertices(gltfWithExtras);

--- a/lib/gltfPipeline.js
+++ b/lib/gltfPipeline.js
@@ -18,6 +18,7 @@ var cacheOptimizeIndices = require('./cacheOptimizeIndices');
 var encodeImages = require('./encodeImages');
 var Cesium = require('cesium');
 var defaultValue = Cesium.defaultValue;
+var bakeAmbientOcclusion = require('./bakeAmbientOcclusion').bakeAmbientOcclusion;
 
 module.exports = {
     processJSON : processJSON,
@@ -52,6 +53,18 @@ function processJSONWithExtras(gltfWithExtras, options, callback) {
     convertDagToTree(gltfWithExtras);
     combineMeshes(gltfWithExtras);
     combinePrimitives(gltfWithExtras);
+
+    // run the AO stage
+    if (options.ao_diffuse) {
+        var aoOptions = {
+            scene: options.ao_scene,
+            rayDepth: options.ao_rayDepth,
+            numberSamples: options.ao_samples,
+            resolution: options.ao_resolution
+        };
+        bakeAmbientOcclusion(gltfWithExtras, aoOptions);
+    }
+
     // Merging duplicate vertices again to prevent repeat data in newly combined primitives
     mergeDuplicateVertices(gltfWithExtras);
     cacheOptimizeIndices(gltfWithExtras);

--- a/specs/data/ambientOcclusion/cube_over_ground.gltf
+++ b/specs/data/ambientOcclusion/cube_over_ground.gltf
@@ -1,0 +1,429 @@
+{
+    "accessors": {
+        "accessor_21": {
+            "bufferView": "bufferView_56",
+            "byteOffset": 0,
+            "byteStride": 0,
+            "componentType": 5123,
+            "count": 36,
+            "type": "SCALAR"
+        },
+        "accessor_23": {
+            "bufferView": "bufferView_57",
+            "byteOffset": 0,
+            "byteStride": 12,
+            "componentType": 5126,
+            "count": 36,
+            "max": [
+                1,
+                1,
+                1
+            ],
+            "min": [
+                -1,
+                -1,
+                -1
+            ],
+            "type": "VEC3"
+        },
+        "accessor_25": {
+            "bufferView": "bufferView_57",
+            "byteOffset": 432,
+            "byteStride": 12,
+            "componentType": 5126,
+            "count": 36,
+            "max": [
+                1,
+                1,
+                1
+            ],
+            "min": [
+                -1,
+                -1,
+                -1
+            ],
+            "type": "VEC3"
+        },
+        "accessor_27": {
+            "bufferView": "bufferView_57",
+            "byteOffset": 864,
+            "byteStride": 8,
+            "componentType": 5126,
+            "count": 36,
+            "max": [
+                1,
+                1
+            ],
+            "min": [
+                0,
+                0
+            ],
+            "type": "VEC2"
+        },
+        "accessor_48": {
+            "bufferView": "bufferView_56",
+            "byteOffset": 72,
+            "byteStride": 0,
+            "componentType": 5123,
+            "count": 36,
+            "type": "SCALAR"
+        },
+        "accessor_50": {
+            "bufferView": "bufferView_57",
+            "byteOffset": 1152,
+            "byteStride": 12,
+            "componentType": 5126,
+            "count": 36,
+            "max": [
+                1,
+                1,
+                1
+            ],
+            "min": [
+                -1,
+                -1,
+                -1
+            ],
+            "type": "VEC3"
+        },
+        "accessor_52": {
+            "bufferView": "bufferView_57",
+            "byteOffset": 1584,
+            "byteStride": 12,
+            "componentType": 5126,
+            "count": 36,
+            "max": [
+                1,
+                1,
+                1
+            ],
+            "min": [
+                -1,
+                -1,
+                -1
+            ],
+            "type": "VEC3"
+        },
+        "accessor_54": {
+            "bufferView": "bufferView_57",
+            "byteOffset": 2016,
+            "byteStride": 8,
+            "componentType": 5126,
+            "count": 36,
+            "max": [
+                1,
+                1
+            ],
+            "min": [
+                0,
+                0
+            ],
+            "type": "VEC2"
+        }
+    },
+    "animations": {},
+    "asset": {
+        "generator": "collada2gltf@",
+        "premultipliedAlpha": true,
+        "profile": {
+            "api": "WebGL",
+            "version": "1.0.2"
+        },
+        "version": "1.0"
+    },
+    "bufferViews": {
+        "bufferView_56": {
+            "buffer": "cube_over_ground",
+            "byteLength": 144,
+            "byteOffset": 0,
+            "target": 34963
+        },
+        "bufferView_57": {
+            "buffer": "cube_over_ground",
+            "byteLength": 2304,
+            "byteOffset": 144,
+            "target": 34962
+        }
+    },
+    "buffers": {
+        "cube_over_ground": {
+            "byteLength": 2448,
+            "type": "arraybuffer",
+            "uri": "data:application/octet-stream;base64,AAABAAIAAwAEAAUABgAHAAgACQAKAAsADAANAA4ADwAQABEAEgATABQAFQAWABcAGAAZABoAGwAcAB0AHgAfACAAIQAiACMAAAABAAIAAwAEAAUABgAHAAgACQAKAAsADAANAA4ADwAQABEAEgATABQAFQAWABcAGAAZABoAGwAcAB0AHgAfACAAIQAiACMAAACAPwAAgD8AAIC/AACAvwAAgL8AAIC/AACAvwAAgD8AAIC/AACAvwAAgD8AAIA/7/9/PwAAgL8AAIA/AACAPwAAgD8AAIA/AACAPwAAgD8AAIA/AACAPwAAgL8AAIC/AACAPwAAgD8AAIC/7/9/PwAAgL8AAIA/AACAvwAAgL8AAIC/AACAPwAAgL8AAIC/AACAvwAAgL8AAIC/AACAvwAAgD8AAIA/AACAvwAAgD8AAIC/AACAPwAAgD8AAIC/AACAvwAAgD8AAIA/AACAPwAAgD8AAIA/AACAPwAAgD8AAIC/AACAPwAAgL8AAIC/AACAvwAAgL8AAIC/AACAvwAAgD8AAIA/AACAvwAAgL8AAIA/7/9/PwAAgL8AAIA/AACAPwAAgD8AAIA/7/9/PwAAgL8AAIA/AACAPwAAgL8AAIC/7/9/PwAAgL8AAIA/AACAvwAAgL8AAIA/AACAvwAAgL8AAIC/AACAvwAAgL8AAIC/AACAvwAAgL8AAIA/AACAvwAAgD8AAIA/AACAPwAAgD8AAIC/AACAvwAAgD8AAIC/AACAvwAAgD8AAIA/AAAAAAAAAAAAAIC/AAAAAAAAAAAAAIC/AAAAAAAAAAAAAIC/AAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AACAPwAAAAAPAIC0AACAPwAAAAAPAIC0AACAPwAAAAAPAIC0AAAAAAAAgL/6//+0AAAAAAAAgL/6//+0AAAAAAAAgL/6//+0AACAvw8AgDQbACC0AACAvw8AgDQbACC0AACAvw8AgDQbACC0AwCQNAAAgD8PAIA0AwCQNAAAgD8PAIA0AwCQNAAAgD8PAIA0AAAAAAAAAAAAAIC/AAAAAAAAAAAAAIC/AAAAAAAAAAAAAIC/AAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AACAP/j/H7Xt/680AACAP/j/H7Xt/680AACAP/j/H7Xt/680+v//tAAAgL8AAAAA+v//tAAAgL8AAAAA+v//tAAAgL8AAAAAAACAvw8AgDTX//+zAACAvw8AgDTX//+zAACAvw8AgDTX//+z7v9fNAAAgD8AAAAA7v9fNAAAgD8AAAAA7v9fNAAAgD8AAAAAAAAAAKCqqj6fqqo+AAAAAAAAAAAAAAAAn6qqPqCqqj4AAAAAoKoqP5+qqj6wqio/n6qqPrCqKj+wqio/AACAP7CqKj+wqio/AAAAAP7/fz+fqqo+sKoqPwAAAACwqio/AACAP7CqKj+wqio/AACAPwAAgD8AAIA/sKoqP7CqKj+fqqo+oKqqPp+qqj6wqio/AAAAAKCqqj6fqqo+oKqqPp+qqj4AAAAAn6qqPqCqqj4AAAAAoKqqPgAAAACgqio/n6qqPrCqKj+fqqo+AACAP7CqKj8AAIA/AAAAAP7/fz+fqqo+AACAP5+qqj6wqio/AACAP7CqKj+wqio/sKoqP7CqKj8AAIA/sKoqP7CqKj+wqio/oKqqPp+qqj6gqqo+AACAvwAAgD8AAIA/AACAvwAAgL8AAIC/AACAvwAAgL8AAIA/AACAPwAAgD8AAIA/AACAvwAAgD8AAIC/AACAvwAAgD8AAIA/AACAPwAAgL8AAIA/AACAPwAAgD8AAIC/AACAPwAAgD8AAIA/AACAvwAAgL8AAIA/AACAPwAAgL8AAIC/AACAPwAAgL8AAIA/AACAvwAAgD8AAIC/AACAPwAAgL8AAIC/AACAvwAAgL8AAIC/AACAPwAAgD8AAIA/AACAvwAAgL8AAIA/AACAPwAAgL8AAIA/AACAvwAAgD8AAIA/AACAvwAAgD8AAIC/AACAvwAAgL8AAIC/AACAPwAAgD8AAIA/AACAPwAAgD8AAIC/AACAvwAAgD8AAIC/AACAPwAAgL8AAIA/AACAPwAAgL8AAIC/AACAPwAAgD8AAIC/AACAvwAAgL8AAIA/AACAvwAAgL8AAIC/AACAPwAAgL8AAIC/AACAvwAAgD8AAIC/AACAPwAAgD8AAIC/AACAPwAAgL8AAIC/AACAPwAAgD8AAIA/AACAvwAAgD8AAIA/AACAvwAAgL8AAIA/AACAvwAAAAAAAAAAAACAvwAAAAAAAAAAAACAvwAAAAAAAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAACAPwAAAAAAAAAAAACAPwAAAAAAAAAAAACAPwAAAAAAAAAAAAAAAAAAgL8AAAAAAAAAAAAAgL8AAAAAAAAAAAAAgL8AAAAAAAAAAAAAAAAAAIC/AAAAAAAAAAAAAIC/AAAAAAAAAAAAAIC/AAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AACAvwAAAAAAAAAAAACAvwAAAAAAAAAAAACAvwAAAAAAAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAACAPwAAAAAAAAAAAACAPwAAAAAAAAAAAACAPwAAAAAAAAAAAAAAAAAAgL8AAAAAAAAAAAAAgL8AAAAAAAAAAAAAgL8AAAAAAAAAAAAAAAAAAIC/AAAAAAAAAAAAAIC/AAAAAAAAAAAAAIC/AAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/n6qqPgAAgD+wqio/sKoqP5+qqj6wqio/AAAAALCqKj+fqqo+oKqqPgAAAACgqqo+AAAAAAAAgD+fqqo+sKoqP4+qCjSwqio/sKoqP7CqKj+fqqo+oKqqPp+qqj6wqio/AACAP7CqKj+wqio/AACAPwAAgD8AAIA/n6qqPqCqqj4AAAAAAAAAAAAAAACgqqo+n6qqPgAAgD+wqio/AACAP7CqKj+wqio/AAAAALCqKj+fqqo+sKoqP5+qqj6gqqo+AAAAAAAAgD+fqqo+AACAP5+qqj6wqio/sKoqP7CqKj+wqio/oKqqPp+qqj6gqqo+AACAP7CqKj+wqio/sKoqP7CqKj8AAIA/n6qqPqCqqj6fqqo+AAAAAAAAAAAAAAAA"
+        }
+    },
+    "images": {
+        "Untitled": {
+            "name": "Untitled",
+            "uri": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAYAAADDPmHLAAAACXBIWXMAAAsTAAALEwEAmpwYAAAbFUlEQVR4Ae2dWZAVVZrHT20sRbEjWCL7KhZLISICFlu3W9sTtoazOGHEPEw4zks/OAY+TBjjRDsP6uM4MeG8TUfYExNht/sa7oKguIAKyiYgCCKySl0oapvznby/WyfzLnlvfsUk1d6MgH/l/+TJ5SzfdpZbc3b9+t6NGzearq4uU19fb2prax1ynslkQud56XfFpMfk772nzWie/0rmstLvF/P8lpbHVc/P/Kfu+x+aovv+azNfqb6/ts5Weqet/MRYZ/N32vxJsVaXv94+t8s+PznW2fydNn9CrLf5umz+hFhXX2vLv9OWf10qWEtPT4yqwreV1x1InsTPz0qugZu/O9SDK/+O5I1PGq1eAiglSPKeq+355E/Y85EYCXt+UokRzZdYcmfrrbbG6vyhjY0GbLc6s7unx4DwIDxYU2PzD7X5s9jebvN32/xZhAfhwRqjy19bU2Mahw41YKa93fR0dxsQHoQH4UF4EB6EB+FBeBAehAdtsdnyH2rLv8Zhe6bdln+3Lf8A4UF4EB6EB+FBeDB9CWDoiWlh2hLAKG0InQ1XqzIARYxoDEAxHHsVBqTaAJRGpzAARQ0oDEAR551dvakZgGJ41orrV7nh4Rlu2kqoUT5f+/6p56/Rlb/SBqlFl4PoehAehAfhQXgQHoQHM+czVmf3WJ0doDVKrE5vtDo9QHgQHoQH4UF4EB5EF4PoahAehAczVlf3WJ0N1lpd3mh1OggPwoOZzHlVfsoVpFxBeBAe1NsAIsa1akCRP7H/jhWfMqbl//NcvQ2gCSKJ+NXGEdT507UB9DaEIohny//PQAJoG1G6XgA9MS20oX2ra20cAJTYf4+NA4DwIDyILgXRtSA8CA9yX5D7gvAgPAgPwoPwIDwID8KD8CA8CA/Cg/AgPAgPwoPwIDyILQFia4DwIDyolwBWjGhcyWokUOdKqiOBmspzD1cYcIkHkDzDU+3Ha+MAyvxpDgSJ2qlKAK0XoPTDo7H9Ss/VEgD/EMQ/BOFBeJCYPkjMH4QH4UF4EB6EB+FBbAkQWwOEB+FB/HsQ/x6EB+FBdCmIrgXhQXiQmDxIzB6EB+FBeBAehAfhwfQjgalH4gZ6JFJnQ1TjAEodrvXjtfm1NpzeBvAMsjQigtVIoG4mkVWFyvkAyvzoYhBdDcKD8CA8CA/Cg/AguhxE14PwIDyILgfR9SA8CA/Cg/AgPAgPauvvz0ACVCOBGlcy/TmBA35Onzc0nopBW50TqBxQSncsoFK/P3p9NQ4wwOYAYkuA+Ocg/jkID8KD8CA8CA/Cg3oboDoWoJ4WpnEF1RJA60em4fr5Ywj6+QTpzgfQGHD9MYRcjQSmYrj1p+GojARq/UhtfvxzEP8chAfhQXgQHoQH4UF0MYh/D8KD8CD+OYh/DsKD8CA8CA/Cg/Cguvy1OsQXx2mog2okUBkJVNsA1TmBiReGRl26JOfa+qs5/PDDvf66AJkO5p/LdDH/PC/9L2PSY/Lvnz+29P1j8n/VOEOVv6bmL1T5G9/Uff+NF3Tff0PjKdX71/f09ppNmzfnbiJzz/zFIjL3zD/PS78sJj0mf0dzi2p9/obMttLvF/P8trbbzOZNm5J//zu67188Vvf9P2T2qL6/Ggf4uc8I0uqQNAw/3/CszgnUbS5RlQA/dwnAfHOQ+eYgPAgP4l+D+NcgPAgPcl+Q+4LwIDwID8KD8CA8CA/Cg/AgPAgPwoPwIDwID8KD8CA8SHwAJD4AwoPwoF4CpD4jqDofQBNOrs4JrM4J1K3s8Q2yNAzCaiRQGQlkvj+ojS1Xmh9bAMRWAOFBeBAehAfhQXiQmD5IzB+EB+FBdCmIrgXhQXgQHoQH4UF4kHoDKy3/6mjgz3w0sN6PA0jET8597MhG0qI85x2dQSRMxL/LF8GOjtLpvtqIy99Q32AWTllj6u3mkpMvu8rtInJP02SHp8/9ZM5cOGt+zJwwx+y/vcf3m32nD5lM9vlu3oBUdvb9+tCbD+DSZY6dXBdgpqMjdN5t+Rljx5pJTU2mecQIM3Jcgxk9cqhpahxkOi50mxOnz5uz7Z3m28OnzPGT582WbQeC/G4vIXvfCPoGXFDuwXOFl/OOTPB8zvMwE74+mh6X3y7ODVe6xP6pXMGLnT7IehF9ldHllqr757nVw/Y9p4ybZ/5uzUOmnGPrkR3mty/8S98Ooq5SC90/OyfQpXdmnx8UqjSCsbY8Zo0ZY5ZMnGgWXn65mTJqlGmwsYPcsTD3V94f7285YD7bfihU6cHYSvb+rpIZzw8aR6Xp2vqpR2fIgI/sFyi6JGh5AYr/KXzR9Oz+gC7d7u0ja/hc/mzPc/ktXyydNX7F0v3818xa6wpZBqT+8Ic/5BW4EFdffbVpbW018yfMMcPqh5j2znNuH0G5v+wnKLpc3o+ejS7301ttZd8ya5ZpbW4244YNK/gceYcdO3aYL7/80n2bf9GUKVPMDTfcYEYMG5Tbv9C/v/985ua577d7C8ncvaD8g54flP/QbPnnp2vz50mAiltUvU5i+D3c9fwSEmHx9NWunD/44ANzzz33+GWe+3vVqlXmnXfeMXW1dWbpxEXm/YNbQhIm/3lhCSBeRavt6b+cOTN3T/nj2LFj5sMPPzSb7MDRZjt49tFHH5mzZ8+GruHkjjvucA3gigkjbGWGe3il53ESoa4xLMErrb96aXnS4kCJMPnn8GBeekSnxuncvPQynz9mWLMZ3TTBlfFzzz1HWefhhg0bzMmTJ83o0aPNL2avNG/v2xT6nrz3L/D8y4cPd/d97733zJNPPukq/Jtvvsl7VhzR0FCbK9ei5Vfg+RWVf9ZWwLbIZG0GzqMYTR8wkcBF09ty5V2qAXTbbWJfeukld+21kxaZIQ2DAwmAZMnDrATwxgQuz4r91157zamaJJUvLzB0cIMnAZAEYeyPiZ1i+CW9T/r7BGb3Byzupwf7By6atspV6s6dO83u3bvd38X+o4EMqR9s5o6eEbMPYf7ewk1DhhS7dWV8jcntH1jMj4cH8e9BeBAexP8HselAeBAeHBASYHB9k3X75rjCp3L9mhCjyz+k5164cMH02skua2ctD1w6r4fHDSGLFIk7pk2bZu6++26zZMmSkpfGRSqT9tz+yjcgxgIWz2izu5Hb7mSPaAMYN26cuf/++0OV8NNPPzlDUPKsmnF9nyuYJ/7FBbUuWaRxdEQawBArEVasWGEeeOAB88wzz5jvv//eiFp46qmnzOLFi0PPjp4EOjgs9vsMQT3vu+oYgJXggIgEts5c7cpVLHGxwv3jxhtvNLfccotPub+fffZZh6MbR5rpoyeHDEEMsmJ48NQpl/fOO+90lv+ZM2eMGJePP/64uf32282ECYExmvfQAkQpg67Y8yvjdY3IhsSV+wNk4wD48+zlA8KD8CA8CA82WF9+3uRrXdG+8MILTqz75SyVP8v67FOnTvVpI9dyrJu7ssTew/m/N3DcxgrkWLBokVm6dKkLhsm5/I7C/hMnzHPbt5tzVsWUc6CrQXQ5iB8PsoYPhAfhQXgQHoQH4cFLPg6weOZSK6IbXFk///zzeWUuEkCOm266yblsXHDo0CHz2WefuaDQ6hnLzX9veTrsDWQjgznxn40Eyvm71sjctH+/6bYu2hAbPKJH7jx61HRa9SDnayNxAp4bwl7jeQFBpK9P/Jd3frHjAHobwMYBLuaQ8PypK12Znj9/3rz++uuh8pWI3/jx4x138803h9LkBDUwZcxEM2awDcpEdH2x8302jrD98GGzx/b2HUeOmG/suaBIS2wGK4rynpdHWLOF64uhxoXrD0NQ7wXYnqMxRHKRuYIGWpdpnXGDK9c33njDnDt3LlTG0us51q1b5/Q854K+xLhh5rKwBMg9z+rQAoZgscYB7z+n6N8hCaDT1X2SI3yfSgy+QvVUy9wyUGLPInZAeBAexH8HGWcH4UF4kPuC3Fdw3rRrTOOQICpHb/YL2zf+htvo3fXXX+8nm61bt5qDBw86rm36dW4PZP/+8p08Fyw33boloWcVPLGXcF+w3PtzHflAeBBbAsTWAOFB+BxqW9DFFP9XT1nmylX8+RdffDFUxn6Fy+IWOQqpAdzGBROvMoNqbGQu1/PFBbRh8DLVQvS60MuUOCnWc+H7Q4xr1IjeBrAGkaYRhQaAIpWzdM4vXNHKIMxRa4D5x9q1a01DQ2AcHjp52CUVagCoARkcWmkNyvzn5ccBopVd6LwsG8C+1SUfB9BUntMpttL8SR39JREmjJ5kxo1sdhVLL/YbAJXd0XXBvPLFmy5JjEIJDPmHjAyKHy9SpG3GdYl7fLQRlKUC7ItE80XPU5cA6jiAMo6ALQBiK1w1KfD9pTJLNYBth7abTw996epcIn+4hY6w/3VaA+/VV191kcQVs5baGTb2N3pCv1GUHwco53cHy5UAOV2b/S0hdDGoTdfW3yUbCVw2L/DvJeT61VdfUZ8O/cDPxr1bzFdHdpv2CxmX5huGZKIBDW0YYhZPW5jz6/HvkyD3LolW6lzykcBCrkFFauEixAFGDBttpl4+15VtIesf8S8XbNrzsTPstuzb6q6PSgAhX375ZVfp8vfK6de66/tsgYQ2gNws7rASKc4G0Bhw/aE+XCRwuR3ooKXmrf/PTgcrmr5Otz5+d12NWbE8/PypY+Y7N1TKl97rlzUNoL3jtLl6yQJXuScGnXWXSGBokQ3higvIccrG9mVyhxiOtyxaZz7t2Jn7XtHJK5Yvz51X8v3cvxiKq7Zu3dqQxInev/6E/f4VyZ4vkmtR47mS9w8iiX2TfvKe/+Px46r1+ZlT4RlE8tE0FkHxX/3zaPrlv2mzAzzh/QkW//rXrkxP2Ejcxo0bQ+U7aNAgs3r1asd9tvt9887bb7v7fzlom/nNP/7S6XppIH4DkIvFG5AGMGJQk/npu5Nm7w/7Xb6WlmWJvv+f7NxDewP3HsX+E1viT3/8Y8nvn9Viv39z8v0JTmYOlrx/XPlfcpHAwVZPz53U6spUfP/o2LxMtpRWLcfnezfnxPlZOwn1u5NHHI+EcCfZ/3AHxRu4dvLCXL6oVV7uedleQG5OYDiCRxxAixWp6wIu+yW3V/B0u2NIg53JIweVlq1DB1Su/ML2vu93hMTfBmsQSgUvtyK9yc7b9499+/a5GbziKayZsyKUz5dQ5RqE5XoB5d4v+XXWhlE0srzRQOldYhhKofgGIud56dk4gEu3BqFLlwib5PcMRM7j0ltnBoM/MqNHZvZEDxpAb2+P+ee//S/T1Wt/fz17NNh3kQqWANGaNWtCQ8JyiTSolpYWM2XMleay4WPNsTPHrSTIjgXY95UxAXk/NzaQPS+WzjPjsK9ygtE/d39vIieGXFC+wfPFMOT8Yqdb91s5H0CZH/8fXDB9uSvTt956K2/a9RVXXOEqUC6QIeJRTePMuOFjcv9GNo7I1QcNJUfYP/AopJG0XtHi4gGsCwBZAwjCg/BljAW6R2v9/Lj82vrLkwDolKAFZnt0KYlQZyWGoscTOZTnNY+ZZpdYjXQFR2X5FSi958EHH/Spon/LtK3osWXLFnPEDus22wUfa65abl7c+nqeBCjW4+X9/FHD6L0LnUsjid4veh7t4dFzJzFLSIS6xmB1cFKJkbc2MHYtYNxawQrT+/xx69LMXOHKUfS4P6OHwt2zZ4957LHHOE2Ect97773XLLhynmkaMixUqVKIrBgKqQEq30sv5+EyXhg3Lz8cJxCvKVgRFM3HeTTdV9fy/pXW3yUVCWydHYz9f/LJJ+awnZBxMQ7iCjIquGhSi9O1SQywct7NSQBpPFkJenFQ513o1wXYef3dNrbOHD7m9oHwIDwIP6RuuJkw+kpXrlRSOYVc6TVvvvmmfddgzt+aeSvcWsFyYv/ofmyBMmYDGLmGmD8Y1enMzQOZuwfCg/AgPAgPwoPwYJ4NEOicCrwA28J9MVRpfumJogYWzwmsf6nQQu6fWO9j7CrdSg/R+/5Mog673Fu8C1m/d930xeat7z8MWf3y/iHxX8RLKPc94rwAbXrFNlvEy8uzAfzKLEun9NP+ANfMXeXK9MCBA+bzzz/PK19Z7jV58uQ8Po646667zNNPPx26TBqYNIBhgxvNRLsMLGqYyXfTCIrZBKEbljjhPsXQHwuQ5/ouYFD+gU0Q5XPnyv0BLolIYEPtYDNj4jxXjIXE/5w5c3KV32MDQBIEivsnhqQchUYHpTFJTFyuabFz/F3l0NPLRHfzMv7r6+E6XV3sPkiApFgvsXkn9qyhIkjsGIxNt+sCGrPr/wVlPF9aLquAXf6Y9CVXt9nBn2DThUINwJ/8uf7f7zZn7A4gGFQHaseEDDne+1/vXG+Wz762YAP48ccfjSwxX7lypd1HYEKi76eBxbWB2PLTln92noGUR6PdX0BsDVf+WW8ieH4wtb1Qep4NQEsKxFEZcQDl/gASB1g4M5jMefr0aTdqFy1UGsCJM8fM6fa+ynfxB7s+3rmSTmxb2yVrU3ywa4trAOLzL1iwIE+tSEOTBjDKLvuSrV6O2Gf7kuCv7Ahpox14WjB1qtsRZPzIkXbPgSDqKJVfzgLShoZ68z9P/jb3OV1d3ebY8TMmc77D7Nx92Jw4ddbUndP58er9AaLh3kr9SD8I5HRWzJ5A0T2Durt6TMv0pa6QRDRLS/YPf/Tviz1isAUGajFE8mza+bExtwV3EjUQtSvEDpClXnK0XXWVeer997OSK9C5f20bQLPdY0BziMU/sTlsuE6ZdJm7ZduyeebbQ8fMht/vts9FPSSJA/SFjV35x+wpFN0zSC8BlJHA5lHTzCC7hl+OQta/P/q3bdem3CIUJ6GkMdhIWMjAyurwM71nzHcnjpiJY5qdGnj00UfdM/hv165dRpaai32xet48879WJfgSYNjg4J2eeOIJI/MJih2ffvppXtLXX39tHnnkkTweQuYt3nfffWbYsCG5df2BxO1b58954FX1VXI0UqiOBLJunJ4vOqPknkD9nD5h+DRXLjJ375VXXqGMckhMX4y+r/dty63xczovxubYtOtjc+d1t7nRQZlGLquG/UPUwPr1681sO8bQYMX6BTt+H9gsQ62HEDQAkRLffvutny32b9k76KGHHip63ezZs10DGNEU6GwxbInwxensaHp75pSTXEnrL/VI4NTxgfX/7rvvutm70VJD/+8/vNPqzsDAwQCMw827P8mNDsrKoeiBxJHBoTYbZ/DvJ9zFPkRFSE/3n1v5OeojGaa+LmDf0R2unAsN/ogBN3/+fJe+Zfu7OfHPAJKgswWK4K4je01HZ7CKt5A7KJ6AeATiEr73xRd98QCrRsq18jWNpKen1/n9iPVkqFuXoY8D2ML3x/39yimHnzYhkACFBn/8CZ47vvmsZGVj/fsoUb9t+7e7Orr11lvz6koqWWYdiVh1EsBbI1jujJ+8m1ZI9BmAyXpwskbj2RqMJ4sYSmOfwAPHvjZzJy4xEgEsdpz66bg5fOyAGWp1vowdiJjEm3Cx9ewS7kL7AH7w9Ydm6axWc+WVV7peLZUeFe8iATZbw83P/4M1/Jpt6LnUexV733L5I0dP2hXHNbbcAz9dUGL27vs8P75Uuja/XgLYyvBdSeII5eKksbNiy2v73k9y/r3fw0uJf677dN8XoftHK18SRQKstJ6A7wUUui50o344kcaolwC68k99n8A/bf6P0KxcInkYRlI5vmEUTec6MJp+9OQP5lf/9jc5QyuavmzZ3xd8/u2/+517btzza3eUfr+4/P+w8lbV93V1ncvmD1xFvAnmD0Qxmp66BKjUZoheT09Pjtk4QpljALmBI67PBXHS0eHlStpi16U+H4C1gCBzA0F4EB6EB+FBeBAeZJwfZLwfhAfhQcb5weh4PzzY3+mM84PYBCA8CA/qJYDSC4j26ErP83okPXOAoNaK1+ZPPQ5QjiGXXLyXjhME97W6U9NY3ITNZOJfawBKfo0BLmoh9Uigb+BhyFUxO+BlXfP48tE1PqsK010XwNxAkDmCIDwID6LLQXQ9CA/Cg+hyEF0PwoPwoFano4tBdDUID8KD2vpL3Qa4uOLd9qAiYeI+Pl0vQKsG0rcB7JBspYZbf17vB29UutwLA/9/3sefE6itzCT5a154+OFeX+dG148zXQxdlJe+SLc/QMfUsbkgjbxH3v1llq6nC6PppxvHl0yPe/+amrmq/I0HS79f3PNbBuu+f2ZjsHNp0fqJKb962WJtk/0JFAo5LnKVl36y9Pr/aOQtmn9sU0soEhdNj8u/NxOOxFWav61tttlsN6BO/P1bdd/fPFX3/dsyR0OGYqXfr7cBlGMBWnXQp8vLcfkK2QTp2gBJxHZYbejGAvRxAKUNUI0DSAw/uSsXbgyV/4ysXgJUI4GhUcRKDUi9BKi80v1GY1VGhXsD29W/YoiJbhas5h/g5VdslKhsXikB9Do8qe4nX7o2gEb8y1CvVoLobQDropXdWAoZjKnbEOmOBfjiOFll6so/dRugKgGSG4D9IgFYFwBWHFvup/0BiO0T8wfhQXiQmDxIzB6EB+FBeBAehAfhQXgQHoQH4UFi+iAxfxAehAfhQXgQHoQH9aOBVqwTRKliOaN3l1Z56W2A1HV4oeAOBl45mK4NEMzZS64GtDaE3gYoZNhVYhim7kWk6wUkM/x8618ZCaxY51v/X34/L2czKH83kHF6kHF6EB6EB+FBeBAehAfRxSC6GoQH4UHtfABtfnQ5iK4H4UF4UC8BlD1YPxag7MGa6WD9MISslwDKSGDVcBt4hhtDv/2BqUuAahwguQF4acQBojZBpXMMlXEEdDmIrgfhQXgQXQ6i60F4EB5kvj9YqU5HF4PoahAehAexxcBKbbqqBNDaAIqhXK0L2C8SQDuvvJwl4FpDr1T+6pxA3yWs3CCsRgJ/5pFMqwqV6wKqcQC3Px+6H1sAhAfhQXgQHoQH4UFsARBbAYQH4UG9DVCNBNqxkOTTuvRxAGUkMG0boDonMHnjCdYGKm0A1WQOiflXI4EDe04gc/vA6hy/AT7Hr8I5nnobQCkBqpHAlCOBahugkqHfQgZj6vMJ0p0PoB3P19ZfVQL83COBaccBmNsHMvcPhAfhQWLyIDF7EB6EB+FBeBAehAfhQXgQHoQH8c9B/HMQHoQH4UF4EB6EB6uRwJ97JFCrQ7RjAdU4QLpxgJrfP/qobn+ASbr18WcH14RmFUfX/8etr+9pHKXKP3bsbFX+xnO67x/eqfv+CfKLKdYQZ3JIpeX3f1gkTJOVXef6AAAAAElFTkSuQmCC"
+        },
+        "Untitled_001": {
+            "name": "Untitled_001",
+            "uri": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAYAAADDPmHLAAAACXBIWXMAAAsTAAALEwEAmpwYAAAbFUlEQVR4Ae2dWZAVVZrHT20sRbEjWCL7KhZLISICFlu3W9sTtoazOGHEPEw4zks/OAY+TBjjRDsP6uM4MeG8TUfYExNht/sa7oKguIAKyiYgCCKySl0oapvznby/WyfzLnlvfsUk1d6MgH/l/+TJ5SzfdpZbc3b9+t6NGzearq4uU19fb2prax1ynslkQud56XfFpMfk772nzWie/0rmstLvF/P8lpbHVc/P/Kfu+x+aovv+azNfqb6/ts5Weqet/MRYZ/N32vxJsVaXv94+t8s+PznW2fydNn9CrLf5umz+hFhXX2vLv9OWf10qWEtPT4yqwreV1x1InsTPz0qugZu/O9SDK/+O5I1PGq1eAiglSPKeq+355E/Y85EYCXt+UokRzZdYcmfrrbbG6vyhjY0GbLc6s7unx4DwIDxYU2PzD7X5s9jebvN32/xZhAfhwRqjy19bU2Mahw41YKa93fR0dxsQHoQH4UF4EB6EB+FBeBAehAdtsdnyH2rLv8Zhe6bdln+3Lf8A4UF4EB6EB+FBeDB9CWDoiWlh2hLAKG0InQ1XqzIARYxoDEAxHHsVBqTaAJRGpzAARQ0oDEAR551dvakZgGJ41orrV7nh4Rlu2kqoUT5f+/6p56/Rlb/SBqlFl4PoehAehAfhQXgQHoQHM+czVmf3WJ0doDVKrE5vtDo9QHgQHoQH4UF4EB5EF4PoahAehAczVlf3WJ0N1lpd3mh1OggPwoOZzHlVfsoVpFxBeBAe1NsAIsa1akCRP7H/jhWfMqbl//NcvQ2gCSKJ+NXGEdT507UB9DaEIohny//PQAJoG1G6XgA9MS20oX2ra20cAJTYf4+NA4DwIDyILgXRtSA8CA9yX5D7gvAgPAgPwoPwIDwID8KD8CA8CA/Cg/AgPAgPwoPwIDyILQFia4DwIDyolwBWjGhcyWokUOdKqiOBmspzD1cYcIkHkDzDU+3Ha+MAyvxpDgSJ2qlKAK0XoPTDo7H9Ss/VEgD/EMQ/BOFBeJCYPkjMH4QH4UF4EB6EB+FBbAkQWwOEB+FB/HsQ/x6EB+FBdCmIrgXhQXiQmDxIzB6EB+FBeBAehAfhwfQjgalH4gZ6JFJnQ1TjAEodrvXjtfm1NpzeBvAMsjQigtVIoG4mkVWFyvkAyvzoYhBdDcKD8CA8CA/Cg/AguhxE14PwIDyILgfR9SA8CA/Cg/AgPAgPauvvz0ACVCOBGlcy/TmBA35Onzc0nopBW50TqBxQSncsoFK/P3p9NQ4wwOYAYkuA+Ocg/jkID8KD8CA8CA/Cg3oboDoWoJ4WpnEF1RJA60em4fr5Ywj6+QTpzgfQGHD9MYRcjQSmYrj1p+GojARq/UhtfvxzEP8chAfhQXgQHoQH4UF0MYh/D8KD8CD+OYh/DsKD8CA8CA/Cg/Cguvy1OsQXx2mog2okUBkJVNsA1TmBiReGRl26JOfa+qs5/PDDvf66AJkO5p/LdDH/PC/9L2PSY/Lvnz+29P1j8n/VOEOVv6bmL1T5G9/Uff+NF3Tff0PjKdX71/f09ppNmzfnbiJzz/zFIjL3zD/PS78sJj0mf0dzi2p9/obMttLvF/P8trbbzOZNm5J//zu67188Vvf9P2T2qL6/Ggf4uc8I0uqQNAw/3/CszgnUbS5RlQA/dwnAfHOQ+eYgPAgP4l+D+NcgPAgPcl+Q+4LwIDwID8KD8CA8CA/Cg/AgPAgPwoPwIDwID8KD8CA8SHwAJD4AwoPwoF4CpD4jqDofQBNOrs4JrM4J1K3s8Q2yNAzCaiRQGQlkvj+ojS1Xmh9bAMRWAOFBeBAehAfhQXiQmD5IzB+EB+FBdCmIrgXhQXgQHoQH4UF4kHoDKy3/6mjgz3w0sN6PA0jET8597MhG0qI85x2dQSRMxL/LF8GOjtLpvtqIy99Q32AWTllj6u3mkpMvu8rtInJP02SHp8/9ZM5cOGt+zJwwx+y/vcf3m32nD5lM9vlu3oBUdvb9+tCbD+DSZY6dXBdgpqMjdN5t+Rljx5pJTU2mecQIM3Jcgxk9cqhpahxkOi50mxOnz5uz7Z3m28OnzPGT582WbQeC/G4vIXvfCPoGXFDuwXOFl/OOTPB8zvMwE74+mh6X3y7ODVe6xP6pXMGLnT7IehF9ldHllqr757nVw/Y9p4ybZ/5uzUOmnGPrkR3mty/8S98Ooq5SC90/OyfQpXdmnx8UqjSCsbY8Zo0ZY5ZMnGgWXn65mTJqlGmwsYPcsTD3V94f7285YD7bfihU6cHYSvb+rpIZzw8aR6Xp2vqpR2fIgI/sFyi6JGh5AYr/KXzR9Oz+gC7d7u0ja/hc/mzPc/ktXyydNX7F0v3818xa6wpZBqT+8Ic/5BW4EFdffbVpbW018yfMMcPqh5j2znNuH0G5v+wnKLpc3o+ejS7301ttZd8ya5ZpbW4244YNK/gceYcdO3aYL7/80n2bf9GUKVPMDTfcYEYMG5Tbv9C/v/985ua577d7C8ncvaD8g54flP/QbPnnp2vz50mAiltUvU5i+D3c9fwSEmHx9NWunD/44ANzzz33+GWe+3vVqlXmnXfeMXW1dWbpxEXm/YNbQhIm/3lhCSBeRavt6b+cOTN3T/nj2LFj5sMPPzSb7MDRZjt49tFHH5mzZ8+GruHkjjvucA3gigkjbGWGe3il53ESoa4xLMErrb96aXnS4kCJMPnn8GBeekSnxuncvPQynz9mWLMZ3TTBlfFzzz1HWefhhg0bzMmTJ83o0aPNL2avNG/v2xT6nrz3L/D8y4cPd/d97733zJNPPukq/Jtvvsl7VhzR0FCbK9ei5Vfg+RWVf9ZWwLbIZG0GzqMYTR8wkcBF09ty5V2qAXTbbWJfeukld+21kxaZIQ2DAwmAZMnDrATwxgQuz4r91157zamaJJUvLzB0cIMnAZAEYeyPiZ1i+CW9T/r7BGb3Byzupwf7By6atspV6s6dO83u3bvd38X+o4EMqR9s5o6eEbMPYf7ewk1DhhS7dWV8jcntH1jMj4cH8e9BeBAexP8HselAeBAeHBASYHB9k3X75rjCp3L9mhCjyz+k5164cMH02skua2ctD1w6r4fHDSGLFIk7pk2bZu6++26zZMmSkpfGRSqT9tz+yjcgxgIWz2izu5Hb7mSPaAMYN26cuf/++0OV8NNPPzlDUPKsmnF9nyuYJ/7FBbUuWaRxdEQawBArEVasWGEeeOAB88wzz5jvv//eiFp46qmnzOLFi0PPjp4EOjgs9vsMQT3vu+oYgJXggIgEts5c7cpVLHGxwv3jxhtvNLfccotPub+fffZZh6MbR5rpoyeHDEEMsmJ48NQpl/fOO+90lv+ZM2eMGJePP/64uf32282ECYExmvfQAkQpg67Y8yvjdY3IhsSV+wNk4wD48+zlA8KD8CA8CA82WF9+3uRrXdG+8MILTqz75SyVP8v67FOnTvVpI9dyrJu7ssTew/m/N3DcxgrkWLBokVm6dKkLhsm5/I7C/hMnzHPbt5tzVsWUc6CrQXQ5iB8PsoYPhAfhQXgQHoQH4cFLPg6weOZSK6IbXFk///zzeWUuEkCOm266yblsXHDo0CHz2WefuaDQ6hnLzX9veTrsDWQjgznxn40Eyvm71sjctH+/6bYu2hAbPKJH7jx61HRa9SDnayNxAp4bwl7jeQFBpK9P/Jd3frHjAHobwMYBLuaQ8PypK12Znj9/3rz++uuh8pWI3/jx4x138803h9LkBDUwZcxEM2awDcpEdH2x8302jrD98GGzx/b2HUeOmG/suaBIS2wGK4rynpdHWLOF64uhxoXrD0NQ7wXYnqMxRHKRuYIGWpdpnXGDK9c33njDnDt3LlTG0us51q1b5/Q854K+xLhh5rKwBMg9z+rQAoZgscYB7z+n6N8hCaDT1X2SI3yfSgy+QvVUy9wyUGLPInZAeBAexH8HGWcH4UF4kPuC3Fdw3rRrTOOQICpHb/YL2zf+htvo3fXXX+8nm61bt5qDBw86rm36dW4PZP/+8p08Fyw33boloWcVPLGXcF+w3PtzHflAeBBbAsTWAOFB+BxqW9DFFP9XT1nmylX8+RdffDFUxn6Fy+IWOQqpAdzGBROvMoNqbGQu1/PFBbRh8DLVQvS60MuUOCnWc+H7Q4xr1IjeBrAGkaYRhQaAIpWzdM4vXNHKIMxRa4D5x9q1a01DQ2AcHjp52CUVagCoARkcWmkNyvzn5ccBopVd6LwsG8C+1SUfB9BUntMpttL8SR39JREmjJ5kxo1sdhVLL/YbAJXd0XXBvPLFmy5JjEIJDPmHjAyKHy9SpG3GdYl7fLQRlKUC7ItE80XPU5cA6jiAMo6ALQBiK1w1KfD9pTJLNYBth7abTw996epcIn+4hY6w/3VaA+/VV191kcQVs5baGTb2N3pCv1GUHwco53cHy5UAOV2b/S0hdDGoTdfW3yUbCVw2L/DvJeT61VdfUZ8O/cDPxr1bzFdHdpv2CxmX5huGZKIBDW0YYhZPW5jz6/HvkyD3LolW6lzykcBCrkFFauEixAFGDBttpl4+15VtIesf8S8XbNrzsTPstuzb6q6PSgAhX375ZVfp8vfK6de66/tsgYQ2gNws7rASKc4G0Bhw/aE+XCRwuR3ooKXmrf/PTgcrmr5Otz5+d12NWbE8/PypY+Y7N1TKl97rlzUNoL3jtLl6yQJXuScGnXWXSGBokQ3higvIccrG9mVyhxiOtyxaZz7t2Jn7XtHJK5Yvz51X8v3cvxiKq7Zu3dqQxInev/6E/f4VyZ4vkmtR47mS9w8iiX2TfvKe/+Px46r1+ZlT4RlE8tE0FkHxX/3zaPrlv2mzAzzh/QkW//rXrkxP2Ejcxo0bQ+U7aNAgs3r1asd9tvt9887bb7v7fzlom/nNP/7S6XppIH4DkIvFG5AGMGJQk/npu5Nm7w/7Xb6WlmWJvv+f7NxDewP3HsX+E1viT3/8Y8nvn9Viv39z8v0JTmYOlrx/XPlfcpHAwVZPz53U6spUfP/o2LxMtpRWLcfnezfnxPlZOwn1u5NHHI+EcCfZ/3AHxRu4dvLCXL6oVV7uedleQG5OYDiCRxxAixWp6wIu+yW3V/B0u2NIg53JIweVlq1DB1Su/ML2vu93hMTfBmsQSgUvtyK9yc7b9499+/a5GbziKayZsyKUz5dQ5RqE5XoB5d4v+XXWhlE0srzRQOldYhhKofgGIud56dk4gEu3BqFLlwib5PcMRM7j0ltnBoM/MqNHZvZEDxpAb2+P+ee//S/T1Wt/fz17NNh3kQqWANGaNWtCQ8JyiTSolpYWM2XMleay4WPNsTPHrSTIjgXY95UxAXk/NzaQPS+WzjPjsK9ygtE/d39vIieGXFC+wfPFMOT8Yqdb91s5H0CZH/8fXDB9uSvTt956K2/a9RVXXOEqUC6QIeJRTePMuOFjcv9GNo7I1QcNJUfYP/AopJG0XtHi4gGsCwBZAwjCg/BljAW6R2v9/Lj82vrLkwDolKAFZnt0KYlQZyWGoscTOZTnNY+ZZpdYjXQFR2X5FSi958EHH/Spon/LtK3osWXLFnPEDus22wUfa65abl7c+nqeBCjW4+X9/FHD6L0LnUsjid4veh7t4dFzJzFLSIS6xmB1cFKJkbc2MHYtYNxawQrT+/xx69LMXOHKUfS4P6OHwt2zZ4957LHHOE2Ect97773XLLhynmkaMixUqVKIrBgKqQEq30sv5+EyXhg3Lz8cJxCvKVgRFM3HeTTdV9fy/pXW3yUVCWydHYz9f/LJJ+awnZBxMQ7iCjIquGhSi9O1SQywct7NSQBpPFkJenFQ513o1wXYef3dNrbOHD7m9oHwIDwIP6RuuJkw+kpXrlRSOYVc6TVvvvmmfddgzt+aeSvcWsFyYv/ofmyBMmYDGLmGmD8Y1enMzQOZuwfCg/AgPAgPwoPwYJ4NEOicCrwA28J9MVRpfumJogYWzwmsf6nQQu6fWO9j7CrdSg/R+/5Mog673Fu8C1m/d930xeat7z8MWf3y/iHxX8RLKPc94rwAbXrFNlvEy8uzAfzKLEun9NP+ANfMXeXK9MCBA+bzzz/PK19Z7jV58uQ8Po646667zNNPPx26TBqYNIBhgxvNRLsMLGqYyXfTCIrZBKEbljjhPsXQHwuQ5/ouYFD+gU0Q5XPnyv0BLolIYEPtYDNj4jxXjIXE/5w5c3KV32MDQBIEivsnhqQchUYHpTFJTFyuabFz/F3l0NPLRHfzMv7r6+E6XV3sPkiApFgvsXkn9qyhIkjsGIxNt+sCGrPr/wVlPF9aLquAXf6Y9CVXt9nBn2DThUINwJ/8uf7f7zZn7A4gGFQHaseEDDne+1/vXG+Wz762YAP48ccfjSwxX7lypd1HYEKi76eBxbWB2PLTln92noGUR6PdX0BsDVf+WW8ieH4wtb1Qep4NQEsKxFEZcQDl/gASB1g4M5jMefr0aTdqFy1UGsCJM8fM6fa+ynfxB7s+3rmSTmxb2yVrU3ywa4trAOLzL1iwIE+tSEOTBjDKLvuSrV6O2Gf7kuCv7Ahpox14WjB1qtsRZPzIkXbPgSDqKJVfzgLShoZ68z9P/jb3OV1d3ebY8TMmc77D7Nx92Jw4ddbUndP58er9AaLh3kr9SD8I5HRWzJ5A0T2Durt6TMv0pa6QRDRLS/YPf/Tviz1isAUGajFE8mza+bExtwV3EjUQtSvEDpClXnK0XXWVeer997OSK9C5f20bQLPdY0BziMU/sTlsuE6ZdJm7ZduyeebbQ8fMht/vts9FPSSJA/SFjV35x+wpFN0zSC8BlJHA5lHTzCC7hl+OQta/P/q3bdem3CIUJ6GkMdhIWMjAyurwM71nzHcnjpiJY5qdGnj00UfdM/hv165dRpaai32xet48879WJfgSYNjg4J2eeOIJI/MJih2ffvppXtLXX39tHnnkkTweQuYt3nfffWbYsCG5df2BxO1b58954FX1VXI0UqiOBLJunJ4vOqPknkD9nD5h+DRXLjJ375VXXqGMckhMX4y+r/dty63xczovxubYtOtjc+d1t7nRQZlGLquG/UPUwPr1681sO8bQYMX6BTt+H9gsQ62HEDQAkRLffvutny32b9k76KGHHip63ezZs10DGNEU6GwxbInwxensaHp75pSTXEnrL/VI4NTxgfX/7rvvutm70VJD/+8/vNPqzsDAwQCMw827P8mNDsrKoeiBxJHBoTYbZ/DvJ9zFPkRFSE/3n1v5OeojGaa+LmDf0R2unAsN/ogBN3/+fJe+Zfu7OfHPAJKgswWK4K4je01HZ7CKt5A7KJ6AeATiEr73xRd98QCrRsq18jWNpKen1/n9iPVkqFuXoY8D2ML3x/39yimHnzYhkACFBn/8CZ47vvmsZGVj/fsoUb9t+7e7Orr11lvz6koqWWYdiVh1EsBbI1jujJ+8m1ZI9BmAyXpwskbj2RqMJ4sYSmOfwAPHvjZzJy4xEgEsdpz66bg5fOyAGWp1vowdiJjEm3Cx9ewS7kL7AH7w9Ydm6axWc+WVV7peLZUeFe8iATZbw83P/4M1/Jpt6LnUexV733L5I0dP2hXHNbbcAz9dUGL27vs8P75Uuja/XgLYyvBdSeII5eKksbNiy2v73k9y/r3fw0uJf677dN8XoftHK18SRQKstJ6A7wUUui50o344kcaolwC68k99n8A/bf6P0KxcInkYRlI5vmEUTec6MJp+9OQP5lf/9jc5QyuavmzZ3xd8/u2/+517btzza3eUfr+4/P+w8lbV93V1ncvmD1xFvAnmD0Qxmp66BKjUZoheT09Pjtk4QpljALmBI67PBXHS0eHlStpi16U+H4C1gCBzA0F4EB6EB+FBeBAeZJwfZLwfhAfhQcb5weh4PzzY3+mM84PYBCA8CA/qJYDSC4j26ErP83okPXOAoNaK1+ZPPQ5QjiGXXLyXjhME97W6U9NY3ITNZOJfawBKfo0BLmoh9Uigb+BhyFUxO+BlXfP48tE1PqsK010XwNxAkDmCIDwID6LLQXQ9CA/Cg+hyEF0PwoPwoFano4tBdDUID8KD2vpL3Qa4uOLd9qAiYeI+Pl0vQKsG0rcB7JBspYZbf17vB29UutwLA/9/3sefE6itzCT5a154+OFeX+dG148zXQxdlJe+SLc/QMfUsbkgjbxH3v1llq6nC6PppxvHl0yPe/+amrmq/I0HS79f3PNbBuu+f2ZjsHNp0fqJKb962WJtk/0JFAo5LnKVl36y9Pr/aOQtmn9sU0soEhdNj8u/NxOOxFWav61tttlsN6BO/P1bdd/fPFX3/dsyR0OGYqXfr7cBlGMBWnXQp8vLcfkK2QTp2gBJxHZYbejGAvRxAKUNUI0DSAw/uSsXbgyV/4ysXgJUI4GhUcRKDUi9BKi80v1GY1VGhXsD29W/YoiJbhas5h/g5VdslKhsXikB9Do8qe4nX7o2gEb8y1CvVoLobQDropXdWAoZjKnbEOmOBfjiOFll6so/dRugKgGSG4D9IgFYFwBWHFvup/0BiO0T8wfhQXiQmDxIzB6EB+FBeBAehAfhQXgQHoQH4UFi+iAxfxAehAfhQXgQHoQH9aOBVqwTRKliOaN3l1Z56W2A1HV4oeAOBl45mK4NEMzZS64GtDaE3gYoZNhVYhim7kWk6wUkM/x8618ZCaxY51v/X34/L2czKH83kHF6kHF6EB6EB+FBeBAehAfRxSC6GoQH4UHtfABtfnQ5iK4H4UF4UC8BlD1YPxag7MGa6WD9MISslwDKSGDVcBt4hhtDv/2BqUuAahwguQF4acQBojZBpXMMlXEEdDmIrgfhQXgQXQ6i60F4EB5kvj9YqU5HF4PoahAehAexxcBKbbqqBNDaAIqhXK0L2C8SQDuvvJwl4FpDr1T+6pxA3yWs3CCsRgJ/5pFMqwqV6wKqcQC3Px+6H1sAhAfhQXgQHoQH4UFsARBbAYQH4UG9DVCNBNqxkOTTuvRxAGUkMG0boDonMHnjCdYGKm0A1WQOiflXI4EDe04gc/vA6hy/AT7Hr8I5nnobQCkBqpHAlCOBahugkqHfQgZj6vMJ0p0PoB3P19ZfVQL83COBaccBmNsHMvcPhAfhQWLyIDF7EB6EB+FBeBAehAfhQXgQHoQH8c9B/HMQHoQH4UF4EB6EB6uRwJ97JFCrQ7RjAdU4QLpxgJrfP/qobn+ASbr18WcH14RmFUfX/8etr+9pHKXKP3bsbFX+xnO67x/eqfv+CfKLKdYQZ3JIpeX3f1gkTJOVXef6AAAAAElFTkSuQmCC"
+        }
+    },
+    "materials": {
+        "Material-effect": {
+		  "name": "Material-effect",
+		  "technique": "technique0",
+		  "values": {
+			"diffuse": "texture_Untitled",
+			"shininess": 256,
+			"specular": [
+			  0.2,
+			  0.2,
+			  0.2,
+			  1
+			]
+		  }
+        },
+        "Material_001-effect": {
+            "name": "Material_001",
+            "technique": "technique0",
+			   "values": {
+				"diffuse": "texture_Untitled_001",
+				"shininess": 256,
+				"specular": [
+				  0.2,
+				  0.2,
+				  0.2,
+				  1
+				]
+			  }
+        }
+    },
+    "meshes": {
+        "Cube-mesh": {
+            "name": "Cube",
+            "primitives": [
+                {
+                    "attributes": {
+                        "NORMAL": "accessor_25",
+                        "POSITION": "accessor_23",
+                        "TEXCOORD_0": "accessor_27"
+                    },
+                    "indices": "accessor_21",
+                    "material": "Material-effect",
+                    "mode": 4
+                }
+            ]
+        },
+        "Cube_001-mesh": {
+            "name": "Cube.001",
+            "primitives": [
+                {
+                    "attributes": {
+                        "NORMAL": "accessor_52",
+                        "POSITION": "accessor_50",
+                        "TEXCOORD_0": "accessor_54"
+                    },
+                    "indices": "accessor_48",
+                    "material": "Material_001-effect",
+                    "mode": 4
+                }
+            ]
+        }
+    },
+    "nodes": {
+        "Cube": {
+            "children": [],
+            "matrix": [
+                1,
+                0,
+                0,
+                0,
+                0,
+                1,
+                0,
+                0,
+                0,
+                0,
+                1,
+                0,
+                0,
+                0,
+                0,
+                1
+            ],
+            "meshes": [
+                "Cube-mesh"
+            ],
+            "name": "Cube"
+        },
+        "Cube_001": {
+            "children": [],
+            "matrix": [
+                2,
+                0,
+                0,
+                0,
+                0,
+                2,
+                0,
+                0,
+                0,
+                0,
+                0.10000000149011612,
+                0,
+                0,
+                0,
+                -1.3000000715255737,
+                1
+            ],
+            "meshes": [
+                "Cube_001-mesh"
+            ],
+            "name": "Cube_001"
+        },
+        "node_2": {
+            "children": [
+                "Cube",
+                "Cube_001"
+            ],
+            "matrix": [
+                1,
+                0,
+                0,
+                0,
+                0,
+                0,
+                -1,
+                0,
+                0,
+                1,
+                0,
+                0,
+                0,
+                0,
+                0,
+                1
+            ],
+            "name": "Y_UP_Transform"
+        }
+    },
+    "programs": {
+        "program_0": {
+            "attributes": [
+                "a_normal",
+                "a_position",
+                "a_texcoord0"
+            ],
+            "fragmentShader": "cube_over_ground0FS",
+            "vertexShader": "cube_over_ground0VS"
+        }
+    },
+    "samplers": {
+        "sampler_0": {
+            "magFilter": 9729,
+            "minFilter": 9987,
+            "wrapS": 10497,
+            "wrapT": 10497
+        }
+    },
+    "scene": "defaultScene",
+    "scenes": {
+        "defaultScene": {
+            "nodes": [
+                "node_2"
+            ],
+            "node": []
+        }
+    },
+    "shaders": {
+        "cube_over_ground0FS": {
+            "type": 35632,
+            "type": 35632,
+			"uri": "data:text/plain;base64,cHJlY2lzaW9uIGhpZ2hwIGZsb2F0Ow0KdmFyeWluZyB2ZWMzIHZfbm9ybWFsOw0KdmFyeWluZyB2ZWMyIHZfdGV4Y29vcmQwOw0KdW5pZm9ybSBzYW1wbGVyMkQgdV9kaWZmdXNlOw0KdW5pZm9ybSB2ZWM0IHVfc3BlY3VsYXI7DQp1bmlmb3JtIGZsb2F0IHVfc2hpbmluZXNzOw0Kdm9pZCBtYWluKHZvaWQpIHsNCnZlYzMgbm9ybWFsID0gbm9ybWFsaXplKHZfbm9ybWFsKTsNCnZlYzQgY29sb3IgPSB2ZWM0KDAuLCAwLiwgMC4sIDAuKTsNCnZlYzQgZGlmZnVzZSA9IHZlYzQoMC4sIDAuLCAwLiwgMS4pOw0KdmVjNCBzcGVjdWxhcjsNCmRpZmZ1c2UgPSB0ZXh0dXJlMkQodV9kaWZmdXNlLCB2X3RleGNvb3JkMCk7DQpzcGVjdWxhciA9IHVfc3BlY3VsYXI7DQpkaWZmdXNlLnh5eiAqPSBtYXgoZG90KG5vcm1hbCx2ZWMzKDAuLDAuLDEuKSksIDAuKTsNCmNvbG9yLnh5eiArPSBkaWZmdXNlLnh5ejsNCmNvbG9yID0gdmVjNChjb2xvci5yZ2IgKiBkaWZmdXNlLmEsIGRpZmZ1c2UuYSk7DQpnbF9GcmFnQ29sb3IgPSBjb2xvcjsNCn0NCg=="	
+        },
+        "cube_over_ground0VS": {
+            "type": 35633,
+            "uri": "data:text/plain;base64,cHJlY2lzaW9uIGhpZ2hwIGZsb2F0Ow0KYXR0cmlidXRlIHZlYzMgYV9wb3NpdGlvbjsNCmF0dHJpYnV0ZSB2ZWMzIGFfbm9ybWFsOw0KdmFyeWluZyB2ZWMzIHZfbm9ybWFsOw0KdW5pZm9ybSBtYXQzIHVfbm9ybWFsTWF0cml4Ow0KdW5pZm9ybSBtYXQ0IHVfbW9kZWxWaWV3TWF0cml4Ow0KdW5pZm9ybSBtYXQ0IHVfcHJvamVjdGlvbk1hdHJpeDsNCmF0dHJpYnV0ZSB2ZWMyIGFfdGV4Y29vcmQwOw0KdmFyeWluZyB2ZWMyIHZfdGV4Y29vcmQwOw0Kdm9pZCBtYWluKHZvaWQpIHsNCnZlYzQgcG9zID0gdV9tb2RlbFZpZXdNYXRyaXggKiB2ZWM0KGFfcG9zaXRpb24sMS4wKTsNCnZfbm9ybWFsID0gdV9ub3JtYWxNYXRyaXggKiBhX25vcm1hbDsNCnZfdGV4Y29vcmQwID0gYV90ZXhjb29yZDA7DQpnbF9Qb3NpdGlvbiA9IHVfcHJvamVjdGlvbk1hdHJpeCAqIHBvczsNCn0NCg=="
+        }
+    },
+    "skins": {},
+    "techniques": {
+        "technique0": {
+		  "attributes": {
+			"a_normal": "normal",
+			"a_position": "position",
+			"a_texcoord0": "texcoord0"
+		  },
+		  "parameters": {
+			"diffuse": {
+			  "type": 35678
+			},
+			"modelViewMatrix": {
+			  "semantic": "MODELVIEW",
+			  "type": 35676
+			},
+			"normal": {
+			  "semantic": "NORMAL",
+			  "type": 35665
+			},
+			"normalMatrix": {
+			  "semantic": "MODELVIEWINVERSETRANSPOSE",
+			  "type": 35675
+			},
+			"position": {
+			  "semantic": "POSITION",
+			  "type": 35665
+			},
+			"projectionMatrix": {
+			  "semantic": "PROJECTION",
+			  "type": 35676
+			},
+			"shininess": {
+			  "type": 5126
+			},
+			"specular": {
+			  "type": 35666
+			},
+			"texcoord0": {
+			  "semantic": "TEXCOORD_0",
+			  "type": 35664
+			}
+		  },
+		  "program": "program_0",
+		  "states": {
+			"enable": [
+			  2929,
+			  2884
+			],
+			"disable": []
+		  },
+		  "uniforms": {
+			"u_diffuse": "diffuse",
+			"u_modelViewMatrix": "modelViewMatrix",
+			"u_normalMatrix": "normalMatrix",
+			"u_projectionMatrix": "projectionMatrix",
+			"u_shininess": "shininess",
+			"u_specular": "specular"
+		  }
+		}
+    },
+    "textures": {
+        "texture_Untitled": {
+            "format": 6408,
+            "internalFormat": 6408,
+            "sampler": "sampler_0",
+            "source": "Untitled",
+            "target": 3553,
+            "type": 5121
+        },
+        "texture_Untitled_001": {
+            "format": 6408,
+            "internalFormat": 6408,
+            "sampler": "sampler_0",
+            "source": "Untitled_001",
+            "target": 3553,
+            "type": 5121
+        }
+    },
+    "extensionsUsed": [],
+    "cameras": {},
+    "extensions": {
+        "KHR_materials_common": {
+            "lights": {}
+        }
+    }
+}

--- a/specs/lib/bakeAmbientOcclusionSpec.js
+++ b/specs/lib/bakeAmbientOcclusionSpec.js
@@ -335,10 +335,10 @@ describe('bakeAmbientOcclusion', function() {
             });
         }
 
-        for (var i = 0; i < 6; i++) {
+        for (i = 0; i < 6; i++) {
           var texel = texelPoints[i];
           bakeAmbientOcclusion.computeAmbientOcclusionAt(
-            texel.position, texel.normal, 16,
+            texel.position, texel.normal, 16, 4,
             tetrahedron, 0.001, 10.0, aoBuffer, texel.index);
         }
 
@@ -385,7 +385,7 @@ describe('bakeAmbientOcclusion', function() {
         for (var i = 0; i < 3; i++) {
           var texel = texelPoints[i];
           bakeAmbientOcclusion.computeAmbientOcclusionAt(
-            texel.position, texel.normal, 16,
+            texel.position, texel.normal, 16, 4,
             tetrahedron, 0.001, 10.0, aoBuffer, texel.index);
         }
 
@@ -477,11 +477,15 @@ describe('bakeAmbientOcclusion', function() {
         boxOverGroundGltfClone.materials[materialID] = material;
 
         var meshes = boxOverGroundGltfClone.meshes;
-        var setPrimitiveMaterial = function(primitive) {
-            primitive.material = materialID;
-        };
 
-        NodeHelpers.forEachPrimitive(boxOverGroundGltfClone, setPrimitiveMaterial);
+        var scene = boxOverGroundGltfClone.scenes[boxOverGroundGltfClone.scene];
+        var parameters = {
+            meshes : boxOverGroundGltfClone.meshes,
+            primitiveFunction : function(primitive) {
+                primitive.material = materialID;
+            }
+        };
+        NodeHelpers.forEachPrimitiveInScene(boxOverGroundGltfClone, scene, parameters);
 
         var options = {
             numberSamples: 1,

--- a/specs/lib/bakeAmbientOcclusionSpec.js
+++ b/specs/lib/bakeAmbientOcclusionSpec.js
@@ -479,13 +479,11 @@ describe('bakeAmbientOcclusion', function() {
         var meshes = boxOverGroundGltfClone.meshes;
 
         var scene = boxOverGroundGltfClone.scenes[boxOverGroundGltfClone.scene];
-        var parameters = {
-            meshes : boxOverGroundGltfClone.meshes,
-            primitiveFunction : function(primitive) {
-                primitive.material = materialID;
-            }
+        var primitiveFunction = function(primitive) {
+            primitive.material = materialID;
         };
-        NodeHelpers.forEachPrimitiveInScene(boxOverGroundGltfClone, scene, parameters);
+
+        NodeHelpers.forEachPrimitiveInScene(boxOverGroundGltfClone, scene, primitiveFunction);
 
         var options = {
             numberSamples: 1,

--- a/specs/lib/bakeAmbientOcclusionSpec.js
+++ b/specs/lib/bakeAmbientOcclusionSpec.js
@@ -1,0 +1,555 @@
+'use strict';
+var Cesium = require('cesium');
+var CesiumMath = Cesium.Math;
+var Cartesian3 = Cesium.Cartesian3;
+
+var fs = require('fs');
+var path = require('path');
+var clone = require('clone');
+var loadGltfUris = require('../../lib/loadGltfUris');
+var addPipelineExtras = require('../../lib/addPipelineExtras');
+var bakeAmbientOcclusion = require('../../lib/bakeAmbientOcclusion');
+var readAccessor = require('../../lib/readAccessor');
+var Jimp = require('jimp');
+var NodeHelpers = require('../../lib/NodeHelpers');
+
+var boxGltfPath = './specs/data/boxTexturedUnoptimized/CesiumTexturedBoxTest.gltf';
+var boxOverGroundGltfPath = './specs/data/ambientOcclusion/cube_over_ground.gltf';
+
+function cloneGltfWithJimps(gltf) {
+    var gltfClone = clone(gltf);
+
+    // clone the jimps too
+    var originalJimp = gltf.extras._pipeline.jimpScratch;
+    gltfClone.extras._pipeline.jimpScratch = originalJimp.clone();
+    var images = gltfClone.images;
+    for (var imageID in images) {
+        if (images.hasOwnProperty(imageID)) {
+            var image = images[imageID];
+            originalJimp = gltf.images[imageID].extras._pipeline.jimpImage;
+            image.extras._pipeline.jimpImage = originalJimp.clone();
+        }
+    }
+
+    return gltfClone;
+}
+
+describe('bakeAmbientOcclusion', function() {
+    var boxGltf;
+    var boxOverGroundGltf;
+
+    var loadGltfUriOptions = {
+        basePath: path.dirname(boxGltfPath),
+        imageProcess: true
+    };
+
+    var indices = [0,1,2,0,2,3];
+    var indicesBuffer = new Buffer(indices.length * 2);
+    for (var i = 0; i < indices.length; i++) {
+        indicesBuffer.writeUInt16LE(indices[i], i * 2);
+    }
+    var positions = [
+        0,0,0,
+        0,1,0,
+        1,1,0,
+        1,0,0
+    ];
+    var normals = [
+        0,0,1,
+        0,0,1,
+        0,0,1,
+        0,0,1
+    ];
+    var uvs = [
+        0.25,0.25,
+        0.75,0.25,
+        0.75,0.75,
+        0.25,0.75
+    ];
+    var positionsBuffer = new Buffer(positions.length * 4);
+    for (i = 0; i < positions.length; i++) {
+        positionsBuffer.writeFloatLE(positions[i], i * 4);
+    }
+    var normalsBuffer = new Buffer(normals.length * 4);
+    for (i = 0; i < normals.length; i++) {
+        normalsBuffer.writeFloatLE(normals[i], i * 4);
+    }
+    var uvsBuffer = new Buffer(uvs.length * 4);
+    for (i = 0; i < uvs.length; i++) {
+        uvsBuffer.writeFloatLE(uvs[i], i * 4);
+    }
+
+    var dataBuffer = Buffer.concat([indicesBuffer, positionsBuffer, normalsBuffer, uvsBuffer]);
+
+    var testGltf = {
+        "accessors": {
+            "accessor_index": {
+                "bufferView": "index_view",
+                "byteOffset": 0,
+                "componentType": 5123,
+                "count": 6,
+                "type": "SCALAR"
+            },
+            "accessor_position": {
+                "bufferView": "position_view",
+                "byteOffset": 0,
+                "componentType": 5126,
+                "count": 4,
+                "type": "VEC3"
+            },
+            "accessor_normal": {
+                "bufferView": "normal_view",
+                "byteOffset": 0,
+                "componentType": 5126,
+                "count": 4,
+                "type": "VEC3"
+            },
+            "accessor_uv": {
+                "bufferView": "uv_view",
+                "byteOffset": 0,
+                "componentType": 5126,
+                "count": 4,
+                "type": "VEC2"
+            }
+        },
+        "bufferViews": {
+            "index_view": {
+                "buffer": "buffer_0",
+                "byteOffset": 0,
+                "byteLength": 6 * 2,
+                "target": 34963
+            },
+            "position_view": {
+                "buffer": "buffer_0",
+                "byteOffset": 6 * 2,
+                "byteLength": 4 * 3 * 4,
+                "target": 34962
+            },
+            "normal_view": {
+                "buffer": "buffer_0",
+                "byteOffset": 6 * 2 + (4 * 3 * 4),
+                "byteLength": 4 * 3 * 4,
+                "target": 34962
+            },
+            "uv_view": {
+                "buffer": "buffer_0",
+                "byteOffset": 6 * 2 + (4 * 3 * 4) * 2,
+                "byteLength": 4 * 2 * 4,
+                "target": 34962
+            }
+        },
+        "buffers": {
+            "buffer_0": {
+                "uri": "data:",
+                "byteLength": indices.length * 2 + (positions.length + normals.length + uvs.length) * 4,
+                "extras": {
+                    "_pipeline": {
+                        "source": dataBuffer
+                    }
+                }
+            }
+        },
+        "scene": "defaultScene",
+        "scenes": {
+            "defaultScene": {
+                "nodes": [
+                    "squareNode"
+                ]
+            }
+        },
+        "nodes": {
+            "squareNode": {
+                "children": [],
+                "matrix": [
+                    2, 0, 0, 0,
+                    0, 2, 0, 0,
+                    0, 0, 2, 0,
+                    0, 0, 0, 1
+                ],
+                "meshes": [
+                    "mesh_square"
+                ],
+                "name": "square",
+                "extras": {
+                    "_pipeline": {}
+                }
+            }
+        },
+        "meshes": {
+            "mesh_square": {
+                "name": "square",
+                "primitives": [
+                    {
+                        "attributes": {
+                            "POSITION": "accessor_position",
+                            "NORMAL": "accessor_normal",
+                            "TEXCOORD_0": "accessor_uv"
+                        },
+                        "indices": "accessor_index"
+                    }
+                ]
+            }
+        }
+    };
+
+
+
+    beforeAll(function(done) {
+        fs.readFile(boxGltfPath, function(err, data) {
+            if (err) {
+                throw err;
+            }
+            else {
+                boxGltf = JSON.parse(data);
+                addPipelineExtras(boxGltf);
+                loadGltfUris(boxGltf, loadGltfUriOptions, function(err, gltf) {
+                    if (err) {
+                        throw err;
+                    }
+                    done();
+                });
+            }
+        });
+
+        fs.readFile(boxOverGroundGltfPath, function(err, data) {
+            if (err) {
+                throw err;
+            }
+            else {
+                boxOverGroundGltf = JSON.parse(data);
+                addPipelineExtras(boxOverGroundGltf);
+                loadGltfUris(boxOverGroundGltf, loadGltfUriOptions, function(err, gltf) {
+                    if (err) {
+                        throw err;
+                    }
+                    done();
+                });
+            }
+        });
+    });
+
+    // tetrahedron
+    var point0 = new Cartesian3(0.0, -1.0, 1.0);
+    var point1 = new Cartesian3(1.0, -1.0, -1.0);
+    var point2 = new Cartesian3(-1.0, -1.0, -1.0);
+    var point3 = new Cartesian3(0.0, 1.0, 0.0);
+
+    var tetrahedron = [
+        {positions: [point0, point1, point2]},
+        {positions: [point0, point1, point3]},
+        {positions: [point1, point2, point3]},
+        {positions: [point2, point0, point3]}
+    ];
+
+    function testContainmentAndFitCartesian3(min, max, cartesian3s) {
+        // check if the data in values is bounded by min and max precisely
+        var minInValues = new Array(min.length).fill(Number.POSITIVE_INFINITY);
+        var maxInValues = new Array(max.length).fill(Number.NEGATIVE_INFINITY);
+
+        var data = cartesian3s;
+
+        for (var i = 0; i < data.length; i++) {
+            var values = [data[i].x, data[i].y, data[i].z];
+            for (var j = 0; j < min.length; j++) {
+                if (values[j] > max[j] || values[j] < min[j]) {
+                    return false;
+                }
+                minInValues[j] = Math.min(minInValues[j], values[j]);
+                maxInValues[j] = Math.max(maxInValues[j], values[j]);
+            }
+        }
+        for (i = 0; i < min.length; i++) {
+            if (!CesiumMath.equalsEpsilon(minInValues[i], min[i], CesiumMath.EPSILON7)) {
+                return false;
+            }
+            if (!CesiumMath.equalsEpsilon(maxInValues[i], max[i], CesiumMath.EPSILON7)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    it('correctly processes a basic 2-triangle square primitive', function() {
+        var scene = testGltf.scenes[testGltf.scene];
+        var options = {
+            "rayDepth" : 0.1,
+            "resolution" : 10
+        };
+        var raytracerScene = bakeAmbientOcclusion.generateRaytracerScene(testGltf, scene, options);
+        var triangleSoup = raytracerScene.triangleSoup;
+        var texelPoints = raytracerScene.texelPoints;
+
+        // because of the uniform scale, expect triangles to be bigger
+        var point0 = new Cartesian3(0.0, 0.0, 0.0);
+        var point1 = new Cartesian3(0.0, 2.0, 0.0);
+        var point2 = new Cartesian3(2.0, 2.0, 0.0);
+        var point3 = new Cartesian3(2.0, 0.0, 0.0);
+        var normal = new Cartesian3(0.0, 0.0, 1.0);
+
+        var expectedPixelIndices = {
+            22: 0, 23: 0, 24: 0, 25: 0, 26: 0, 27: 0,
+            32: 0, 33: 0, 34: 0, 35: 0, 36: 0, 37: 0,
+            42: 0, 43: 0, 44: 0, 45: 0, 46: 0, 47: 0,
+            52: 0, 53: 0, 54: 0, 55: 0, 56: 0, 57: 0,
+            62: 0, 63: 0, 64: 0, 65: 0, 66: 0, 67: 0,
+            72: 0, 73: 0, 74: 0, 75: 0, 76: 0, 77: 0
+        };
+
+        ////////// check texel points //////////
+        expect(texelPoints.length >= 36).toEqual(true); // barycentric coordinate precisions make this imprecise
+        expect(texelPoints.length <= 46).toEqual(true); // at most, all pixels on triangle diagonals are double sampled
+
+        // each texel point has a world position, world normal, pixel index, and buffer pointer
+        var cartesian3s = [];
+        for (var i = 0; i < texelPoints.length; i++) {
+            var texelPoint = texelPoints[i];
+            expect(Cartesian3.equalsEpsilon(texelPoint.normal, normal, CesiumMath.EPSILON7)).toEqual(true);
+            expect(texelPoint.buffer.resolution).toEqual(10);
+            expect(texelPoint.buffer.samples.length).toEqual(100);
+            expect(expectedPixelIndices.hasOwnProperty(texelPoint.index)).toEqual(true);
+            if (expectedPixelIndices.hasOwnProperty(texelPoint.index)) {
+                expectedPixelIndices[texelPoint.index]++;
+            }
+            cartesian3s.push(texelPoint.position);
+        }
+        expect(testContainmentAndFitCartesian3([0.0, 0.0, 0.0], [2.0, 2.0, 0.0], cartesian3s)).toEqual(true);
+        for (var id in expectedPixelIndices) {
+            if (expectedPixelIndices.hasOwnProperty(id)) {
+                expect(expectedPixelIndices[id] > 0).toEqual(true);
+            }
+        }
+
+        ////////// check triangle soup //////////
+
+        expect(triangleSoup.length).toEqual(2);
+
+        var triangle0 = triangleSoup[0];
+        var triangle1 = triangleSoup[1];
+
+        expect(Cartesian3.equalsEpsilon(triangle0.positions[0], point0, CesiumMath.EPSILON7)).toEqual(true);
+        expect(Cartesian3.equalsEpsilon(triangle0.positions[1], point1, CesiumMath.EPSILON7)).toEqual(true);
+        expect(Cartesian3.equalsEpsilon(triangle0.positions[2], point2, CesiumMath.EPSILON7)).toEqual(true);
+
+        expect(Cartesian3.equalsEpsilon(triangle1.positions[0], point0, CesiumMath.EPSILON7)).toEqual(true);
+        expect(Cartesian3.equalsEpsilon(triangle1.positions[1], point2, CesiumMath.EPSILON7)).toEqual(true);
+        expect(Cartesian3.equalsEpsilon(triangle1.positions[2], point3, CesiumMath.EPSILON7)).toEqual(true);
+    });
+
+    it('generates "all occluded (1.0)" for samples inside a closed tetrahedron', function() {
+        var normals = [];
+        for (var i = 0; i < 6; i++) {
+            var values = [0.0, 0.0, 0.0];
+            values[i % 3] = (i % 2) ? 1.0 : -1.0;
+            var newNormal = Cartesian3.fromArray(values);
+            normals.push(newNormal);
+        }
+
+        var aoBuffer = {
+            resolution: 3,
+            samples: new Array(9).fill(0.0),
+            count: new Array(9).fill(0.0)
+        };
+
+        var texelPoints = [];
+
+        for (i = 0; i < normals.length; i++) {
+            texelPoints.push({
+                position: Cartesian3.ZERO,
+                normal: normals[i],
+                index: i,
+                buffer: aoBuffer
+            });
+        }
+
+        var raytracerScene = {
+            numberSamples : 16,
+            rayDepth : 10.0,
+            triangleSoup : tetrahedron,
+            texelPoints : texelPoints,
+            nearCull: 0.001
+        };
+
+        bakeAmbientOcclusion.generateOcclusionData(raytracerScene);
+
+        var samples = aoBuffer.samples;
+        var counts = aoBuffer.count;
+        for (i = 0; i < 6; i++) {
+            expect(samples[i]).toEqual(16.0);
+            expect(counts[i]).toEqual(16);
+        }
+    });
+
+    it('generates various levels of occlusion for samples in the mouth of an open tetrahedron', function() {
+        var openTetrahedron = [tetrahedron[1], tetrahedron[2], tetrahedron[3]];
+
+        var aoBuffer = {
+            resolution: 2,
+            samples: new Array(4).fill(0.0),
+            count: new Array(4).fill(0.0)
+        };
+
+        var bottomCenter = new Cartesian3(0.0, -1.0, 0.0);
+
+        var texelPoints = [
+            {
+                position: bottomCenter,
+                normal: new Cartesian3(0.0, 1.0, 0.0),
+                index: 0,
+                buffer: aoBuffer
+            },
+            {
+                position: bottomCenter,
+                normal: new Cartesian3(0.0, -1.0, 0.0),
+                index: 1,
+                buffer: aoBuffer
+            },
+            {
+                position: bottomCenter,
+                normal: new Cartesian3(1.0, 0.0, 0.0),
+                index: 2,
+                buffer: aoBuffer
+            }
+        ];
+
+        var raytracerScene = {
+            numberSamples : 16,
+            rayDepth : 10.0,
+            triangleSoup : openTetrahedron,
+            texelPoints : texelPoints,
+            nearCull: 0.001
+        };
+
+        bakeAmbientOcclusion.generateOcclusionData(raytracerScene);
+
+        var samples = aoBuffer.samples;
+
+        expect(samples[0]).toEqual(16);
+        expect(samples[1]).toEqual(0);
+        expect(samples[2] > 6 && samples[2] < 10).toEqual(true); // randomized, but stratification should ensure this.
+    });
+
+    it('modifies existing images, textures, and materials in place', function() {
+        var boxOverGroundGltfClone = cloneGltfWithJimps(boxOverGroundGltf);
+
+        var options = {
+            numberSamples: 1,
+            rayDepth: 1.0,
+            resolution: 4
+        };
+        bakeAmbientOcclusion.bakeAmbientOcclusion(boxOverGroundGltfClone, options);
+
+        expect(Object.keys(boxOverGroundGltfClone.images).length).toEqual(2);
+        expect(Object.keys(boxOverGroundGltfClone.textures).length).toEqual(2);
+        expect(Object.keys(boxOverGroundGltfClone.materials).length).toEqual(2);
+    });
+
+    it('adds additional images as needed', function() {
+        var boxOverGroundGltfClone = cloneGltfWithJimps(boxOverGroundGltf);
+
+        // remove some images
+        var imageID = 'Untitled';
+        var image = boxOverGroundGltfClone.images[imageID];
+        boxOverGroundGltfClone.images = {};
+        boxOverGroundGltfClone.images[imageID] = image;
+        var textures = boxOverGroundGltfClone.textures;
+        for (var textureID in textures) {
+            if (textures.hasOwnProperty(textureID)) {
+                var texture = textures[textureID];
+                texture.source = imageID;
+            }
+        }
+
+        var options = {
+            numberSamples: 1,
+            rayDepth: 1.0,
+            resolution: 4
+        };
+        bakeAmbientOcclusion.bakeAmbientOcclusion(boxOverGroundGltfClone, options);
+
+        expect(Object.keys(boxOverGroundGltfClone.images).length).toEqual(2);
+        expect(Object.keys(boxOverGroundGltfClone.textures).length).toEqual(2);
+        expect(Object.keys(boxOverGroundGltfClone.materials).length).toEqual(2);
+    });
+    
+    it('adds additional textures as needed', function() {
+        var boxOverGroundGltfClone = cloneGltfWithJimps(boxOverGroundGltf);
+
+        // remove some textures
+        var textureID = 'texture_Untitled';
+        var texture = boxOverGroundGltfClone.textures[textureID];
+        boxOverGroundGltfClone.textures = {};
+        boxOverGroundGltfClone.textures[textureID] = texture;
+
+        var materials = boxOverGroundGltfClone.materials;
+        for (var materialID in materials) {
+            if (materials.hasOwnProperty(materialID)) {
+                materials[materialID].values.diffuse = textureID;
+            }
+        }
+
+        var options = {
+            numberSamples: 1,
+            rayDepth: 1.0,
+            resolution: 4
+        };
+        bakeAmbientOcclusion.bakeAmbientOcclusion(boxOverGroundGltfClone, options);
+
+        expect(Object.keys(boxOverGroundGltfClone.images).length).toEqual(3); // 1 unused image and 2 images with AO
+        expect(Object.keys(boxOverGroundGltfClone.textures).length).toEqual(2);
+        expect(Object.keys(boxOverGroundGltfClone.materials).length).toEqual(2);
+    });
+
+    it ('adds additional materials as needed', function() {
+        var boxOverGroundGltfClone = cloneGltfWithJimps(boxOverGroundGltf);
+
+        // remove some materials
+        var materialID = 'Material-effect';
+        var material = boxOverGroundGltfClone.materials[materialID];
+        boxOverGroundGltfClone.materials = {};
+        boxOverGroundGltfClone.materials[materialID] = material;
+
+        var meshes = boxOverGroundGltfClone.meshes;
+        var setPrimitiveMaterial = function(primitive) {
+            primitive.material = materialID;
+        };
+
+        NodeHelpers.forEachPrimitive(boxOverGroundGltfClone, setPrimitiveMaterial);
+
+        var options = {
+            numberSamples: 1,
+            rayDepth: 1.0,
+            resolution: 4
+        };
+        bakeAmbientOcclusion.bakeAmbientOcclusion(boxOverGroundGltfClone, options);
+
+        expect(Object.keys(boxOverGroundGltfClone.images).length).toEqual(3); // 1 unused image and 2 with AO
+        expect(Object.keys(boxOverGroundGltfClone.textures).length).toEqual(3); // 1 unused texture, 2 with AO
+        expect(Object.keys(boxOverGroundGltfClone.materials).length).toEqual(2);
+    });
+
+    it ('can generate new images for materials that just have a diffuse color', function() {
+        var boxOverGroundGltfClone = cloneGltfWithJimps(boxOverGroundGltf);
+
+        // remove some textures
+        var textureID = 'texture_Untitled';
+        var materials = boxOverGroundGltfClone.materials;
+        for (var materialID in materials) {
+            if (materials.hasOwnProperty(materialID)) {
+                if (materials[materialID].values.diffuse === textureID) {
+                    materials[materialID].values.diffuse = [1.0, 1.0, 1.0, 1.0];
+                }
+            }
+        }
+
+        var options = {
+            numberSamples: 1,
+            rayDepth: 1.0,
+            resolution: 4
+        };
+        bakeAmbientOcclusion.bakeAmbientOcclusion(boxOverGroundGltfClone, options);
+
+        expect(Object.keys(boxOverGroundGltfClone.images).length).toEqual(3); // 1 unused image and 2 images with AO
+        expect(Object.keys(boxOverGroundGltfClone.textures).length).toEqual(3); // 1 unused texture, 2 with AO
+        expect(Object.keys(boxOverGroundGltfClone.materials).length).toEqual(3); // 1 unused material, 2 with AO
+    });
+});

--- a/specs/lib/nodeHelpersSpec.js
+++ b/specs/lib/nodeHelpersSpec.js
@@ -181,18 +181,18 @@ describe('NodeHelpers', function() {
             var scene = gltf.scenes[gltf.scene];
 
             var functionParameters = {
-                meshes: gltf.meshes,
-                primitiveFunction: function(primitive, meshPrimitiveID, parameters) {
-                    parameters.numberPrimitives++;
-                    parameters.primitiveMeshIDs.push(meshPrimitiveID);
-                    parameters.materialIDs.push(primitive.material);
-                },
                 numberPrimitives: 0,
                 primitiveMeshIDs: [],
                 materialIDs: []
             };
 
-            NodeHelpers.forEachPrimitiveInScene(gltf, scene, functionParameters);
+            var primitiveFunction = function(primitive, meshPrimitiveID, parameters) {
+                parameters.numberPrimitives++;
+                parameters.primitiveMeshIDs.push(meshPrimitiveID);
+                parameters.materialIDs.push(primitive.material);
+            };
+
+            NodeHelpers.forEachPrimitiveInScene(gltf, scene, primitiveFunction, functionParameters);
 
             expect(functionParameters.numberPrimitives).toEqual(5);
             expect(functionParameters.primitiveMeshIDs[0]).toEqual('meshTest_0');

--- a/specs/lib/nodeHelpersSpec.js
+++ b/specs/lib/nodeHelpersSpec.js
@@ -172,24 +172,27 @@ describe('NodeHelpers', function() {
         expect(Matrix4.equalsEpsilon(actualRightWrist, expectRightWrist, CesiumMath.EPSILON7)).toEqual(true);
     });
 
-    it('performs operations per primitive', function(done) {
+    it('performs operations per primitive in a scene', function(done) {
         fs.readFile(fiveBoxPath, function(err, data) {
             if (err) {
                 throw err;
             }
             var gltf = JSON.parse(data);
+            var scene = gltf.scenes[gltf.scene];
+
             var functionParameters = {
+                meshes: gltf.meshes,
+                primitiveFunction: function(primitive, meshPrimitiveID, parameters) {
+                    parameters.numberPrimitives++;
+                    parameters.primitiveMeshIDs.push(meshPrimitiveID);
+                    parameters.materialIDs.push(primitive.material);
+                },
                 numberPrimitives: 0,
                 primitiveMeshIDs: [],
                 materialIDs: []
             };
-            var countPrimitives = function(primitive, meshPrimitiveID, parameters) {
-                parameters.numberPrimitives++;
-                parameters.primitiveMeshIDs.push(meshPrimitiveID);
-                parameters.materialIDs.push(primitive.material);
-            };
 
-            NodeHelpers.forEachPrimitive(gltf, countPrimitives, functionParameters);
+            NodeHelpers.forEachPrimitiveInScene(gltf, scene, functionParameters);
 
             expect(functionParameters.numberPrimitives).toEqual(5);
             expect(functionParameters.primitiveMeshIDs[0]).toEqual('meshTest_0');

--- a/specs/lib/nodeHelpersSpec.js
+++ b/specs/lib/nodeHelpersSpec.js
@@ -3,8 +3,10 @@ var Cesium = require('cesium');
 var Matrix4 = Cesium.Matrix4;
 var CesiumMath = Cesium.Math;
 var clone = require('clone');
+var fs = require('fs');
 
 var NodeHelpers = require('../../lib/NodeHelpers');
+var fiveBoxPath = './specs/data/combineObjects/fiveBox.gltf';
 
 describe('NodeHelpers', function() {
     var testScene = {
@@ -169,4 +171,33 @@ describe('NodeHelpers', function() {
         expect(Matrix4.equalsEpsilon(actualLeftPinkie, expectLeftPinkie, CesiumMath.EPSILON7)).toEqual(true);
         expect(Matrix4.equalsEpsilon(actualRightWrist, expectRightWrist, CesiumMath.EPSILON7)).toEqual(true);
     });
+
+    it('performs operations per primitive', function(done) {
+        fs.readFile(fiveBoxPath, function(err, data) {
+            if (err) {
+                throw err;
+            }
+            var gltf = JSON.parse(data);
+            var functionParameters = {
+                numberPrimitives: 0,
+                primitiveMeshIDs: [],
+                materialIDs: []
+            };
+            var countPrimitives = function(primitive, meshPrimitiveID, parameters) {
+                parameters.numberPrimitives++;
+                parameters.primitiveMeshIDs.push(meshPrimitiveID);
+                parameters.materialIDs.push(primitive.material);
+            };
+
+            NodeHelpers.forEachPrimitive(gltf, countPrimitives, functionParameters);
+
+            expect(functionParameters.numberPrimitives).toEqual(5);
+            expect(functionParameters.primitiveMeshIDs[0]).toEqual('meshTest_0');
+            expect(functionParameters.primitiveMeshIDs[4]).toEqual('meshTest_4');
+            expect(functionParameters.materialIDs[0]).toEqual('Effect_outer');
+            expect(functionParameters.materialIDs[2]).toEqual('Effect_inner');
+
+            done();
+        });
+    })
 });


### PR DESCRIPTION
Run:

`node ./bin/gltf-pipeline.js ./specs/data/ambientOcclusion/cube_over_ground.gltf --ao_diffuse=true --ao_samples=128 --ao_rayDepth=1.0 --ao_resolution=64 -o hello_AO.gltf`

This takes a couple seconds on my machine, but it's a really small model.

This version of naiveAO outputs a gltf with a separate image for each primitive and adds materials and textures as needed. It won't work with models that don't have any diffuse-textured materials, though, since it tries to find reference materials and textures to clone.

#### Tasks for this PR
* [x] improve memory efficiency by raytracing "on the fly" instead of precomputing and storing all the sample points
* [ ] improve sampling to avoid artifacts near the edges of triangles in UV space
* [ ] profile the code to get an idea of how to make speed improvements

#### Tasks for upcoming PRs
* [ ] evaluate speed benefits using a uniform grid for faster raytracing
* [ ] add an option to bake the AO to vertices or a separate texture and automatically modify relevant shader code
* [ ] evaluate the speed and memory benefits of moving the raytracing math to basic types instead of `Cartesian3`
* [ ] GPU-accelerate with CUDA or WebGL rasterization, e.g. [hemicube](http://the-witness.net/news/2010/09/hemicube-rendering-and-integration/)
   * [ ] Expand to prebaking IBL?
* [ ] UV preprocessing, checking, and cleanup: currently, this stage only works with primitives that already have normalized, non-overlapping UVs