### PR TITLE
Add KHR_binary_glTF to extensionsUsed when exporting binary glTF

### DIFF
--- a/lib/getBinaryGltf.js
+++ b/lib/getBinaryGltf.js
@@ -73,7 +73,7 @@ function updateBinaryObject(gltf, pipelineExtras, name, state) {
  * @see loadGltfUris
  */
 function getBinaryGltf(gltf, embed, embedImage) {
-    addExtensionsUsed(gltf, 'KHR_binary_glTF')
+    addExtensionsUsed(gltf, 'KHR_binary_glTF');
     // Create the special binary buffer from the existing buffers
     gltf.bufferViews = defaultValue(gltf.bufferViews, {});
     gltf.buffers = defaultValue(gltf.buffers, {});

--- a/lib/getBinaryGltf.js
+++ b/lib/getBinaryGltf.js
@@ -6,6 +6,7 @@ var sizeOf = require('image-size');
 var defaultValue = Cesium.defaultValue;
 var defined = Cesium.defined;
 
+var addExtensionsUsed = require('./addExtensionsUsed');
 var mergeBuffers = require('./mergeBuffers');
 var removePipelineExtras = require('./removePipelineExtras');
 
@@ -72,6 +73,7 @@ function updateBinaryObject(gltf, pipelineExtras, name, state) {
  * @see loadGltfUris
  */
 function getBinaryGltf(gltf, embed, embedImage) {
+    addExtensionsUsed(gltf, 'KHR_binary_glTF')
     // Create the special binary buffer from the existing buffers
     gltf.bufferViews = defaultValue(gltf.bufferViews, {});
     gltf.buffers = defaultValue(gltf.buffers, {});

--- a/specs/data/boxTexturedUnoptimized/CesiumTexturedBoxTest_BinaryCheck.gltf
+++ b/specs/data/boxTexturedUnoptimized/CesiumTexturedBoxTest_BinaryCheck.gltf
@@ -107,6 +107,7 @@
       "uri": "data:,"
     }
   },
+  "extensionsUsed": ["KHR_binary_glTF"],
   "images": {
     "Image0001": {
       "name": "Image0001",

--- a/specs/lib/getBinaryGltfSpec.js
+++ b/specs/lib/getBinaryGltfSpec.js
@@ -58,8 +58,8 @@ describe('getBinaryGltf', function() {
 
         expect(header.toString('utf8', 0, 4)).toEqual('glTF');
         expect(header.readUInt32LE(4)).toEqual(1);
-        expect(header.readUInt32LE(8)).toEqual(17706);
-        expect(header.readUInt32LE(12)).toEqual(3896);
+        expect(header.readUInt32LE(8)).toEqual(17742);
+        expect(header.readUInt32LE(12)).toEqual(3932);
         expect(header.readUInt32LE(16)).toEqual(0);
     });
 
@@ -70,8 +70,8 @@ describe('getBinaryGltf', function() {
 
         expect(header.toString('utf8', 0, 4)).toEqual('glTF');
         expect(header.readUInt32LE(4)).toEqual(1);
-        expect(header.readUInt32LE(8)).toEqual(4336);
-        expect(header.readUInt32LE(12)).toEqual(3476);
+        expect(header.readUInt32LE(8)).toEqual(4372);
+        expect(header.readUInt32LE(12)).toEqual(3512);
         expect(header.readUInt32LE(16)).toEqual(0);
     });
 


### PR DESCRIPTION
Another pretty simple change for passing validation: http://github.khronos.org/glTF-Validator/