### PR TITLE
Update b3dm spec

### DIFF
--- a/lib/generateNormals.js
+++ b/lib/generateNormals.js
@@ -239,6 +239,12 @@ function generateMaterial(gltf, options, primitive, generatedMaterials) {
 
     var material = materials[materialId];
     var techniqueId = material.technique;
+
+    if (!defined(techniques) || !defined(techniqueId)) {
+        // Could have materials common
+        return;
+    }
+
     var technique = techniques[techniqueId];
 
     var normalParameter = jp.query(technique, '$.parameters[?(@.semantic == \"NORMAL\")]');


### PR DESCRIPTION
b3dm files now have an additional field for binaryBatchTableLength so the header is now 24-bytes. The batchLength was also moved to the end of the header. See spec https://github.com/AnalyticalGraphicsInc/3d-tiles/blob/master/TileFormats/Batched3DModel/README.md.

Once this is merged old b3dm files won't work. I'm thinking we don't need the backwards compatibility, but we can if anyone feels strongly about it.