### PR TITLE
Add empty data uri if it is missing

### DIFF
--- a/lib/loadGltfUris.js
+++ b/lib/loadGltfUris.js
@@ -51,9 +51,12 @@ function loadURI(gltf, basePath, name) {
         for (var id in objects) {
             if (objects.hasOwnProperty(id)) {
                 var object = objects[id];
-                var uri = object.uri;
                 object.extras = defaultValue(object.extras, {});
                 object.extras._pipeline = defaultValue(object.extras._pipeline, {});
+                if (defined(object.extras._pipeline.source) && !defined(object.uri)) {
+                    object.uri = 'data:,';
+                }
+                var uri = object.uri;
                 //Load the uri into the extras object based on the uri type
                 if (isDataUri(uri)) {
                     if (!defined(object.extras._pipeline.source)) {


### PR DESCRIPTION
I encountered a model whose shader is defined in the binary-gltf body but doesn't set a data-uri. I believe this is technically invalid according to the spec, but it is worth handling this case anyways.

@lasalvavida