### PR TITLE
Fix write source

### DIFF
--- a/lib/writeSource.js
+++ b/lib/writeSource.js
@@ -1,5 +1,5 @@
 'use strict';
-var fs = require('fs');
+var fsExtra = require('fs-extra');
 var path = require('path');
 var Cesium = require('cesium');
 var defined = Cesium.defined;
@@ -39,7 +39,7 @@ function writeSource(gltf, basePath, name, embed, embedImage, callback) {
                     var fileName = id + extension;
                     object.uri = fileName;
                     var outputPath = path.join(basePath, fileName);
-                    fs.writeFile(outputPath, source, function (err) {
+                    fsExtra.outputFile(outputPath, source, function (err) {
                         asyncCallback(err);
                     });  
                 }


### PR DESCRIPTION
This is fixed in https://github.com/AnalyticalGraphicsInc/gltf-pipeline/pull/135, but since we plan on releasing before then this change should be merged in.

When `-s` is supplied the `writeFile` fails when the output directory doesn't exist. I changed it to `outputFile`.