### PR TITLE
Parsing arguments exposed as a separate function

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -3,14 +3,4 @@
   <component name="JavaScriptSettings">
     <option name="languageLevel" value="ES5" />
   </component>
-  <component name="ProjectLevelVcsManager" settingsEditedManually="false">
-    <OptionsSetting value="true" id="Add" />
-    <OptionsSetting value="true" id="Remove" />
-    <OptionsSetting value="true" id="Checkout" />
-    <OptionsSetting value="true" id="Update" />
-    <OptionsSetting value="true" id="Status" />
-    <OptionsSetting value="true" id="Edit" />
-    <ConfirmationsSetting value="0" id="Add" />
-    <ConfirmationsSetting value="0" id="Remove" />
-  </component>
 </project>

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@ Change Log
 
 ### Next Release
 * Fixed `combinePrimitives` stage and re-added it to the pipeline. [#108](https://github.com/AnalyticalGraphicsInc/gltf-pipeline/issues/108)
+* Expose parsing argument arrays into an options object via `parseArguments`. [#183](https://github.com/AnalyticalGraphicsInc/gltf-pipeline/pull/183)
 
 ### 0.1.0-alpha5 - 2016-11-02
 

--- a/bin/gltf-pipeline.js
+++ b/bin/gltf-pipeline.js
@@ -1,157 +1,17 @@
 #!/usr/bin/env node
 'use strict';
-var Cesium = require('cesium');
-var path = require('path');
-var yargs = require('yargs');
 var Pipeline = require('../lib/Pipeline');
+var parseArguments = require('../lib/parseArguments');
 
-var defaultValue = Cesium.defaultValue;
-var defined = Cesium.defined;
 var processFileToDisk = Pipeline.processFileToDisk;
 
-var argv = yargs
-    .usage('Usage: node $0 -i inputPath -o outputPath')
-    .example('node $0 -i ./specs/data/boxTexturedUnoptimized/CesiumTexturedBoxTest.gltf -o output.gltf')
-    .help('h')
-    .alias('h', 'help')
-    .options({
-        'input': {
-            alias: 'i',
-            describe: 'input=PATH, Read unoptimized glTF from the specified file.',
-            group: 'Options:', // make sure 'Options:' is listed first
-            normalize: true,
-            type: 'string'
-        },
-        'output': {
-            alias: 'o',
-            describe: 'output=PATH, Write optimized glTF to the specified file.',
-            normalize: true,
-            type: 'string'
-        },
-        'binary': {
-            alias: 'b',
-            describe: 'Write binary glTF file using KHR_binary_glTF extension.',
-            type: 'boolean'
-        },
-        'separate': {
-            alias: 's',
-            describe: 'Write separate geometry/animation data files, shader files, and textures instead of embedding them in the glTF asset.',
-            type: 'boolean'
-        },
-        'separateImage': {
-            alias: 't',
-            describe: 'Write out separate textures, but embeds geometry/animation data files and shader files in the glTF asset.',
-            type: 'boolean'
-        },
-        'quantize': {
-            alias: 'q',
-            describe: 'Quantize the attributes of this glTF asset using the WEB3D_quantized_attributes extension.',
-            type: 'boolean'
-        },
-        'encodeNormals': {
-            alias: 'n',
-            describe: 'Oct-encode the normals of this glTF asset.',
-            type: 'boolean'
-        },
-        'compressTextureCoordinates': {
-            alias: 'c',
-            describe: 'Compress the testure coordinates of this glTF asset.',
-            type: 'boolean'
-        },
-        'removeNormals': {
-            alias: 'r',
-            describe: 'Strips off existing normals, allowing them to be regenerated.',
-            type: 'boolean'
-        },
-        'faceNormals': {
-            alias: 'f',
-            describe: 'If normals are missing, they should be generated using the face normal.',
-            type: 'boolean'
-        },
-        'cesium': {
-            describe: 'Optimize the glTF for Cesium by using the sun as a default light source.',
-            type: 'boolean'
-        },
-        'ao.enable': {
-            default: false,
-            describe: 'Bake ambient occlusion (to vertex data by default). If other `ao` flags are enabled, this is implicitly true.',
-            group: 'Options: Ambient Occlusion'
-        },
-        'ao.toTexture': {
-            default: false,
-            describe: 'Bake AO to existing diffuse textures instead of vertices. Does not modify shaders.',
-            group: 'Options: Ambient Occlusion'
-        },
-        'ao.groundPlane': {
-            default: false,
-            describe: 'Simulate a ground plane at the lowest point of the model when baking AO.',
-            group: 'Options: Ambient Occlusion'
-        },
-        'ao.ambientShadowContribution': {
-            default: 0.5,
-            describe: 'Amount of AO to show when blending shader computed lighting and AO. 1.0 is full AO, 0.5 is a 50/50 blend.',
-            group: 'Options: Ambient Occlusion',
-            nargs: 1,
-            type: 'number'
-        },
-        'ao.quality': {
-            choices: ['high', 'medium', 'low'],
-            default: 'low',
-            describe: 'Quality to use when baking AO. Valid settings are high, medium, and low.',
-            group: 'Options: Ambient Occlusion',
-            nargs: 1,
-            type: 'string'
-        }
-    })
-    .argv;
-
-// If any raw ao parameters were specified, ao is enabled
-var nargs = process.argv.length;
-for (var i = 0; i < nargs; i++) {
-    var arg = process.argv[i];
-    if (arg.indexOf('ao') >= 0) {
-        argv.ao.enable = true;
-    }
-}
-
-var gltfPath = defaultValue(argv.i, argv._[0]);
-var outputPath = defaultValue(argv.o, argv._[1]);
-
-if (!defined(gltfPath)) {
-    yargs.showHelp();
-    return;
-}
-
-if (!defined(outputPath)) {
-    var outputFileExtension;
-    if (argv.b) {
-        outputFileExtension = '.glb';
-    } else {
-        outputFileExtension = '.gltf';
-    }
-    var fileExtension = path.extname(gltfPath);
-    var fileName = path.basename(gltfPath, fileExtension);
-    var filePath = path.dirname(gltfPath);
-    // Default output.  For example, path/asset.gltf becomes path/asset-optimized.gltf
-    outputPath = path.join(filePath, fileName + '-optimized' + outputFileExtension);
-}
-
-var options = {
-    aoOptions: argv.ao,
-    binary: argv.b,
-    compressTextureCoordinates: argv.c,
-    embed: !argv.s,
-    embedImage: !argv.t,
-    encodeNormals: argv.n,
-    faceNormals: argv.f,
-    removeNormals: argv.r,
-    optimizeForCesium: argv.cesium,
-    quantize: argv.q
-};
+var args = process.argv;
+args = args.slice(2, args.length);
+var options = parseArguments(args);
 
 console.time('optimize');
 // Node automatically waits for all promises to terminate
-processFileToDisk(gltfPath, outputPath, options)
+processFileToDisk(options.inputPath, options.outputPath, options)
     .then(function() {
         console.timeEnd('optimize');
     });

--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ module.exports = {
     octEncodeNormals : require('./lib/octEncodeNormals'),
     optimizeForVertexCache : require('./lib/optimizeForVertexCache'),
     packArray : require('./lib/packArray'),
+    parseArguments : require('./lib/parseArguments'),
     parseBinaryGltf : require('./lib/parseBinaryGltf'),
     Pipeline : require('./lib/Pipeline'),
     quantizeAttributes : require('./lib/quantizeAttributes'),

--- a/lib/parseArguments.js
+++ b/lib/parseArguments.js
@@ -1,0 +1,159 @@
+'use strict';
+var Cesium = require('cesium');
+var path = require('path');
+var yargs = require('yargs');
+
+var defaultValue = Cesium.defaultValue;
+var defined = Cesium.defined;
+
+module.exports = parseArguments;
+
+/**
+ * Exposes parsing an array of command line arguments into an options object as a function.
+ * Uses yargs and will produce perhaps undesired console output if used incorrectly.
+ *
+ * @param [Array] args An array of command line arguments to process into an options object.
+ * @returns {Object} An options object usable with pipeline function calls.
+ */
+function parseArguments(args) {
+    var argv = yargs
+        .usage('Usage: node $0 -i inputPath -o outputPath')
+        .example('node $0 -i ./specs/data/boxTexturedUnoptimized/CesiumTexturedBoxTest.gltf -o output.gltf')
+        .help('h')
+        .alias('h', 'help')
+        .options({
+            'input': {
+                alias: 'i',
+                describe: 'input=PATH, Read unoptimized glTF from the specified file.',
+                group: 'Options:', // make sure 'Options:' is listed first
+                normalize: true,
+                type: 'string'
+            },
+            'output': {
+                alias: 'o',
+                describe: 'output=PATH, Write optimized glTF to the specified file.',
+                normalize: true,
+                type: 'string'
+            },
+            'binary': {
+                alias: 'b',
+                describe: 'Write binary glTF file using KHR_binary_glTF extension.',
+                type: 'boolean'
+            },
+            'separate': {
+                alias: 's',
+                describe: 'Write separate geometry/animation data files, shader files, and textures instead of embedding them in the glTF asset.',
+                type: 'boolean'
+            },
+            'separateImage': {
+                alias: 't',
+                describe: 'Write out separate textures, but embeds geometry/animation data files and shader files in the glTF asset.',
+                type: 'boolean'
+            },
+            'quantize': {
+                alias: 'q',
+                describe: 'Quantize the attributes of this glTF asset using the WEB3D_quantized_attributes extension.',
+                type: 'boolean'
+            },
+            'encodeNormals': {
+                alias: 'n',
+                describe: 'Oct-encode the normals of this glTF asset.',
+                type: 'boolean'
+            },
+            'compressTextureCoordinates': {
+                alias: 'c',
+                describe: 'Compress the testure coordinates of this glTF asset.',
+                type: 'boolean'
+            },
+            'removeNormals': {
+                alias: 'r',
+                describe: 'Strips off existing normals, allowing them to be regenerated.',
+                type: 'boolean'
+            },
+            'faceNormals': {
+                alias: 'f',
+                describe: 'If normals are missing, they should be generated using the face normal.',
+                type: 'boolean'
+            },
+            'cesium': {
+                describe: 'Optimize the glTF for Cesium by using the sun as a default light source.',
+                type: 'boolean'
+            },
+            'ao.enable': {
+                default: false,
+                describe: 'Bake ambient occlusion (to vertex data by default). If other `ao` flags are enabled, this is implicitly true.',
+                group: 'Options: Ambient Occlusion'
+            },
+            'ao.toTexture': {
+                default: false,
+                describe: 'Bake AO to existing diffuse textures instead of vertices. Does not modify shaders.',
+                group: 'Options: Ambient Occlusion'
+            },
+            'ao.groundPlane': {
+                default: false,
+                describe: 'Simulate a ground plane at the lowest point of the model when baking AO.',
+                group: 'Options: Ambient Occlusion'
+            },
+            'ao.ambientShadowContribution': {
+                default: 0.5,
+                describe: 'Amount of AO to show when blending shader computed lighting and AO. 1.0 is full AO, 0.5 is a 50/50 blend.',
+                group: 'Options: Ambient Occlusion',
+                nargs: 1,
+                type: 'number'
+            },
+            'ao.quality': {
+                choices: ['high', 'medium', 'low'],
+                default: 'low',
+                describe: 'Quality to use when baking AO. Valid settings are high, medium, and low.',
+                group: 'Options: Ambient Occlusion',
+                nargs: 1,
+                type: 'string'
+            }
+        }).parse(args);
+
+    // If any raw ao parameters were specified, ao is enabled
+    var nargs = process.argv.length;
+    for (var i = 0; i < nargs; i++) {
+        var arg = process.argv[i];
+        if (arg.indexOf('ao') >= 0) {
+            argv.ao.enable = true;
+        }
+    }
+
+    var gltfPath = defaultValue(argv.i, argv._[0]);
+    var outputPath = defaultValue(argv.o, argv._[1]);
+
+    if (!defined(gltfPath)) {
+        yargs.showHelp();
+        return;
+    }
+
+    if (!defined(outputPath)) {
+        var outputFileExtension;
+        if (argv.b) {
+            outputFileExtension = '.glb';
+        } else {
+            outputFileExtension = '.gltf';
+        }
+        var fileExtension = path.extname(gltfPath);
+        var fileName = path.basename(gltfPath, fileExtension);
+        var filePath = path.dirname(gltfPath);
+        // Default output.  For example, path/asset.gltf becomes path/asset-optimized.gltf
+        outputPath = path.join(filePath, fileName + '-optimized' + outputFileExtension);
+    }
+
+    return {
+        aoOptions: argv.ao,
+        binary: argv.b,
+        compressTextureCoordinates: argv.c,
+        embed: !argv.s,
+        embedImage: !argv.t,
+        encodeNormals: argv.n,
+        faceNormals: argv.f,
+        inputPath: gltfPath,
+        removeNormals: argv.r,
+        optimizeForCesium: argv.cesium,
+        outputPath: outputPath,
+        quantize: argv.q
+    };
+}


### PR DESCRIPTION
Allows API use applications to use the gltf-pipeline argument parsing to create objects for use with the API functions.