### PR TITLE
Ceil instead of rounding

### DIFF
--- a/lib/quantizeAttributes.js
+++ b/lib/quantizeAttributes.js
@@ -118,7 +118,7 @@ function quantizeAttributes(gltf, options) {
             for (i = offset; num < count; i+=byteStride) {
                 for (var j = 0; j < numberOfComponents; j++) {
                     value = source.readFloatLE(i + j * componentByteLength);
-                    var encoded = Math.round((value - min[j]) * range / (max[j] - min[j]));
+                    var encoded = Math.ceil((value - min[j]) * range / (max[j] - min[j]));
                     source.writeUInt16LE(encoded, i + j * 2);
                 }
                 num++;


### PR DESCRIPTION
When decoding something like a joint, it is used as an index in the shader, so always round up the encoded value.