### PR TITLE
Adds _OCCLUSION to be excluded from quantization

### DIFF
--- a/lib/gltfPipeline.js
+++ b/lib/gltfPipeline.js
@@ -106,7 +106,10 @@ function processJSONWithExtras(gltfWithExtras, options, callback) {
         if (options.quantize) {
             var quantizedOptions = {
                 findMinMax : true,
-                exclude : ['JOINT']
+                exclude : [
+                    'JOINT',
+                    '_OCCLUSION'
+                ]
             };
             if (options.compressTextureCoordinates) {
                 quantizedOptions.exclude.push('TEXCOORD');


### PR DESCRIPTION
For #143. Even without the shader crash, there's some strange behavior when both are enabled. I suspect it's just too many cooks in the shader. Probably best to just keep them separate, at least for now.