### PR TITLE
Added support for glTF 1.0.1 normalized to quantizeAttributes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+### Next Release
+
+* `quantizedAttributes` has an optional `normalized` flag to use the glTF 1.0.1 `accessor.normalized` for a higher precision decode matrix.
+
 ### 0.1.0-alpha4 - 2016-08-25
 
 * `cacheOptimization` no longer crashes on primitives without indices. [#154](https://github.com/AnalyticalGraphicsInc/gltf-pipeline/issues/154)

--- a/lib/quantizeAttributes.js
+++ b/lib/quantizeAttributes.js
@@ -26,6 +26,7 @@ module.exports = quantizeAttributes;
  * @param {Object} [options.semantics=undefined] Defines which semantics should be quantized.
  * @param {Object} [options.exclude=undefined] Don't quantize the specified semantics
  * @param {Number} [options.precision=undefined] Restricts the number of decimal places in the decodeMatrix.
+ * @param {Boolean} [options.normalized=false] If this is true, the accessor.normalized property will be set to true, and the decodeMatrix will be stored with greater precision.
  * @param {Boolean} [options.findMinMax=false] If this is true, the accessor min and max will be calculated.
  *
  * @returns The glTF asset with quantized attributes.
@@ -66,6 +67,7 @@ function quantizeAttributes(gltf, options) {
     var validSemantics;
     var excludeSemantics;
     var findMinMax = defaultValue(options.findMinMax, false);
+    var normalized = defaultValue(options.normalized, false);
 
     if (defined(options.precision)) {
         precision = Math.pow(10, options.precision);
@@ -107,7 +109,10 @@ function quantizeAttributes(gltf, options) {
             }
             accessor.min = new Array(min.length).fill(0);
             accessor.max = new Array(max.length).fill(range);
-            var decodeMatrix = createDecodeMatrix(min, max, range);
+            if (normalized) {
+                accessor.normalized = true;
+            }
+            var decodeMatrix = createDecodeMatrix(min, max, normalized ? 1.0 : range);
 
             // change matrix precision to save space
             if (defined(precision)) {

--- a/specs/lib/quantizeAttributesSpec.js
+++ b/specs/lib/quantizeAttributesSpec.js
@@ -18,7 +18,7 @@ describe('quantizeAttributes', function() {
                 count : 3,
                 min : [-1.0, -1.0, -1.0],
                 max : [1.0, 1.0, 1.0],
-                type : 'VEC3',
+                type : 'VEC3'
             },
             accessor_1 : {
                 bufferView : 'bufferView_0',
@@ -171,6 +171,27 @@ describe('quantizeAttributes', function() {
         gltf.buffers.buffer.extras._pipeline.source = buffer;
         quantizeAttributes(gltf, {semantics: ['POSITION']});
         expect(gltf.buffers.buffer.byteLength + size).toEqual(buffer.length);
+        var decodeMatrix = accessor_0.extensions.WEB3D_quantized_attributes.decodeMatrix;
+        expect(decodeMatrix[0]).toBe(2.0 / 65535.0);
+    });
+
+    it('Quantizes attributes using options.normalized for higher precision decode', function() {
+        var gltf = clone(testGltf);
+        var accessor_0 = gltf.accessors.accessor_0;
+        var accessor_2 = gltf.accessors.accessor_2;
+        var size = byteLengthForComponentType(accessor_0.componentType) * numberOfComponentsForType(accessor_0.type) * accessor_0.count;
+        size += byteLengthForComponentType(accessor_2.componentType) * numberOfComponentsForType(accessor_2.type) * accessor_2.count;
+        size = size/2.0;
+        gltf.buffers.buffer.extras._pipeline.source = buffer;
+        quantizeAttributes(gltf, {
+            semantics : ['POSITION'],
+            normalized : true
+        });
+        expect(gltf.buffers.buffer.byteLength + size).toEqual(buffer.length);
+        expect(accessor_0.normalized).toBeTruthy();
+        expect(accessor_2.normalized).toBeTruthy();
+        var decodeMatrix = accessor_0.extensions.WEB3D_quantized_attributes.decodeMatrix;
+        expect(decodeMatrix[0]).toBe(2.0);
     });
 
     it('Reduces the decimal places in decode matrix using options.precision', function() {


### PR DESCRIPTION
Adds an optional flag to use the glTF 1.0.1 normalized property for higher precision decode matrices.