### PR TITLE
Only compress accessors that use JOINT semantic

### DIFF
--- a/lib/compressIntegerAccessors.js
+++ b/lib/compressIntegerAccessors.js
@@ -62,7 +62,9 @@ function compressIntegerAccessors(gltf, options) {
 }
 
 function compressIntegerAccessor(gltf, primitive, accessorId, matchedSemantic) {
+    /* These callback parameters are unused */
     void(primitive, matchedSemantic);
+
     var accessors = gltf.accessors;
     var accessor = accessors[accessorId];
     var accessorReader = new AccessorReader(gltf, accessor);

--- a/lib/compressIntegerAccessors.js
+++ b/lib/compressIntegerAccessors.js
@@ -1,10 +1,14 @@
 'use strict';
 var Cesium = require('cesium');
+var Promise = require('bluebird');
+
 var WebGLConstants = Cesium.WebGLConstants;
 var defined = Cesium.defined;
+var defaultValue = Cesium.defaultValue;
 
 var AccessorReader = require('./AccessorReader');
 var findAccessorMinMax = require('./findAccessorMinMax');
+var getAccessorsForSemantic = require('./getAccessorsForSemantic');
 var uninterLeaveAndPackBuffers = require('./uninterleaveAndPackBuffers');
 
 module.exports = compressIntegerAccessors;
@@ -41,29 +45,40 @@ var unsignedComponentTypes = [
  * than necessary. The data is rewritten to the most optimal data type.
  *
  * @param {Object} gltf
+ * @param {Object} options
+ * @param {Array} options.semantics An array of semantics to compress
  */
-function compressIntegerAccessors(gltf) {
+function compressIntegerAccessors(gltf, options) {
+    var semantics = defaultValue(options.semantics, []);
+    var semanticsLength = semantics.length;
+    var promises = [];
+    for (var i = 0; i < semanticsLength; i++) {
+        var semantic = semantics[i];
+        promises.push(getAccessorsForSemantic(gltf, semantic, compressIntegerAccessor));
+    }
+    return Promise.all(promises).then(function() {
+        uninterLeaveAndPackBuffers(gltf);
+    });
+}
+
+function compressIntegerAccessor(gltf, primitive, accessorId, matchedSemantic) {
+    void(primitive, matchedSemantic);
     var accessors = gltf.accessors;
-    for (var accessorId in accessors) {
-        if (accessors.hasOwnProperty(accessorId)) {
-            var accessor = accessors[accessorId];
-            var accessorReader = new AccessorReader(gltf, accessor);
-            var bufferView = accessorReader.bufferView;
-            if (bufferView.target === WebGLConstants.ARRAY_BUFFER) {
-                var newComponentType = canCompressAccessor(gltf, accessorReader);
-                if (defined(newComponentType)) {
-                    accessorReader.reset();
-                    var components = [];
-                    while (defined(accessorReader.read(components))) {
-                        accessorReader.write(components, newComponentType);
-                        accessorReader.next();
-                    }
-                    accessor.componentType = newComponentType;
-                }
+    var accessor = accessors[accessorId];
+    var accessorReader = new AccessorReader(gltf, accessor);
+    var bufferView = accessorReader.bufferView;
+    if (bufferView.target === WebGLConstants.ARRAY_BUFFER) {
+        var newComponentType = canCompressAccessor(gltf, accessorReader);
+        if (defined(newComponentType)) {
+            accessorReader.reset();
+            var components = [];
+            while (defined(accessorReader.read(components))) {
+                accessorReader.write(components, newComponentType);
+                accessorReader.next();
             }
+            accessor.componentType = newComponentType;
         }
     }
-    uninterLeaveAndPackBuffers(gltf);
 }
 
 function canCompressAccessor(gltf, accessorReader) {

--- a/lib/getAccessorsForSemantic.js
+++ b/lib/getAccessorsForSemantic.js
@@ -9,7 +9,7 @@ module.exports = getAccessorsForSemantic;
  *
  * @param {Object} gltf The glTF hierarchy
  * @param {String} semantic Matches against the beginning of the semantic string for the primitives' attributes
- * @param {Function} callback This gets called when a match is found with the arguments (gltf, primitive, matchedSemantic, accessorId)
+ * @param {Function} callback This gets called when a match is found with the arguments (gltf, primitive, accessorId, matchedSemantic)
  * 
  * @returns {Promise} A promise that resolves when all primitives have been searched.
  */

--- a/lib/gltfPipeline.js
+++ b/lib/gltfPipeline.js
@@ -73,7 +73,6 @@ function processJSONWithExtras(gltfWithExtras, options, callback) {
     // It is generally better to merge the duplicate vertices before merging accessors.
     // Once accessors merge, there is more likely to be overlap in accessor usage between primitives
     // which limits the effectiveness of merging duplicate vertices.
-    compressIntegerAccessors(gltfWithExtras);
     mergeDuplicateVertices(gltfWithExtras);
     mergeDuplicateAccessors(gltfWithExtras);
     removeDuplicatePrimitives(gltfWithExtras);
@@ -102,6 +101,9 @@ function processJSONWithExtras(gltfWithExtras, options, callback) {
     if (options.compressTextureCoordinates) {
         waitForStages.push(compressTextureCoordinates(gltfWithExtras));
     }
+    waitForStages.push(compressIntegerAccessors(gltfWithExtras, {
+        semantics : ["JOINT"]
+    }));
     Promise.all(waitForStages).then(function() {
         if (options.quantize) {
             var quantizedOptions = {

--- a/specs/lib/compressIntegerAccessorsSpec.js
+++ b/specs/lib/compressIntegerAccessorsSpec.js
@@ -180,13 +180,32 @@ var testGltf = {
             },
             type : "arraybuffer"
         }
+    },
+    meshes : {
+        mesh : {
+            primitives : [
+                {
+                    attributes : {
+                        A : 'cantCompressByte',
+                        B : 'cantCompressUByte',
+                        C : 'cantCompressIndices',
+                        D : 'cantCompressBigShort',
+                        E : 'floatToShort',
+                        F : 'floatToByte',
+                        G : 'shortToByte'
+                    }
+                }
+            ]
+        }
     }
 };
 
 describe('compressIntegerAccessors', function() {
     it('compresses integer accessors and leaves uncompressible accessors alone', function() {
         var gltf = testGltf;
-        compressIntegerAccessors(gltf);
+        compressIntegerAccessors(gltf, {
+            semantics : ['A', 'B', 'C', 'D', 'E', 'F', 'G']
+        });
         expect(gltf.accessors.cantCompressByte.componentType === WebGLConstants.BYTE);
         expect(gltf.accessors.cantCompressUByte.componentType === WebGLConstants.UNSIGNED_BYTE);
         expect(gltf.accessors.cantCompressIndices.componentType === WebGLConstants.UNSIGNED_SHORT);


### PR DESCRIPTION
ReciprocatingSaw currently fails to render in Cesium after converting.

This is because it has a normal accessor with only integer values, but all unsigned.

`compressIntegerAccessors` puts them into an `UNSIGNED_BYTE` which crashes WebGL for some reason. (Note: if they are in `BYTE`, it is fine).

This change allows `compressIntegerAccessors` to distinguish based on semantics and the main pipeline only runs it on JOINT, which is really what it was for anyway. 