### PR TITLE
Change ceil back to round

### DIFF
--- a/lib/quantizeAttributes.js
+++ b/lib/quantizeAttributes.js
@@ -121,7 +121,7 @@ function quantizeAttributes(gltf, options) {
             var components = [];
             while (defined(accessorReader.read(components))) {
                 for (i = 0; i < numberOfComponents; i++) {
-                    components[i] = Math.ceil((components[i] - min[i]) * range / (max[i] - min[i]));
+                    components[i] = Math.round((components[i] - min[i]) * range / (max[i] - min[i]));
                 }
                 accessorReader.write(components, newComponentType);
                 accessorReader.next();

--- a/specs/lib/quantizeAttributesSpec.js
+++ b/specs/lib/quantizeAttributesSpec.js
@@ -71,6 +71,16 @@ describe('quantizeAttributes', function() {
                 min : [0],
                 max : [1],
                 type : 'SCALAR'
+            },
+            // floating-point rounding test
+            accessor_5 : {
+                bufferView : 'bufferView_2',
+                byteOffset : 0,
+                componentType : 5126,
+                count : 1,
+                min : [-82.39035034179688],
+                max : [0.0026710000820457935],
+                type : 'SCALAR'
             }
         },
         bufferViews : {
@@ -85,6 +95,12 @@ describe('quantizeAttributes', function() {
                 byteLength : 72,
                 byteOffset : 48,
                 target : 34962
+            },
+            bufferView_2 : {
+                buffer : 'buffer_float',
+                byteLength : 4,
+                byteOffset : 0,
+                target: 34962
             }
         },
         buffers : {
@@ -93,6 +109,15 @@ describe('quantizeAttributes', function() {
                 type : 'arraybuffer',
                 extras : {
                     _pipeline : {}
+                }
+            },
+            buffer_float : {
+                byteLength : 4,
+                type : 'array_buffer',
+                extras : {
+                    _pipeline : {
+                        source : new Buffer(new Float32Array([0.0026710000820457935]).buffer)
+                    }
                 }
             }
         },
@@ -111,6 +136,11 @@ describe('quantizeAttributes', function() {
                             TEXCOORD : 'accessor_3',
                             SCALAR_TEST : 'accessor_4'
                         }
+                    },
+                    {
+                        attributes : {
+                            FLOAT_TEST : 'accessor_5'
+                        }
                     }
                 ]
             }
@@ -127,7 +157,7 @@ describe('quantizeAttributes', function() {
     it('Doesn\'t quantize excluded semantics', function() {
         var gltf = clone(testGltf);
         gltf.buffers.buffer.extras._pipeline.source = buffer;
-        quantizeAttributes(gltf, {exclude: ['POSITION', 'NORMAL', 'TEXCOORD', 'SCALAR_TEST']});
+        quantizeAttributes(gltf, {exclude: ['POSITION', 'NORMAL', 'TEXCOORD', 'SCALAR_TEST', 'FLOAT_TEST']});
         expect(gltf.buffers.buffer.byteLength).toEqual(buffer.length);
     });
 


### PR DESCRIPTION
@lilleyse, we changed this before to make sure that rounding for integers went up for models with JOINT semantics. That is no longer an issue.

Currently if you run 2CylinderEngine through the pipeline with quantization, it tries to write 65536 to a uint16 buffer and crashes. This is because of a very minor floating point error that is solved by rounding instead.