### PR TITLE
Add --cesium flag for exporting a model with the Cesium sun as a light source

### DIFF
--- a/bin/gltf-pipeline.js
+++ b/bin/gltf-pipeline.js
@@ -17,7 +17,8 @@ if (process.argv.length < 3 || defined(argv.h) || defined(argv.help)) {
         '  -t --separateImage, write out separate textures, but embed geometry/animation data files, and shader files.\n' +
         '  -q --quantize, quantize the attributes of this model.\n' +
         '  -n --encodeNormals, oct-encode the normals of this model.\n' +
-        '  -c --compressTextureCoordinates, compress the texture coordinates of this model.\n';
+        '  -c --compressTextureCoordinates, compress the texture coordinates of this model.\n' +
+        '     --cesium, optimize the glTF for Cesium by using the sun as a default light source. \n';
     process.stdout.write(help);
     return;
 }
@@ -30,6 +31,7 @@ var separateImage = defaultValue(defaultValue(argv.t, argv.separateImage), false
 var quantize = defaultValue(defaultValue(argv.q, argv.quantize), false);
 var encodeNormals = defaultValue(defaultValue(argv.n, argv.encodeNormals), false);
 var compressTextureCoordinates = defaultValue(defaultValue(argv.c, argv.compressTextureCoordinates), false);
+var optimizeForCesium = defaultValue(argv.cesium, false);
 
 if (!defined(outputPath)) {
     var outputFileExtension;
@@ -51,7 +53,8 @@ var options = {
     embedImage : !separateImage,
     quantize : quantize,
     encodeNormals : encodeNormals,
-    compressTextureCoordinates : compressTextureCoordinates
+    compressTextureCoordinates : compressTextureCoordinates,
+    optimizeForCesium : optimizeForCesium
 };
 
 processFileToDisk(gltfPath, outputPath, options);

--- a/lib/addDefaults.js
+++ b/lib/addDefaults.js
@@ -540,6 +540,8 @@ function textureDefaults(gltf) {
 }
 
 function addDefaults(gltf, options) {
+    options = defaultValue(options, Cesium.defaultValue.EMPTY_OBJECT);
+
     if (!defined(gltf)) {
         return undefined;
     }

--- a/lib/addDefaults.js
+++ b/lib/addDefaults.js
@@ -544,14 +544,6 @@ function addDefaults(gltf, options) {
         return undefined;
     }
 
-    var defaultOptions = options;
-    if (!defined(options)) {
-        defaultOptions = {
-            specularTechnique: 'BLINN',
-            diffuseTechnique: 'LAMBERT'
-        };
-    }
-
     if (defined(gltf.allExtensions)) {
         gltf.extensionsUsed = gltf.allExtensions;
         gltf.allExtensions = undefined;
@@ -566,7 +558,7 @@ function addDefaults(gltf, options) {
     cameraDefaults(gltf);
     imageDefaults(gltf);
     lightDefaults(gltf);
-    materialDefaults(gltf, defaultOptions);
+    materialDefaults(gltf, options);
     meshDefaults(gltf);
     nodeDefaults(gltf);
     programDefaults(gltf);
@@ -577,7 +569,7 @@ function addDefaults(gltf, options) {
     techniqueDefaults(gltf);
     textureDefaults(gltf);
 
-    modelMaterialsCommon(gltf);
+    modelMaterialsCommon(gltf, options);
 
     return gltf;
 }

--- a/lib/gltfPipeline.js
+++ b/lib/gltfPipeline.js
@@ -59,7 +59,7 @@ function processJSON(gltf, options, callback) {
 
 function processJSONWithExtras(gltfWithExtras, options, callback) {
     var stats = new OptimizationStatistics();
-    addDefaults(gltfWithExtras, stats);
+    addDefaults(gltfWithExtras, options);
     removeUnused(gltfWithExtras, stats);
     if (options.printStats) {
         printStats(stats);

--- a/lib/modelMaterialsCommon.js
+++ b/lib/modelMaterialsCommon.js
@@ -155,7 +155,8 @@ var techniqueCount = 0;
 var vertexShaderCount = 0;
 var fragmentShaderCount = 0;
 var programCount = 0;
-function generateTechnique(gltf, khrMaterialsCommon, lightParameters) {
+
+function generateTechnique(gltf, khrMaterialsCommon, lightParameters, optimizeForCesium) {
     var techniques = gltf.techniques;
     var shaders = gltf.shaders;
     var programs = gltf.programs;
@@ -414,7 +415,11 @@ function generateTechnique(gltf, khrMaterialsCommon, lightParameters) {
     }
 
     if (!hasNonAmbientLights && (lightingModel !== 'CONSTANT')) {
-        fragmentLightingBlock += '  vec3 l = normalize(czm_sunDirectionEC);\n';
+        if (optimizeForCesium) {
+            fragmentLightingBlock += '  vec3 l = normalize(czm_sunDirectionEC);\n';
+        } else {
+            fragmentLightingBlock += '  vec3 l = vec3(0.0, 0.0, 1.0);\n';
+        }
         fragmentLightingBlock += '  diffuseLight += vec3(1.0, 1.0, 1.0) * max(dot(normal,l), 0.);\n';
 
         if (hasSpecular) {
@@ -653,7 +658,7 @@ function getTechniqueKey(khrMaterialsCommon) {
  *
  * @private
  */
-function modelMaterialsCommon(gltf) {
+function modelMaterialsCommon(gltf, options) {
     if (!defined(gltf)) {
         return undefined;
     }
@@ -694,7 +699,7 @@ function modelMaterialsCommon(gltf) {
                     var techniqueKey = getTechniqueKey(khrMaterialsCommon);
                     var technique = techniques[techniqueKey];
                     if (!defined(technique)) {
-                        technique = generateTechnique(gltf, khrMaterialsCommon, lightParameters);
+                        technique = generateTechnique(gltf, khrMaterialsCommon, lightParameters, options.optimizeForCesium);
                         techniques[techniqueKey] = technique;
                     }
 

--- a/specs/lib/addDefaultsSpec.js
+++ b/specs/lib/addDefaultsSpec.js
@@ -4,7 +4,6 @@ var addDefaults = require('../../lib/addDefaults');
 var Cesium = require('cesium');
 var clone = require('clone');
 var WebGLConstants = Cesium.WebGLConstants;
-var defined = Cesium.defined;
 
 describe('addDefaults', function() {
     it('Adds accessor properties', function() {
@@ -42,7 +41,7 @@ describe('addDefaults', function() {
                     ],
                     "parameters": {
                         "TIME": "timeAccessorId",
-                        "rotation": "rotationAccessorId",
+                        "rotation": "rotationAccessorId"
                     },
                     "samplers": {
                         "samplerId": {
@@ -178,23 +177,26 @@ describe('addDefaults', function() {
             diffuseTechnique: 'CONSTANT'
         };
 
+        var gltfClone;
+        var materialID;
+
         // default lambert
-        var gltfClone = clone(gltf);
+        gltfClone = clone(gltf);
         addDefaults(gltfClone);
         expect(Object.keys(gltfClone.materials).length > 0).toEqual(true);
         expect(Object.keys(gltfClone.techniques).length > 0).toEqual(true);
-        for (var materialID in gltfClone.materials) {
+        for (materialID in gltfClone.materials) {
             if (gltf.materials.hasOwnProperty(materialID)) {
                 expect(gltfClone.materials[materialID].values).toEqual(expectValues);
             }
         }
 
         // constant
-        var gltfClone = clone(gltf);
+        gltfClone = clone(gltf);
         addDefaults(gltfClone, options);
         expect(Object.keys(gltfClone.materials).length > 0).toEqual(true);
         expect(Object.keys(gltfClone.techniques).length > 0).toEqual(true);
-        for (var materialID in gltfClone.materials) {
+        for (materialID in gltfClone.materials) {
             if (gltf.materials.hasOwnProperty(materialID)) {
                 expect(gltfClone.materials[materialID].values).toEqual(expectValues);
             }
@@ -229,7 +231,7 @@ describe('addDefaults', function() {
         addDefaults(gltfClone);
         expect(Object.keys(gltfClone.materials).length > 0).toEqual(true);
         expect(Object.keys(gltfClone.techniques).length > 0).toEqual(true);
-        for (var materialID in gltfClone.materials) {
+        for (materialID in gltfClone.materials) {
             if (gltfClone.materials.hasOwnProperty(materialID)) {
                 expect(gltfClone.materials[materialID].values).toEqual(expectValues);
             }
@@ -240,7 +242,7 @@ describe('addDefaults', function() {
         addDefaults(gltfClone, options);
         expect(Object.keys(gltfClone.materials).length > 0).toEqual(true);
         expect(Object.keys(gltfClone.techniques).length > 0).toEqual(true);
-        for (var materialID in gltfClone.materials) {
+        for (materialID in gltfClone.materials) {
             if (gltf.materials.hasOwnProperty(materialID)) {
                 expect(gltfClone.materials[materialID].values).toEqual(expectValues);
             }
@@ -273,7 +275,7 @@ describe('addDefaults', function() {
                     "children": [],
                     "extensions": {
                         "KHR_materials_common": {
-                            "light": "ambientLight",
+                            "light": "ambientLight"
                         }
                     }
                 },
@@ -281,7 +283,7 @@ describe('addDefaults', function() {
                     "children": [],
                     "extensions": {
                         "KHR_materials_common": {
-                            "light": "directionalLight",
+                            "light": "directionalLight"
                         }
                     }
                 },
@@ -289,7 +291,7 @@ describe('addDefaults', function() {
                     "children": [],
                     "extensions": {
                         "KHR_materials_common": {
-                            "light": "pointLight",
+                            "light": "pointLight"
                         }
                     }
                 },
@@ -297,10 +299,10 @@ describe('addDefaults', function() {
                     "children": [],
                     "extensions": {
                         "KHR_materials_common": {
-                            "light": "spotLight",
+                            "light": "spotLight"
                         }
                     }
-                },
+                }
 
             },
             "extensionsUsed": [
@@ -383,6 +385,31 @@ describe('addDefaults', function() {
         }
     });
 
+    it('modelMaterialCommon uses the Cesium sun as its default light source when the optimizeForCesium flag is set', function() {
+        var gltf = {
+            "materials": {
+                "material1": {
+                    "values": {
+                        "ambient": [0, 0, 0, 1],
+                        "diffuse": "texture_file2",
+                        "emission": [1, 0, 0, 1]
+                    }
+                }
+            }
+        };
+
+        var gltfClone = clone(gltf);
+        addDefaults(gltfClone, {
+            optimizeForCesium : true
+        });
+        var fragmentShaderSource = gltfClone.shaders.fragmentShader0.extras._pipeline.source;
+        expect(fragmentShaderSource.indexOf('czm_sunDirectionEC') > -1).toBe(true);
+
+        gltfClone = clone(gltf);
+        addDefaults(gltfClone);
+        fragmentShaderSource = gltfClone.shaders.fragmentShader0.extras._pipeline.source;
+        expect(fragmentShaderSource.indexOf('czm_sunDirectionEC') > -1).toBe(false);
+    });
 
     it('Adds mesh properties', function() {
         var gltf = {


### PR DESCRIPTION
Fixes #114 

Added a command line flag `--cesium` for optimizing a model for use in Cesium. Right now this just means using `czm_sunDirectionEC` in the shader, but there could be other use cases for a having a Cesium-only pipeline. By default if a model does not have lights/shaders and goes through `modelMaterialCommon`, it will use a light source that is always pointing in the direction of the camera, which is the same behavior as COLLADA2GLTF. The images below show with the flag set vs. not set.

![capture3](https://cloud.githubusercontent.com/assets/915398/16593316/bc11047e-42b2-11e6-93b9-10e57605b6b1.JPG)
![capture4](https://cloud.githubusercontent.com/assets/915398/16593317/bc12eb04-42b2-11e6-84ac-7245769044dc.JPG)

