### PR TITLE
Output correct glTF type based on extension

### DIFF
--- a/bin/gltf-pipeline.js
+++ b/bin/gltf-pipeline.js
@@ -27,6 +27,7 @@ var fileName = path.basename(gltfPath, fileExtension);
 var filePath = path.dirname(gltfPath);
 
 var outputPath = defaultValue(argv._[1], defaultValue(argv.o, argv.output));
+var outputExtension = path.extname(outputPath);
 var binary = defaultValue(defaultValue(argv.b, argv.binary), false);
 var separate = defaultValue(defaultValue(argv.s, argv.separate), false);
 var separateImage = defaultValue(defaultValue(argv.t, argv.separateImage), false);
@@ -38,6 +39,10 @@ if (!defined(gltfPath)) {
 
 if (fileExtension !== '.glb' && fileExtension !== '.gltf') {
     throw new DeveloperError('Invalid glTF file.');
+}
+
+if (outputExtension !== '.gltf' && outputExtension !== '.glb' || binary && outputExtension !== '.glb') {
+    throw new DeveloperError('Invalid output path extension.');
 }
 
 if (!defined(outputPath)) {

--- a/bin/gltf-pipeline.js
+++ b/bin/gltf-pipeline.js
@@ -4,7 +4,6 @@ var path = require('path');
 var Cesium = require('cesium');
 var defaultValue = Cesium.defaultValue;
 var defined = Cesium.defined;
-var DeveloperError = Cesium.DeveloperError;
 var gltfPipeline = require('../lib/gltfPipeline');
 var processFileToDisk = gltfPipeline.processFileToDisk;
 
@@ -22,30 +21,21 @@ if (process.argv.length < 3 || defined(argv.h) || defined(argv.help)) {
 }
 
 var gltfPath = defaultValue(argv._[0], defaultValue(argv.i, argv.input));
-var fileExtension = path.extname(gltfPath);
-var fileName = path.basename(gltfPath, fileExtension);
-var filePath = path.dirname(gltfPath);
-
 var outputPath = defaultValue(argv._[1], defaultValue(argv.o, argv.output));
-var outputExtension = path.extname(outputPath);
 var binary = defaultValue(defaultValue(argv.b, argv.binary), false);
 var separate = defaultValue(defaultValue(argv.s, argv.separate), false);
 var separateImage = defaultValue(defaultValue(argv.t, argv.separateImage), false);
 var quantize = defaultValue(defaultValue(argv.q, argv.quantize), false);
 
-if (!defined(gltfPath)) {
-    throw new DeveloperError('Input path is undefined.');
-}
-
-if (fileExtension !== '.glb' && fileExtension !== '.gltf') {
-    throw new DeveloperError('Invalid glTF file.');
-}
-
-if (outputExtension !== '.gltf' && outputExtension !== '.glb' || binary && outputExtension !== '.glb') {
-    throw new DeveloperError('Invalid output path extension.');
-}
-
 if (!defined(outputPath)) {
+    var fileExtension;
+    if (binary) {
+        fileExtension = '.glb';
+    } else {
+        fileExtension = path.extname(gltfPath);
+    }
+    var fileName = path.basename(gltfPath, fileExtension);
+    var filePath = path.dirname(gltfPath);
     // Default output.  For example, path/asset.gltf becomes path/asset-optimized.gltf
     outputPath = path.join(filePath, fileName + '-optimized' + fileExtension);
 }

--- a/lib/gltfPipeline.js
+++ b/lib/gltfPipeline.js
@@ -1,5 +1,6 @@
 'use strict';
 var async = require('async');
+var path = require('path');
 var addDefaults = require('./addDefaults');
 var addPipelineExtras = require('./addPipelineExtras');
 var removeUnused = require('./removeUnused');
@@ -96,11 +97,12 @@ function processFile(inputPath, options, callback) {
 }
 
 function writeFile(gltf, outputPath, options, callback) {
+    var fileExtension = path.extname(outputPath);
     var binary = defaultValue(options.binary, false);
     var embed = defaultValue(options.embed, true);
     var embedImage = defaultValue(options.embedImage, true);
     var createDirectory = defaultValue(options.createDirectory, true);
-    if (binary) {
+    if (binary || fileExtension === '.glb') {
         writeBinaryGltf(gltf, outputPath, createDirectory, callback);
     } else {
         writeGltf(gltf, outputPath, embed, embedImage, createDirectory, callback);

--- a/lib/writeBinaryGltf.js
+++ b/lib/writeBinaryGltf.js
@@ -3,14 +3,20 @@ var fs = require('fs');
 var path = require('path');
 var mkdirp = require('mkdirp');
 var getBinaryGltf = require('./getBinaryGltf');
+var Cesium = require('cesium');
+var defined = Cesium.defined;
+var DeveloperError = Cesium.DeveloperError;
 
 module.exports = writeBinaryGltf;
 
 function writeBinaryGltf(gltf, outputPath, createDirectory, callback) {
-    // Correct output path extension if necessary
+    if (!defined(outputPath)) {
+        throw new DeveloperError('Output path is undefined.');
+    }
+    
     var outputExtension = path.extname(outputPath);
     if (outputExtension !== '.glb') {
-        outputPath = path.join(path.dirname(outputPath), path.basename(outputPath, outputExtension) + '.glb');
+        throw new DeveloperError('Invalid output path extension.');
     }
     // Create the output directory if specified
     if (createDirectory) {

--- a/lib/writeGltf.js
+++ b/lib/writeGltf.js
@@ -5,14 +5,20 @@ var async = require('async');
 var mkdirp = require('mkdirp');
 var writeSource = require('./writeSource');
 var removePipelineExtras = require('./removePipelineExtras');
+var Cesium = require('cesium');
+var defined = Cesium.defined;
+var DeveloperError = Cesium.DeveloperError;
 
 module.exports = writeGltf;
 
 function writeGltf(gltf, outputPath, embed, embedImage, createDirectory, callback) {
-    // Correct output path extension if necessary
+    if (!defined(outputPath)) {
+        throw new DeveloperError('Output path is undefined.');
+    }
+
     var outputExtension = path.extname(outputPath);
     if (outputExtension !== '.gltf') {
-        outputPath = path.join(path.dirname(outputPath), path.basename(outputPath, outputExtension) + '.gltf');
+        throw new DeveloperError('Invalid output path extension.');
     }
     // Create the output directory if specified
     if (createDirectory) {

--- a/specs/lib/writeBinaryGltfSpec.js
+++ b/specs/lib/writeBinaryGltfSpec.js
@@ -14,6 +14,7 @@ var bufferPath = './specs/data/boxTexturedUnoptimized/CesiumTexturedBoxTest.bin'
 var imagePath = './specs/data/boxTexturedUnoptimized/Cesium_Logo_Flat_Binary.png';
 var fragmentShaderPath = './specs/data/boxTexturedUnoptimized/CesiumTexturedBoxTest0FS_Binary.glsl';
 var vertexShaderPath = './specs/data/boxTexturedUnoptimized/CesiumTexturedBoxTest0VS_Binary.glsl';
+var invalidPath = './specs/data/boxTexturedUnoptimized/CesiumTexturedBoxTest.gltf';
 
 describe('writeBinaryGltf', function() {
     var testData = {
@@ -89,5 +90,17 @@ describe('writeBinaryGltf', function() {
             var binaryBody = Buffer.concat([testData.buffer, testData.fragmentShader, testData.vertexShader, testData.image]);
             expect(bufferEqual(binaryBody, body)).toBe(true);
         })
+    });
+    
+    it('throws an invalid output path error', function() {
+        expect(function() {
+            writeBinaryGltf(clone(testData.gltf), undefined, true);
+        }).toThrowError('Output path is undefined.');
+    });
+    
+    it('throws an invalid output extension error', function() {
+        expect(function() {
+            writeBinaryGltf(clone(testData.gltf), invalidPath, true);
+        }).toThrowError('Invalid output path extension.');
     });
 });

--- a/specs/lib/writeGltfSpec.js
+++ b/specs/lib/writeGltfSpec.js
@@ -1,0 +1,41 @@
+'use strict';
+var fs = require('fs');
+var path = require('path');
+var writeGltf = require('../../lib/writeGltf');
+var readGltf = require('../../lib/readGltf');
+
+var gltfPath = './specs/data/boxTexturedUnoptimized/CesiumTexturedBoxTest_BinaryInput.gltf';
+var outputGltfPath = './output/CesiumTexturedBoxTest.gltf';
+var invalidPath = './specs/data/boxTexturedUnoptimized/CesiumTexturedBoxTest.exe';
+
+describe('writeGltf', function() {
+    it('will write a file to the correct directory', function(done) {
+        var spy = spyOn(fs, 'writeFile').and.callFake(function(file, data, callback) {
+            callback();
+        });
+        
+        writeGltf(gltfPath, outputGltfPath, true, true, false, function() {
+            expect(path.normalize(spy.calls.first().args[0])).toEqual(path.normalize(outputGltfPath));
+        });
+        done();
+    });
+
+    it('throws an invalid output path error', function() {
+        var options = {};
+        readGltf(gltfPath, options, function(gltf) {
+            expect(function() {
+                writeGltf(gltf, undefined, true, true, true);
+            }).toThrowError('Output path is undefined.');
+        });
+    });
+
+    it('throws an invalid output extension error', function() {
+        var options = {};
+        readGltf(gltfPath, options, function(gltf) {
+            expect(function() {
+                writeGltf(gltf, invalidPath, true, true, true);
+            }).toThrowError('Invalid output path extension.');
+        });
+    });
+
+});


### PR DESCRIPTION
See #116 

Also added a `DeveloperError` to be thrown if output path given has neither `.glb` or `.gltf` file extensions.