### PR TITLE
String shaders and browser-friendly parseBinaryGltf

### DIFF
--- a/lib/compressTextureCoordinates.js
+++ b/lib/compressTextureCoordinates.js
@@ -147,7 +147,7 @@ function patchProgram(gltf, programId, texCoordVariableName, patchedShaders) {
     }
     var vertexShader = shaders[vertexShaderId];
     var pipelineExtras = vertexShader.extras._pipeline;
-    var shader = pipelineExtras.source.toString('utf8');
+    var shader = pipelineExtras.source;
     var newVariableName = 'czm_com_' + texCoordVariableName;
     shader = shader.replace('attribute vec2 ' + texCoordVariableName + ';', '');
     shader = shader.replace(new RegExp(texCoordVariableName, 'g'), newVariableName);
@@ -167,6 +167,6 @@ function patchProgram(gltf, programId, texCoordVariableName, patchedShaders) {
     });
     shader = source.createCombinedVertexShader();
     shader = shader.replace(new RegExp('czm_', 'g'), 'gltf_');
-    pipelineExtras.source = new Buffer(shader);
+    pipelineExtras.source = shader;
     patchedShaders[vertexShaderId] = true;
 }

--- a/lib/loadGltfUris.js
+++ b/lib/loadGltfUris.js
@@ -60,7 +60,12 @@ function loadURI(gltf, basePath, name) {
                 //Load the uri into the extras object based on the uri type
                 if (isDataUri(uri)) {
                     if (!defined(object.extras._pipeline.source)) {
-                        object.extras._pipeline.source = dataUriToBuffer(uri);
+                        var buffer = dataUriToBuffer(uri);
+                        if (name === 'shaders') {
+                            object.extras._pipeline.source = buffer.toString();
+                        } else {
+                            object.extras._pipeline.source = buffer;
+                        }
                     }
                     if (!defined(object.extras._pipeline.extension)) {
                         switch (name) {
@@ -86,7 +91,7 @@ function loadURI(gltf, basePath, name) {
                         }
                         uriPath = path.join(basePath, uriPath);
                     }
-                    promises.push(readImageFromFile(object, name, uriPath));
+                    promises.push(readFromFile(object, name, uriPath));
                 }
             }
         }
@@ -124,10 +129,14 @@ function isTransparent(image) {
     return false;
 }
 
-function readImageFromFile(object, name, uriPath) {
+function readFromFile(object, name, uriPath) {
     return fsReadFile(uriPath)
         .then(function(data) {
-            object.extras._pipeline.source = data;
+            if (name === 'shaders') {
+                object.extras._pipeline.source = data.toString();
+            } else {
+                object.extras._pipeline.source = data;
+            }
             object.extras._pipeline.extension = path.extname(uriPath);
             if (name === 'images') {
                 return generateJimpImage(object);

--- a/lib/octEncodeNormals.js
+++ b/lib/octEncodeNormals.js
@@ -147,7 +147,7 @@ function patchProgram(gltf, programId, normalVariableName, patchedShaders) {
     }
     var vertexShader = shaders[vertexShaderId];
     var pipelineExtras = vertexShader.extras._pipeline;
-    var shader = pipelineExtras.source.toString('utf8');
+    var shader = pipelineExtras.source;
 
     var newVariableName = 'czm_oct_dec_a_normal';
     shader = shader.replace('attribute vec3 ' + normalVariableName + ';', '');
@@ -168,6 +168,6 @@ function patchProgram(gltf, programId, normalVariableName, patchedShaders) {
     });
     shader = source.createCombinedVertexShader();
     shader = shader.replace(new RegExp('czm_', 'g'), 'gltf_');
-    pipelineExtras.source = new Buffer(shader);
+    pipelineExtras.source = shader;
     patchedShaders[vertexShaderId] = true;
 }

--- a/lib/parseBinaryGltf.js
+++ b/lib/parseBinaryGltf.js
@@ -1,70 +1,69 @@
 'use strict';
 var Cesium = require('cesium');
-var StringDecoder = require('string_decoder').StringDecoder;
-var bufferEqual = require('buffer-equal');
 
+var addPipelineExtras = require('./addPipelineExtras');
+
+var ComponentDatatype = Cesium.ComponentDatatype;
 var defined = Cesium.defined;
 var DeveloperError = Cesium.DeveloperError;
 var defaultValue = Cesium.defaultValue;
-
-var addPipelineExtras = require('./addPipelineExtras');
+var getMagic = Cesium.getMagic;
+var getStringFromTypedArray = Cesium.getStringFromTypedArray;
+var WebGLConstants = Cesium.WebGLConstants;
 
 module.exports = parseBinaryGltf;
 
 /**
  * Parses a binary glTF buffer into glTF JSON.
  *
- * @param {Buffer} data The binary glTF buffer to parse.
+ * @param {Uint8Array} data The binary glTF data to parse.
  * @returns {Object} The parsed binary glTF.
  */
 function parseBinaryGltf(data) {
-    var sizeOfUint32 = Uint32Array.BYTES_PER_ELEMENT;
-    var byteOffset = 0;
     var bufferViewId;
 
-    //Check that the magic string is present
-    if (data.slice(byteOffset, sizeOfUint32).toString() !== 'glTF') {
+    // Check that the magic string is present
+    if (getMagic(data) !== 'glTF') {
         throw new DeveloperError('File is not valid binary glTF');
     }
 
-    //Check that the version is 1
-    byteOffset += sizeOfUint32;
-    if (data.readInt32LE(byteOffset) !== 1) {
+    var uint32View = ComponentDatatype.createArrayBufferView(WebGLConstants.INT, data.buffer, 0, 5);
+
+    // Check that the version is 1
+    if (uint32View[1] !== 1) {
         throw new DeveloperError('Binary glTF version is not 1');
     }
 
-    //Get the length of the glTF scene
-    byteOffset += 2*sizeOfUint32;
-    var sceneLength = data.readInt32LE(byteOffset);
+    // Get the length of the glTF scene
+    var sceneLength = uint32View[3];
 
-    //Check that the scene format is 0, indicating that it is JSON
-    byteOffset += sizeOfUint32;
-    if (data.readInt32LE(byteOffset) !== 0) {
+    // Check that the scene format is 0, indicating that it is JSON
+    if (uint32View[4]) {
         throw new DeveloperError('Binary glTF scene format is not JSON');
     }
 
-    //Parse gltf scene
-    byteOffset += sizeOfUint32;
-    var decoder = new StringDecoder();
-    var scene = decoder.write(data.slice(byteOffset, byteOffset + sceneLength));
+    // Parse gltf scene
+    var scene = getStringFromTypedArray(data.slice(20, 20 + sceneLength));
     var gltf = JSON.parse(scene);
     addPipelineExtras(gltf);
 
-    //Extract binary body
-    byteOffset += sceneLength;
-    var body = data.slice(byteOffset);
-    
-    //Find bufferViews used by accessors
+    // Extract binary body
+    var body = data.slice(20 + sceneLength);
+
+    // Find bufferViews used by accessors
     var usedBufferViews = getUsedBufferViews(gltf);
 
-    //Add image and shader sources, and delete their bufferView if not referenced by an accessor
+    // Add image and shader sources, and delete their bufferView if not referenced by an accessor
     loadSourceFromBody(gltf, body, 'images', usedBufferViews);
     loadSourceFromBody(gltf, body, 'shaders', usedBufferViews);
 
-    //Create a new buffer for each bufferView, and delete the original body buffer
+    // Create a new buffer for each bufferView, and delete the original body buffer
     var buffers = gltf.buffers;
     var bufferViews = gltf.bufferViews;
-    if (defined(buffers) && defined(buffers.binary_glTF)) {
+    // The extension 'KHR_binary_glTF' uses a special buffer entitled just 'binary_glTF'.
+    // The 'KHR_binary_glTF' check is for backwards compatibility for the Cesium model converter
+    // circa Cesium 1.15-1.20 when the converter incorrectly used the buffer name 'KHR_binary_glTF'.
+    if (defined(buffers) && (defined(buffers.binary_glTF) || defined(buffers.KHR_binary_glTF))) {
         if (defined(bufferViews)) {
             //Add id to each bufferView object
             for (bufferViewId in bufferViews) {
@@ -82,13 +81,13 @@ function parseBinaryGltf(data) {
                 }
             }
             sortedBufferViews = sortedBufferViews.filter(function(bufferView) {
-                return bufferView.buffer === 'binary_glTF';
+                return bufferView.buffer === 'binary_glTF' || bufferView.buffer === 'KHR_binary_glTF';
             });
             //Sort bufferViews by increasing byteOffset
             sortedBufferViews.sort(function(a, b) {
                 return a.byteOffset - b.byteOffset;
             });
-            
+
             //Create a new buffer for each set of overlapping bufferViews
             for (var i = 0; i < sortedBufferViews.length; i++) {
                 var currentView = sortedBufferViews[i];
@@ -97,7 +96,7 @@ function parseBinaryGltf(data) {
                 var viewEnd = viewStart + viewLength;
                 currentView.byteOffset = 0;
                 currentView.byteLength = viewLength;
-                
+
                 var bufferName = currentView.extras._pipeline.id + '_buffer';
                 var bufferKeys = Object.keys(buffers);
                 while (bufferKeys.indexOf(bufferName) !== -1) {
@@ -125,12 +124,11 @@ function parseBinaryGltf(data) {
                 }
 
                 buffers[bufferName] = {
-                    "byteLength": viewEnd - viewStart,
-                    "uri": "data:,",
-                    "extras": {
-                        "_pipeline": {
-                            "source": body.slice(viewStart, viewEnd),
-                            "deleteExtras": true //Move to addPipelineExtras
+                    "byteLength" : viewEnd - viewStart,
+                    "uri" : "data:,",
+                    "extras" : {
+                        "_pipeline" : {
+                            "source" : body.slice(viewStart, viewEnd)
                         }
                     }
                 };
@@ -138,18 +136,18 @@ function parseBinaryGltf(data) {
         }
         delete gltf.buffers.binary_glTF;
     }
-    //Remove the KHR_binary_glTF extension
+    // Remove the KHR_binary_glTF extension
     gltf.extensionsUsed = gltf.extensionsUsed.filter(function(extension) {
         return extension !== 'KHR_binary_glTF';
     });
     if (Object.keys(gltf.extensionsUsed).length === 0) {
         delete gltf.extensionsUsed;
     }
-    
+
     return gltf;
 }
 
-//Load the source from the binary body to the corresponding objects
+// Load the source from the binary body to the corresponding objects
 function loadSourceFromBody(gltf, body, name, usedBufferViews) {
     var objects = gltf[name];
     if (defined(objects)) {
@@ -165,6 +163,7 @@ function loadSourceFromBody(gltf, body, name, usedBufferViews) {
 
                     if (name === 'shaders') {
                         object.extras._pipeline.extension = '.glsl';
+                        object.extras._pipeline.source = getStringFromTypedArray(source);
                     }
                     else if (name === 'images') {
                         object.extras._pipeline.extension = getBinaryImageFormat(source.slice(0, 2));
@@ -191,7 +190,7 @@ function getUsedBufferViews(gltf) {
 
     if (defined(accessors)) {
         for (var accessorId in accessors) {
-            if (accessors.hasOwnProperty(accessorId)){
+            if (accessors.hasOwnProperty(accessorId)) {
                 usedBufferViews[accessors[accessorId].bufferView] = true;
             }
         }
@@ -200,18 +199,27 @@ function getUsedBufferViews(gltf) {
     return usedBufferViews;
 }
 
+function bufferEqual(first, second) {
+    for (var i = 0; i < first.length && i < second.length; i++) {
+        if (first[i] !== second[i]) {
+            return false;
+        }
+    }
+    return true;
+}
+
 //Get binary image file format from first two bytes
 function getBinaryImageFormat(header) {
-    if (bufferEqual(header, new Buffer([66, 77]))) { //.bmp: 42 4D
+    if (bufferEqual(header, new Uint8Array([66, 77]))) { //.bmp: 42 4D
         return '.bmp';
     }
-    else if (bufferEqual(header, new Buffer([71, 73]))) { //.gif: 47 49
+    else if (bufferEqual(header, new Uint8Array([71, 73]))) { //.gif: 47 49
         return '.gif';
     }
-    else if (bufferEqual(header, new Buffer([255, 216]))) { //.jpg: ff d8
+    else if (bufferEqual(header, new Uint8Array([255, 216]))) { //.jpg: ff d8
         return '.jpg';
     }
-    else if (bufferEqual(header, new Buffer([137, 80]))) { //.png: 89 50
+    else if (bufferEqual(header, new Uint8Array([137, 80]))) { //.png: 89 50
         return '.png';
     }
     else {

--- a/lib/processModelMaterialsCommon.js
+++ b/lib/processModelMaterialsCommon.js
@@ -572,7 +572,7 @@ function generateTechnique(gltf, khrMaterialsCommon, lightParameters, optimizeFo
         type: WebGLConstants.VERTEX_SHADER,
         extras: {
             _pipeline: {
-                source: new Buffer(vertexShader),
+                source: vertexShader,
                 extension: '.glsl'
             }
         }
@@ -581,7 +581,7 @@ function generateTechnique(gltf, khrMaterialsCommon, lightParameters, optimizeFo
         type: WebGLConstants.FRAGMENT_SHADER,
         extras: {
             _pipeline: {
-                source: new Buffer(fragmentShader),
+                source: fragmentShader,
                 extension: '.glsl'
             }
         }
@@ -769,9 +769,9 @@ function ensureSemanticExistenceForPrimitive(gltf, primitive) {
                 technique.attributes[attributeName] = lowerCase;
                 program.attributes.push(attributeName);
                 var pipelineExtras = vertexShader.extras._pipeline;
-                var shaderText = pipelineExtras.source.toString();
+                var shaderText = pipelineExtras.source;
                 shaderText = 'attribute ' + getShaderVariable(accessor) + ' ' + attributeName + ';\n' + shaderText;
-                pipelineExtras.source = new Buffer(shaderText);
+                pipelineExtras.source = shaderText;
             }
         }
     }

--- a/lib/writeSource.js
+++ b/lib/writeSource.js
@@ -26,7 +26,7 @@ function writeSource(gltf, basePath, name, embed, embedImage) {
 
                 if (embed && (embedImage || name !== 'images') || !defined(basePath)) {
                     if (name === 'shaders') {
-                        object.uri = 'data:text/plain;base64,' + source.toString('base64');
+                        object.uri = 'data:text/plain;base64,' + new Buffer(source).toString('base64');
                     } else {
                         object.uri = 'data:' + mime.lookup(extension) + ';base64,' + source.toString('base64');
                     }

--- a/specs/lib/compressTextureCoordinatesSpec.js
+++ b/specs/lib/compressTextureCoordinatesSpec.js
@@ -87,7 +87,7 @@ describe('compressTextureCoordinates', function() {
             },
             shaders : {
                 VS : {
-                    type: WebGLConstants.VERTEX_SHADER,
+                    type : WebGLConstants.VERTEX_SHADER,
                     extras : {
                         _pipeline : {
                             source : ''
@@ -110,7 +110,7 @@ describe('compressTextureCoordinates', function() {
             expect(encodedBuffer.length).toEqual(buffer.byteLength);
 
             var vs = gltf.shaders.VS.extras._pipeline.source;
-            expect(typeof vs).toEqual('string')
+            expect(typeof vs).toEqual('string');
 
             var texCoord = new Cartesian2();
             for (var i = 0; i < texCoordAccessor.count; i++) {

--- a/specs/lib/compressTextureCoordinatesSpec.js
+++ b/specs/lib/compressTextureCoordinatesSpec.js
@@ -1,9 +1,10 @@
 'use strict';
 var Cesium = require('cesium');
+var compressTextureCoordinates = require('../../lib/compressTextureCoordinates');
+
 var AttributeCompression = Cesium.AttributeCompression;
 var Cartesian2 = Cesium.Cartesian2;
 var WebGLConstants = Cesium.WebGLConstants;
-var compressTextureCoordinates = require('../../lib/compressTextureCoordinates');
 
 describe('compressTextureCoordinates', function() {
     it('compresses texture coordinates', function(done) {
@@ -89,7 +90,7 @@ describe('compressTextureCoordinates', function() {
                     type: WebGLConstants.VERTEX_SHADER,
                     extras : {
                         _pipeline : {
-                            source : new Buffer('')
+                            source : ''
                         }
                     }
                 }
@@ -109,7 +110,7 @@ describe('compressTextureCoordinates', function() {
             expect(encodedBuffer.length).toEqual(buffer.byteLength);
 
             var vs = gltf.shaders.VS.extras._pipeline.source;
-            expect(Buffer.isBuffer(vs)).toBe(true);
+            expect(typeof vs).toEqual('string')
 
             var texCoord = new Cartesian2();
             for (var i = 0; i < texCoordAccessor.count; i++) {
@@ -295,7 +296,7 @@ describe('compressTextureCoordinates', function() {
                     type: WebGLConstants.VERTEX_SHADER,
                     extras : {
                         _pipeline : {
-                            source : new Buffer('')
+                            source : ''
                         }
                     }
                 },
@@ -303,7 +304,7 @@ describe('compressTextureCoordinates', function() {
                     type: WebGLConstants.VERTEX_SHADER,
                     extras : {
                         _pipeline : {
-                            source : new Buffer('')
+                            source : ''
                         }
                     }
                 }

--- a/specs/lib/loadShaderUrisSpec.js
+++ b/specs/lib/loadShaderUrisSpec.js
@@ -21,7 +21,7 @@ describe('loadShaderUris', function() {
     beforeAll(function(done) {
         fsReadFile(fragmentShaderPath)
             .then(function(data){
-                fragmentShaderData = data;
+                fragmentShaderData = data.toString();
                 fragmentShaderUri = 'data:text/plain;base64,' + new Buffer(fragmentShaderData).toString('base64');
                 done();
             })
@@ -44,7 +44,7 @@ describe('loadShaderUris', function() {
         loadGltfUris(gltf, options)
             .then(function() {
                 expect(gltf.shaders.CesiumTexturedBoxTest0FS.extras._pipeline.source).toBeDefined();
-                expect(bufferEqual(gltf.shaders.CesiumTexturedBoxTest0FS.extras._pipeline.source, fragmentShaderData)).toBe(true);
+                expect(gltf.shaders.CesiumTexturedBoxTest0FS.extras._pipeline.source).toEqual(fragmentShaderData);
                 expect(gltf.shaders.CesiumTexturedBoxTest0FS.extras._pipeline.extension).toEqual('.glsl');
                 done();
             });
@@ -64,7 +64,7 @@ describe('loadShaderUris', function() {
         loadGltfUris(gltf, options)
             .then(function() {
                 expect(gltf.shaders.box0FS.extras._pipeline.source).toBeDefined();
-                expect(bufferEqual(gltf.shaders.box0FS.extras._pipeline.source, fragmentShaderData)).toBe(true);
+                expect(gltf.shaders.box0FS.extras._pipeline.source).toEqual(fragmentShaderData);
                 expect(gltf.shaders.box0FS.extras._pipeline.extension).toEqual('.glsl');
                 done();
             });
@@ -88,7 +88,7 @@ describe('loadShaderUris', function() {
         loadGltfUris(gltf, options)
             .then(function() {
                 expect(gltf.shaders.externalBox0FS.extras._pipeline.source).toBeDefined();
-                expect(bufferEqual(gltf.shaders.embeddedBox0FS.extras._pipeline.source, fragmentShaderData)).toBe(true);
+                expect(gltf.shaders.embeddedBox0FS.extras._pipeline.source).toEqual(fragmentShaderData);
                 expect(gltf.shaders.externalBox0FS.extras._pipeline.extension).toEqual('.glsl');
                 done();
             });

--- a/specs/lib/octEncodeNormalsSpec.js
+++ b/specs/lib/octEncodeNormalsSpec.js
@@ -90,7 +90,7 @@ describe('octEncodeNormals', function() {
                    type: WebGLConstants.VERTEX_SHADER,
                    extras : {
                        _pipeline : {
-                           source : new Buffer('')
+                           source : ''
                        }
                    }
                }
@@ -110,7 +110,7 @@ describe('octEncodeNormals', function() {
            expect(encodedBuffer.length).toEqual(buffer.byteLength);
 
            var vs = gltf.shaders.VS.extras._pipeline.source;
-           expect(Buffer.isBuffer(vs)).toBe(true);
+           expect(typeof vs).toEqual('string');
 
            var normal = new Cartesian3();
            for (var i = 0; i < normalAccessor.count; i++) {
@@ -289,7 +289,7 @@ describe('octEncodeNormals', function() {
                     type: WebGLConstants.VERTEX_SHADER,
                     extras : {
                         _pipeline : {
-                            source : new Buffer('')
+                            source : ''
                         }
                     }
                 },
@@ -297,7 +297,7 @@ describe('octEncodeNormals', function() {
                     type: WebGLConstants.VERTEX_SHADER,
                     extras : {
                         _pipeline : {
-                            source : new Buffer('')
+                            source : ''
                         }
                     }
                 }

--- a/specs/lib/parseBinaryGltfSpec.js
+++ b/specs/lib/parseBinaryGltfSpec.js
@@ -105,7 +105,7 @@ describe('parseBinaryGltf', function() {
         var gltf = parseBinaryGltf(testData.binary);
 
         expect(gltf.shaders.CesiumTexturedBoxTest0FS.extras._pipeline.source).toBeDefined();
-        expect(bufferEqual(gltf.shaders.CesiumTexturedBoxTest0FS.extras._pipeline.source, testData.shader)).toBe(true);
+        expect(gltf.shaders.CesiumTexturedBoxTest0FS.extras._pipeline.source).toEqual(testData.shader.toString());
     });
 
     it('throws an error', function() {


### PR DESCRIPTION
@lilleyse, could you take a look at this when you get a chance?

These changes make `parseBinaryGltf` work with Cesium in the browser.

It also changes `extras._pipeline.source` for shaders to be a string. This removes unnecessary conversion back and forth string <-> buffer, and makes more sense in the browser.