### PR TITLE
Force .gltf extension in writeGltf and standardize some tests

### DIFF
--- a/lib/writeGltf.js
+++ b/lib/writeGltf.js
@@ -9,6 +9,11 @@ var removePipelineExtras = require('./removePipelineExtras');
 module.exports = writeGltf;
 
 function writeGltf(gltf, outputPath, embed, embedImage, createDirectory, callback) {
+    // Correct output path extension if necessary
+    var outputExtension = path.extname(outputPath);
+    if (outputExtension !== '.gltf') {
+        outputPath = path.join(path.dirname(outputPath), path.basename(outputPath, outputExtension) + '.gltf');
+    }
     // Create the output directory if specified
     if (createDirectory) {
         outputPath = path.join(path.dirname(outputPath), 'output', path.basename(outputPath));

--- a/specs/lib/gltfPipelineSpec.js
+++ b/specs/lib/gltfPipelineSpec.js
@@ -17,7 +17,8 @@ var writeGltf = require('../../lib/writeGltf');
 var gltfPath = './specs/data/boxTexturedUnoptimized/CesiumTexturedBoxTest.gltf';
 var gltfEmbeddedPath = './specs/data/boxTexturedUnoptimized/CesiumTexturedBoxTestEmbedded.gltf';
 var glbPath = './specs/data/boxTexturedUnoptimized/CesiumTexturedBoxTest.glb';
-var outputPath = './output/';
+var outputGltfPath = './output/CesiumTexturedBoxTest.gltf';
+var outputGlbPath = './output/CesiumTexturedBoxTest.glb';
 
 describe('gltfPipeline', function() {
     it('optimizes a gltf JSON with embedded resources', function(done) {
@@ -79,9 +80,11 @@ describe('gltfPipeline', function() {
         var spy = spyOn(fs, 'writeFile').and.callFake(function(file, data, callback) {
             callback();
         });
-        var options = {};
-        processFileToDisk(gltfPath, outputPath, options, function() {
-            expect(path.normalize(spy.calls.first().args[0])).toEqual(path.normalize('output/output'));
+        var options = {
+            createDirectory : false
+        };
+        processFileToDisk(gltfPath, outputGltfPath, options, function() {
+            expect(path.normalize(spy.calls.first().args[0])).toEqual(path.normalize(outputGltfPath));
             done();
         });
     });
@@ -91,10 +94,11 @@ describe('gltfPipeline', function() {
             callback();
         });
         var options = {
-            binary : true
+            binary : true,
+            createDirectory : false
         };
-        processFileToDisk(gltfPath, outputPath, options, function() {
-            expect(path.normalize(spy.calls.first().args[0])).toEqual(path.normalize('output/output.glb'));
+        processFileToDisk(gltfPath, outputGlbPath, options, function() {
+            expect(path.normalize(spy.calls.first().args[0])).toEqual(path.normalize(outputGlbPath));
             done();
         });
     });
@@ -104,12 +108,12 @@ describe('gltfPipeline', function() {
             callback();
         });
         var options = {
-            createDirectory : false
+            createDirectory : false,
+            basePath : path.dirname(gltfPath)
         };
         readGltf(gltfPath, options, function(gltf) {
-            var options = { basePath : path.dirname(gltfPath) };
-            processJSONToDisk(gltf, outputPath, options, function() {
-                expect(path.normalize(spy.calls.first().args[0])).toEqual(path.normalize('output/output'));
+            processJSONToDisk(gltf, outputGltfPath, options, function() {
+                expect(path.normalize(spy.calls.first().args[0])).toEqual(path.normalize(outputGltfPath));
                 done();
             });
         });


### PR DESCRIPTION
When loading binary and exporting as non-binary, the output extension was still .glb. This PR forces the output extension to be .gltf. I also cleaned up some of the paths for the `gltfPipeline` tests.

@lasalvavida Take a look when you have a chance.