### PR TITLE
Support exporting binary gltf with separate resources.

### DIFF
--- a/bin/gltf-pipeline.js
+++ b/bin/gltf-pipeline.js
@@ -28,16 +28,17 @@ var separateImage = defaultValue(defaultValue(argv.t, argv.separateImage), false
 var quantize = defaultValue(defaultValue(argv.q, argv.quantize), false);
 
 if (!defined(outputPath)) {
-    var fileExtension;
+    var outputFileExtension;
     if (binary) {
-        fileExtension = '.glb';
+        outputFileExtension = '.glb';
     } else {
-        fileExtension = path.extname(gltfPath);
+        outputFileExtension = '.gltf';
     }
+    var fileExtension = path.extname(gltfPath);
     var fileName = path.basename(gltfPath, fileExtension);
     var filePath = path.dirname(gltfPath);
     // Default output.  For example, path/asset.gltf becomes path/asset-optimized.gltf
-    outputPath = path.join(filePath, fileName + '-optimized' + fileExtension);
+    outputPath = path.join(filePath, fileName + '-optimized' + outputFileExtension);
 }
 
 var options = {

--- a/lib/getBinaryGltf.js
+++ b/lib/getBinaryGltf.js
@@ -9,7 +9,7 @@ var removePipelineExtras = require('./removePipelineExtras');
 
 module.exports = getBinaryGltf;
 
-//Update object with KHR_binary_glTF properties and add to body and bufferViews
+// Update object with KHR_binary_glTF properties and add to body and bufferViews
 function updateBinaryObject(gltf, pipelineExtras, name, state) {
     var bufferViews = gltf.bufferViews;
     var objects = gltf[name];
@@ -56,8 +56,8 @@ function updateBinaryObject(gltf, pipelineExtras, name, state) {
     }
 }
 
-function getBinaryGltf(gltf, callback) {
-    //Create the special binary buffer from the existing buffers
+function getBinaryGltf(gltf, embed, embedImage, callback) {
+    // Create the special binary buffer from the existing buffers
     gltf.bufferViews = defaultValue(gltf.bufferViews, {});
     gltf.buffers = defaultValue(gltf.buffers, {});
     mergeBuffers(gltf, 'binary_glTF');
@@ -70,16 +70,20 @@ function getBinaryGltf(gltf, callback) {
         currentBinaryView : 0
     };
 
-    updateBinaryObject(gltf, pipelineExtras, 'shaders', state);
-    updateBinaryObject(gltf, pipelineExtras, 'images', state);
+    if (embed) {
+        updateBinaryObject(gltf, pipelineExtras, 'shaders', state);
+    }
+    if (embedImage) {
+        updateBinaryObject(gltf, pipelineExtras, 'images', state);
+    }
 
     var body = buffers.binary_glTF.extras._pipeline.source;
     buffers.binary_glTF.byteLength = state.offset;
 
-    //Remove extras objects before writing
+    // Remove extras objects before writing
     removePipelineExtras(gltf);
 
-    //Create padded binary scene string and calculate total length
+    // Create padded binary scene string and calculate total length
     var sceneString = JSON.stringify(gltf);
     var sceneLength = Buffer.byteLength(sceneString);
     sceneLength += 4 - (sceneLength % 4);
@@ -88,7 +92,7 @@ function getBinaryGltf(gltf, callback) {
     var bodyOffset = 20 + sceneLength;
     var glbLength = bodyOffset + body.length;
 
-    //Write binary glTF header (magic, version, length, sceneLength, sceneFormat)
+    // Write binary glTF header (magic, version, length, sceneLength, sceneFormat)
     var header = new Buffer(20);
     header.write('glTF', 0);
     header.writeUInt32LE(1, 4);
@@ -96,7 +100,7 @@ function getBinaryGltf(gltf, callback) {
     header.writeUInt32LE(sceneLength, 12);
     header.writeUInt32LE(0, 16);
 
-    //Create scene buffer and overall buffer
+    // Create scene buffer and overall buffer
     var scene = new Buffer(sceneString);
     var glb = Buffer.concat([header, scene, body], glbLength);
     

--- a/lib/gltfPipeline.js
+++ b/lib/gltfPipeline.js
@@ -101,7 +101,7 @@ function writeFile(gltf, outputPath, options, callback) {
     var embedImage = defaultValue(options.embedImage, true);
     var createDirectory = defaultValue(options.createDirectory, true);
     if (binary) {
-        writeBinaryGltf(gltf, outputPath, createDirectory, callback);
+        writeBinaryGltf(gltf, outputPath, embed, embedImage, createDirectory, callback);
     } else {
         writeGltf(gltf, outputPath, embed, embedImage, createDirectory, callback);
     }

--- a/lib/gltfPipeline.js
+++ b/lib/gltfPipeline.js
@@ -1,5 +1,6 @@
 'use strict';
 var async = require('async');
+var path = require('path');
 var addDefaults = require('./addDefaults');
 var addPipelineExtras = require('./addPipelineExtras');
 var removeUnused = require('./removeUnused');
@@ -96,11 +97,12 @@ function processFile(inputPath, options, callback) {
 }
 
 function writeFile(gltf, outputPath, options, callback) {
+    var fileExtension = path.extname(outputPath);
     var binary = defaultValue(options.binary, false);
     var embed = defaultValue(options.embed, true);
     var embedImage = defaultValue(options.embedImage, true);
     var createDirectory = defaultValue(options.createDirectory, true);
-    if (binary) {
+    if (binary || fileExtension === '.glb') {
         writeBinaryGltf(gltf, {
             outputPath : outputPath,
             embed : embed,

--- a/lib/gltfPipeline.js
+++ b/lib/gltfPipeline.js
@@ -1,6 +1,5 @@
 'use strict';
 var async = require('async');
-var path = require('path');
 var addDefaults = require('./addDefaults');
 var addPipelineExtras = require('./addPipelineExtras');
 var removeUnused = require('./removeUnused');
@@ -97,14 +96,12 @@ function processFile(inputPath, options, callback) {
 }
 
 function writeFile(gltf, outputPath, options, callback) {
-    var fileExtension = path.extname(outputPath);
     var binary = defaultValue(options.binary, false);
     var embed = defaultValue(options.embed, true);
     var embedImage = defaultValue(options.embedImage, true);
     var createDirectory = defaultValue(options.createDirectory, true);
     if (binary) {
-        writeBinaryGltf({
-            gltf : gltf,
+        writeBinaryGltf(gltf, {
             outputPath : outputPath,
             embed : embed,
             embedImage : embedImage,

--- a/lib/gltfPipeline.js
+++ b/lib/gltfPipeline.js
@@ -101,7 +101,13 @@ function writeFile(gltf, outputPath, options, callback) {
     var embedImage = defaultValue(options.embedImage, true);
     var createDirectory = defaultValue(options.createDirectory, true);
     if (binary) {
-        writeBinaryGltf(gltf, outputPath, embed, embedImage, createDirectory, callback);
+        writeBinaryGltf({
+            gltf : gltf,
+            outputPath : outputPath,
+            embed : embed,
+            embedImage : embedImage,
+            createDirectory : createDirectory
+        }, callback);
     } else {
         writeGltf(gltf, outputPath, embed, embedImage, createDirectory, callback);
     }

--- a/lib/writeBinaryGltf.js
+++ b/lib/writeBinaryGltf.js
@@ -32,7 +32,6 @@ function writeBinaryGltf(gltf, outputPath, embed, embedImage, createDirectory, c
                 throw err;
             }
         } else {
-
             var glb = getBinaryGltf(gltf, embed, embedImage, function (header, scene, body) {
                 fs.writeFile(outputPath, glb, function (err) {
                     if (err) {

--- a/lib/writeBinaryGltf.js
+++ b/lib/writeBinaryGltf.js
@@ -5,21 +5,27 @@ var async = require('async');
 var mkdirp = require('mkdirp');
 var getBinaryGltf = require('./getBinaryGltf');
 var writeSource = require('./writeSource');
+var Cesium = require('cesium');
+var defined = Cesium.defined;
+var DeveloperError = Cesium.DeveloperError;
 
 module.exports = writeBinaryGltf;
 
-function writeBinaryGltf(options, callback) {
-    var gltf = options.gltf;
+function writeBinaryGltf(gltf, options, callback) {
     var outputPath = options.outputPath;
     var embed = options.embed;
     var embedImage = options.embedImage;
     var createDirectory = options.createDirectory;
 
-    // Correct output path extension if necessary
+    if (!defined(outputPath)) {
+        throw new DeveloperError('Output path is undefined.');
+    }
+    
     var outputExtension = path.extname(outputPath);
     if (outputExtension !== '.glb') {
         throw new DeveloperError('Invalid output path extension.');
     }
+    
     // Create the output directory if specified
     if (createDirectory) {
         outputPath = path.join(path.dirname(outputPath), 'output', path.basename(outputPath));

--- a/lib/writeBinaryGltf.js
+++ b/lib/writeBinaryGltf.js
@@ -5,7 +5,6 @@ var async = require('async');
 var mkdirp = require('mkdirp');
 var getBinaryGltf = require('./getBinaryGltf');
 var writeSource = require('./writeSource');
-var removePipelineExtras = require('./removePipelineExtras');
 
 module.exports = writeBinaryGltf;
 

--- a/lib/writeBinaryGltf.js
+++ b/lib/writeBinaryGltf.js
@@ -8,7 +8,13 @@ var writeSource = require('./writeSource');
 
 module.exports = writeBinaryGltf;
 
-function writeBinaryGltf(gltf, outputPath, embed, embedImage, createDirectory, callback) {
+function writeBinaryGltf(options, callback) {
+    var gltf = options.gltf;
+    var outputPath = options.outputPath;
+    var embed = options.embed;
+    var embedImage = options.embedImage;
+    var createDirectory = options.createDirectory;
+
     // Correct output path extension if necessary
     var outputExtension = path.extname(outputPath);
     if (outputExtension !== '.glb') {

--- a/lib/writeBinaryGltf.js
+++ b/lib/writeBinaryGltf.js
@@ -22,8 +22,6 @@ function writeBinaryGltf(gltf, outputPath, embed, embedImage, createDirectory, c
     mkdirp.sync(path.dirname(outputPath));
 
     var basePath = path.dirname(outputPath);
-
-
     async.each(['buffers', 'images', 'shaders'], function (name, asyncCallback) {
         writeSource(gltf, basePath, name, embed, embedImage, asyncCallback);
     }, function (err) {

--- a/lib/writeBinaryGltf.js
+++ b/lib/writeBinaryGltf.js
@@ -22,7 +22,7 @@ function writeBinaryGltf(gltf, outputPath, embed, embedImage, createDirectory, c
     mkdirp.sync(path.dirname(outputPath));
 
     var basePath = path.dirname(outputPath);
-    async.each(['buffers', 'images', 'shaders'], function (name, asyncCallback) {
+    async.each(['images', 'shaders'], function (name, asyncCallback) {
         writeSource(gltf, basePath, name, embed, embedImage, asyncCallback);
     }, function (err) {
         if (err) {
@@ -32,7 +32,8 @@ function writeBinaryGltf(gltf, outputPath, embed, embedImage, createDirectory, c
                 throw err;
             }
         } else {
-            var glb = getBinaryGltf(gltf, function (header, scene, body) {
+
+            var glb = getBinaryGltf(gltf, embed, embedImage, function (header, scene, body) {
                 fs.writeFile(outputPath, glb, function (err) {
                     if (err) {
                         if (callback) {

--- a/lib/writeBinaryGltf.js
+++ b/lib/writeBinaryGltf.js
@@ -1,12 +1,15 @@
 'use strict';
 var fs = require('fs');
 var path = require('path');
+var async = require('async');
 var mkdirp = require('mkdirp');
 var getBinaryGltf = require('./getBinaryGltf');
+var writeSource = require('./writeSource');
+var removePipelineExtras = require('./removePipelineExtras');
 
 module.exports = writeBinaryGltf;
 
-function writeBinaryGltf(gltf, outputPath, createDirectory, callback) {
+function writeBinaryGltf(gltf, outputPath, embed, embedImage, createDirectory, callback) {
     // Correct output path extension if necessary
     var outputExtension = path.extname(outputPath);
     if (outputExtension !== '.glb') {
@@ -18,17 +21,32 @@ function writeBinaryGltf(gltf, outputPath, createDirectory, callback) {
     }
     mkdirp.sync(path.dirname(outputPath));
 
-    var glb = getBinaryGltf(gltf, function(header, scene, body) {
-        fs.writeFile(outputPath, glb, function (err) {
-            if (err) {
-                if (callback) {
-                    callback(err);
-                } else {
-                    throw err;
-                }
-            } else if (callback) {
-                callback(undefined, header, scene, body);
+    var basePath = path.dirname(outputPath);
+
+
+    async.each(['buffers', 'images', 'shaders'], function (name, asyncCallback) {
+        writeSource(gltf, basePath, name, embed, embedImage, asyncCallback);
+    }, function (err) {
+        if (err) {
+            if (callback) {
+                callback(err);
+            } else {
+                throw err;
             }
-        });
+        } else {
+            var glb = getBinaryGltf(gltf, function (header, scene, body) {
+                fs.writeFile(outputPath, glb, function (err) {
+                    if (err) {
+                        if (callback) {
+                            callback(err);
+                        } else {
+                            throw err;
+                        }
+                    } else if (callback) {
+                        callback(undefined, header, scene, body);
+                    }
+                });
+            });
+        }
     });
 }

--- a/specs/lib/gltfPipelineSpec.js
+++ b/specs/lib/gltfPipelineSpec.js
@@ -10,7 +10,6 @@ var processFileToDisk = gltfPipeline.processFileToDisk;
 var readGltf = require('../../lib/readGltf');
 var removePipelineExtras = require('../../lib/removePipelineExtras');
 var addPipelineExtras = require('../../lib/addPipelineExtras');
-var writeBinaryGltf = require('../../lib/writeBinaryGltf');
 var writeSource = require('../../lib/writeSource');
 var writeGltf = require('../../lib/writeGltf');
 

--- a/specs/lib/writeBinaryGltfSpec.js
+++ b/specs/lib/writeBinaryGltfSpec.js
@@ -17,12 +17,12 @@ var vertexShaderPath = './specs/data/boxTexturedUnoptimized/CesiumTexturedBoxTes
 
 describe('writeBinaryGltf', function() {
     var testData = {
-        gltf: gltfPath,
-        scene: scenePath,
-        image: imagePath,
-        buffer: bufferPath,
-        fragmentShader: fragmentShaderPath,
-        vertexShader: vertexShaderPath
+        gltf : gltfPath,
+        scene : scenePath,
+        image : imagePath,
+        buffer : bufferPath,
+        fragmentShader : fragmentShaderPath,
+        vertexShader : vertexShaderPath
     };
 
     beforeAll(function(done) {
@@ -31,7 +31,7 @@ describe('writeBinaryGltf', function() {
                 throw err;
             }
             var options = {
-                basePath: path.dirname(gltfPath)
+                basePath : path.dirname(gltfPath)
             };
 
             loadGltfUris(removeUnused(JSON.parse(data)), options, function(err, gltf) {
@@ -69,25 +69,90 @@ describe('writeBinaryGltf', function() {
     });
 
     it('writes a valid binary gltf header', function() {
-        writeBinaryGltf(clone(testData.gltf), outputPath, true, true, true, function(err, header, scene, body) {
+        writeBinaryGltf({
+            gltf : clone(testData.gltf),
+            outputPath : outputPath,
+            embed : true,
+            embedImage : true,
+            createDirectory : true
+        }, function(err, header, scene, body) {
             expect(header.toString('utf8', 0, 4)).toEqual('glTF');
             expect(header.readUInt32LE(4)).toEqual(1);
             expect(header.readUInt32LE(8)).toEqual(17706);
             expect(header.readUInt32LE(12)).toEqual(3896);
             expect(header.readUInt32LE(16)).toEqual(0);
         });
+
+        writeBinaryGltf({
+            gltf : clone(testData.gltf),
+            outputPath : outputPath,
+            embed : false,
+            embedImage : false,
+            createDirectory : true
+        }, function(err, header, scene, body) {
+            expect(header.toString('utf8', 0, 4)).toEqual('glTF');
+            expect(header.readUInt32LE(4)).toEqual(1);
+            expect(header.readUInt32LE(8)).toEqual(4308);
+            expect(header.readUInt32LE(12)).toEqual(3448);
+            expect(header.readUInt32LE(16)).toEqual(0);
+        });
     });
 
     it('writes the correct binary scene', function() {
-        writeBinaryGltf(clone(testData.gltf), outputPath, true, true, true, function(err, header, scene, body) {
+        writeBinaryGltf({
+            gltf : clone(testData.gltf),
+            outputPath : outputPath,
+            embed : true,
+            embedImage : true,
+            createDirectory : true
+        }, function(err, header, scene, body) {
             expect(JSON.parse(scene.toString())).toEqual(testData.scene);
         });
     });
 
     it('writes the correct binary body', function() {
-        writeBinaryGltf(clone(testData.gltf), outputPath, true, true, true, function(err, header, scene, body) {
+        writeBinaryGltf({
+            gltf : clone(testData.gltf),
+            outputPath : outputPath,
+            embed : true,
+            embedImage : true,
+            createDirectory : true
+        }, function(err, header, scene, body) {
             var binaryBody = Buffer.concat([testData.buffer, testData.fragmentShader, testData.vertexShader, testData.image]);
             expect(bufferEqual(binaryBody, body)).toBe(true);
-        })
+        });
+
+        writeBinaryGltf({
+            gltf : clone(testData.gltf),
+            outputPath : outputPath,
+            embed : true,
+            embedImage : false,
+            createDirectory : true
+        }, function(err, header, scene, body) {
+            var binaryBody = Buffer.concat([testData.buffer, testData.fragmentShader, testData.vertexShader]);
+            expect(bufferEqual(binaryBody, body)).toBe(true);
+        });
+
+        writeBinaryGltf({
+            gltf : clone(testData.gltf),
+            outputPath : outputPath,
+            embed : false,
+            embedImage : true,
+            createDirectory : true
+        }, function(err, header, scene, body) {
+            var binaryBody = Buffer.concat([testData.buffer, testData.image]);
+            expect(bufferEqual(binaryBody, body)).toBe(true);
+        });
+
+        writeBinaryGltf({
+            gltf : clone(testData.gltf),
+            outputPath : outputPath,
+            embed : false,
+            embedImage : false,
+            createDirectory : true
+        }, function(err, header, scene, body) {
+            var binaryBody = testData.buffer;
+            expect(bufferEqual(binaryBody, body)).toBe(true);
+        });
     });
 });

--- a/specs/lib/writeBinaryGltfSpec.js
+++ b/specs/lib/writeBinaryGltfSpec.js
@@ -69,7 +69,7 @@ describe('writeBinaryGltf', function() {
     });
 
     it('writes a valid binary gltf header', function() {
-        writeBinaryGltf(clone(testData.gltf), outputPath, true, function(err, header, scene, body) {
+        writeBinaryGltf(clone(testData.gltf), outputPath, true, true, true, function(err, header, scene, body) {
             expect(header.toString('utf8', 0, 4)).toEqual('glTF');
             expect(header.readUInt32LE(4)).toEqual(1);
             expect(header.readUInt32LE(8)).toEqual(17706);
@@ -79,13 +79,13 @@ describe('writeBinaryGltf', function() {
     });
 
     it('writes the correct binary scene', function() {
-        writeBinaryGltf(clone(testData.gltf), outputPath, true, function(err, header, scene, body) {
+        writeBinaryGltf(clone(testData.gltf), outputPath, true, true, true, function(err, header, scene, body) {
             expect(JSON.parse(scene.toString())).toEqual(testData.scene);
         });
     });
 
     it('writes the correct binary body', function() {
-        writeBinaryGltf(clone(testData.gltf), outputPath, true, function(err, header, scene, body) {
+        writeBinaryGltf(clone(testData.gltf), outputPath, true, true, true, function(err, header, scene, body) {
             var binaryBody = Buffer.concat([testData.buffer, testData.fragmentShader, testData.vertexShader, testData.image]);
             expect(bufferEqual(binaryBody, body)).toBe(true);
         })

--- a/specs/lib/writeBinaryGltfSpec.js
+++ b/specs/lib/writeBinaryGltfSpec.js
@@ -70,8 +70,7 @@ describe('writeBinaryGltf', function() {
     });
 
     it('writes a valid binary gltf header', function() {
-        writeBinaryGltf({
-            gltf : clone(testData.gltf),
+        writeBinaryGltf(clone(testData.gltf), {
             outputPath : outputPath,
             embed : true,
             embedImage : true,
@@ -84,8 +83,7 @@ describe('writeBinaryGltf', function() {
             expect(header.readUInt32LE(16)).toEqual(0);
         });
 
-        writeBinaryGltf({
-            gltf : clone(testData.gltf),
+        writeBinaryGltf(clone(testData.gltf), {
             outputPath : outputPath,
             embed : false,
             embedImage : false,
@@ -100,8 +98,7 @@ describe('writeBinaryGltf', function() {
     });
 
     it('writes the correct binary scene', function() {
-        writeBinaryGltf({
-            gltf : clone(testData.gltf),
+        writeBinaryGltf(clone(testData.gltf), {
             outputPath : outputPath,
             embed : true,
             embedImage : true,
@@ -112,8 +109,7 @@ describe('writeBinaryGltf', function() {
     });
 
     it('writes the correct binary body', function() {
-        writeBinaryGltf({
-            gltf : clone(testData.gltf),
+        writeBinaryGltf(clone(testData.gltf), {
             outputPath : outputPath,
             embed : true,
             embedImage : true,
@@ -123,8 +119,7 @@ describe('writeBinaryGltf', function() {
             expect(bufferEqual(binaryBody, body)).toBe(true);
         });
 
-        writeBinaryGltf({
-            gltf : clone(testData.gltf),
+        writeBinaryGltf(clone(testData.gltf), {
             outputPath : outputPath,
             embed : true,
             embedImage : false,
@@ -134,8 +129,7 @@ describe('writeBinaryGltf', function() {
             expect(bufferEqual(binaryBody, body)).toBe(true);
         });
 
-        writeBinaryGltf({
-            gltf : clone(testData.gltf),
+        writeBinaryGltf(clone(testData.gltf), {
             outputPath : outputPath,
             embed : false,
             embedImage : true,
@@ -145,8 +139,7 @@ describe('writeBinaryGltf', function() {
             expect(bufferEqual(binaryBody, body)).toBe(true);
         });
 
-        writeBinaryGltf({
-            gltf : clone(testData.gltf),
+        writeBinaryGltf(clone(testData.gltf), {
             outputPath : outputPath,
             embed : false,
             embedImage : false,
@@ -159,13 +152,17 @@ describe('writeBinaryGltf', function() {
     
     it('throws an invalid output path error', function() {
         expect(function() {
-            writeBinaryGltf(clone(testData.gltf), undefined, true);
+            writeBinaryGltf(clone(testData.gltf), {
+                outputPath : undefined
+            }, true);
         }).toThrowError('Output path is undefined.');
     });
     
     it('throws an invalid output extension error', function() {
         expect(function() {
-            writeBinaryGltf(clone(testData.gltf), invalidPath, true);
+            writeBinaryGltf(clone(testData.gltf), {
+                outputPath : invalidPath
+            }, true);
         }).toThrowError('Invalid output path extension.');
     });
 });


### PR DESCRIPTION
As discussed with @lilleyse, I've added code to allow exporting non-embedded .glb files. 
There does not seem to be an issue open for this, nor do I know why anyone would ever want to write a glb with non-embedded resources, but at the very least this removes any possible ambiguity with our command line flags.


Edit: This is, however, noted in the roadmap #1 