### PR TITLE
Transform oct-encoded normals

### DIFF
--- a/lib/PrimitiveHelpers.js
+++ b/lib/PrimitiveHelpers.js
@@ -5,8 +5,10 @@ var AccessorReader = require('./AccessorReader');
 var getPrimitiveAttributeSemantics = require('./getPrimitiveAttributeSemantics');
 var readAccessor = require('./readAccessor');
 
+var AttributeCompression = Cesium.AttributeCompression;
 var Cartesian3 = Cesium.Cartesian3;
 var Matrix4 = Cesium.Matrix4;
+var WebGLConstants = Cesium.WebGLConstants;
 var defined = Cesium.defined;
 
 module.exports = {
@@ -96,9 +98,12 @@ function transformPrimitives(gltf, primitives, transform) {
         var normalAccessorReader;
         var normalSemantics = getPrimitiveAttributeSemantics(primitive, 'NORMAL');
         var normalAccessorId = attributes[normalSemantics[0]];
+        var isOctEncoded = false;
         if (normalSemantics.length > 0) {
             doneIndicesByAccessor[normalAccessorId] = {};
-            normalAccessorReader = new AccessorReader(gltf, accessors[normalAccessorId]);
+            var normalAccessor = accessors[normalAccessorId];
+            normalAccessorReader = new AccessorReader(gltf, normalAccessor);
+            isOctEncoded = normalAccessor.type === 'VEC2';
         }
         var keepReading = true;
         while (keepReading) {
@@ -115,8 +120,26 @@ function transformPrimitives(gltf, primitives, transform) {
                 normalAccessorReader.index = index;
                 normalAccessorReader.read(scratchCartesianArray);
                 Cartesian3.unpack(scratchCartesianArray, 0, scratchCartesian);
+                if (isOctEncoded) {
+                    // Un-encode oct-encoded normals
+                    if (normalAccessorReader.componentType === WebGLConstants.BYTE) {
+                        // Normalize if these are written to signed bytes
+                        scratchCartesian.x += 128;
+                        scratchCartesian.y += 128;
+                    }
+                    AttributeCompression.octDecode(scratchCartesian.x, scratchCartesian.y, scratchCartesian);
+                }
                 Matrix4.multiplyByPointAsVector(inverseTranspose, scratchCartesian, scratchCartesian);
                 Cartesian3.normalize(scratchCartesian, scratchCartesian);
+                if (isOctEncoded) {
+                    // Re-encode oct-encoded normals
+                    AttributeCompression.octEncode(scratchCartesian, scratchCartesian);
+                    if (normalAccessorReader.componentType === WebGLConstants.BYTE) {
+                        // De-normalize back to signed bytes
+                        scratchCartesian.x -= 128;
+                        scratchCartesian.y -= 128;
+                    }
+                }
                 Cartesian3.pack(scratchCartesian, scratchCartesianArray);
                 normalAccessorReader.write(scratchCartesianArray);
                 doneIndicesByAccessor[normalAccessorId][index] = true;


### PR DESCRIPTION
Decode oct-encoded normals when transforming and then re-encode. With these changes, the attached model transforms correctly.

[batched.glb.txt](https://github.com/AnalyticalGraphicsInc/gltf-pipeline/files/600404/batched.glb.txt)
