### PR TITLE
Add pipeline extras cleanup

### DIFF
--- a/lib/addPipelineExtras.js
+++ b/lib/addPipelineExtras.js
@@ -1,116 +1,65 @@
 'use strict';
 var Cesium = require('cesium');
 
+var defaultValue = Cesium.defaultValue;
 var defined = Cesium.defined;
 
 module.exports = addPipelineExtras;
 
+// Objects with these ids should not have extras added
+var exceptions = {
+    attributes: true,
+    uniforms: true
+};
 /**
- * Adds extras._pipeline to each object in the glTF asset.
+ * Adds extras._pipeline to each object that can have extras in the glTF asset.
  *
  * @param {Object} gltf A javascript object containing a glTF asset.
  * @returns {Object} The glTF asset with the added pipeline extras.
  */
 function addPipelineExtras(gltf) {
-    var reference = {
-        "accessors": { "accessorObject": { "addPipelineExtra": true } },
-        "animations": {
-            "animationObject": {
-                "channels": [
-                    { 
-                        "target": { "addPipelineExtra": true },
-                        "addPipelineExtra": true
+    var objectStack = [];
+    gltf.extras = defaultValue(gltf.extras, {});
+    gltf.extras._pipeline = defaultValue(gltf.extras._pipeline, {});
+    for (var rootObjectId in gltf) {
+        if (gltf.hasOwnProperty(rootObjectId)) {
+            var rootObject = gltf[rootObjectId];
+            for (var topLevelObjectId in rootObject) {
+                if (rootObject.hasOwnProperty(topLevelObjectId)) {
+                    var topLevelObject = rootObject[topLevelObjectId];
+                    if (defined(topLevelObject) && typeof topLevelObject === 'object') {
+                        objectStack.push(topLevelObject);
                     }
-                ],
-                "samplers": { "samplerObject": { "addPipelineExtra": true } },
-                "addPipelineExtra": true
-            }
-        },
-        "asset": {
-            "profile": { "addPipelineExtra": true },
-            "addPipelineExtra": true
-        },
-        "buffers": { "bufferObject": { "addPipelineExtra": true } },
-        "bufferViews": { "bufferViewObject": { "addPipelineExtra": true } },
-        "cameras": {
-            "cameraObject": {
-                "orthographic": { "addPipelineExtra": true },
-                "perspective": { "addPipelineExtra": true },
-                "addPipelineExtra": true
-            }
-        },
-        "images": { "imageObject": { "addPipelineExtra": true } },
-        "materials": { "materialObject": { "addPipelineExtra": true } },
-        "meshes": {
-            "meshObject": {
-                "primitives": [
-                    { "addPipelineExtra": true }
-                ],
-                "addPipelineExtra": true
-            }
-        },
-        "nodes": { "nodeObject": { "addPipelineExtra": true } },
-        "programs": { "programObject": { "addPipelineExtra": true } },
-        "samplers": { "samplerObject": { "addPipelineExtra": true } },
-        "scenes": { "sceneObject": { "addPipelineExtra": true } },
-        "shaders": { "shaderObject": { "addPipelineExtra": true } },
-        "skins": { "skinObject": { "addPipelineExtra": true } },
-        "techniques": { 
-            "techniqueObject": {
-                "parameters": { "parameterObject": { "addPipelineExtra": true } },
-                "states": { 
-                    "functions": { "addPipelineExtra": true },
-                    "addPipelineExtra": true 
-                },
-                "addPipelineExtra": true
-            }
-        },
-        "textures": { "textureObject": { "addPipelineExtra": true } },
-        "addPipelineExtra": true
-    };
-
-    addPipelineExtra(gltf, reference);
-
-    return gltf;
-}
-
-function addPipelineExtra(object, reference) {
-    if (defined(reference) && defined(object) && typeof object === 'object') {
-        if (defined(reference.addPipelineExtra)) {
-            if (defined(object.extras)) {
-                object.extras._pipeline = {
-                    "deleteExtras": false
-                };
-            }
-            else {
-                object.extras = {
-                    "_pipeline": {
-                        "deleteExtras": true
-                    }
-                };
+                }
             }
         }
-
-        for (var propertyId in object) {
-            if (object.hasOwnProperty(propertyId) && propertyId !== 'extras') {
-                var property = object[propertyId];
-
-                if (reference.hasOwnProperty(propertyId)) {
-                    addPipelineExtra(property, reference[propertyId]);
+    }
+    if (defined(gltf.asset)) {
+        objectStack.push(gltf.asset);
+    }
+    while (objectStack.length > 0) {
+        var object = objectStack.pop();
+        if (Array.isArray(object)) {
+            var length = object.length;
+            for (var i = 0; i < length; i++) {
+                var item = object[i];
+                if (typeof item === 'object') {
+                    objectStack.push(item);
                 }
-                else {
-                    for (var referencePropertyId in reference) {
-                        if (reference.hasOwnProperty(referencePropertyId)) {
-                            var referenceProperty = reference[referencePropertyId];
-                            if (typeof referenceProperty === 'object') {
-                                addPipelineExtra(property, referenceProperty);
-                            }
-                        }
+            }
+        } else {
+            object.extras = defaultValue(object.extras, {});
+            object.extras._pipeline = defaultValue(object.extras._pipeline, {});
+            for (var propertyId in object) {
+                if (object.hasOwnProperty(propertyId)) {
+                    var property = object[propertyId];
+                    if (defined(property) && typeof property === 'object' && propertyId !== 'extras' && !exceptions[propertyId]) {
+                        objectStack.push(property);
                     }
                 }
             }
         }
     }
 
-    return object;
+    return gltf;
 }

--- a/lib/addPipelineExtras.js
+++ b/lib/addPipelineExtras.js
@@ -9,7 +9,8 @@ module.exports = addPipelineExtras;
 // Objects with these ids should not have extras added
 var exceptions = {
     attributes: true,
-    uniforms: true
+    uniforms: true,
+    extensions: true
 };
 /**
  * Adds extras._pipeline to each object that can have extras in the glTF asset.

--- a/lib/bakeAmbientOcclusion.js
+++ b/lib/bakeAmbientOcclusion.js
@@ -123,7 +123,7 @@ function generateOptions(gltf, aoOptions) {
         rayDistance : -1.0, // indicates that rayDistance must be computed
         nearCull : 0.0001,
         shaderMode : 'blend',
-        sceneID : gltf.scene,
+        sceneID : gltf.scene
     };
 
     if (defined(aoOptions)) {

--- a/lib/combineMeshes.js
+++ b/lib/combineMeshes.js
@@ -54,9 +54,7 @@ function combineMeshes(gltf) {
                         "name": nodeId + '_mesh',
                         "primitives": primitiveList,
                         "extras": {
-                            "_pipeline": {
-                                "deleteExtras": true
-                            }
+                            "_pipeline": {}
                         }
                     };
 

--- a/lib/combinePrimitives.js
+++ b/lib/combinePrimitives.js
@@ -238,9 +238,7 @@ function createPrimitive(gltf, attributes, attributeTypes, indices, materialId, 
         material : materialId,
         mode : mode,
         extras : {
-            _pipeline : {
-                deleteExtras : true
-            }
+            _pipeline : {}
         }
     };
     if(defined(indices)) {

--- a/lib/createAccessor.js
+++ b/lib/createAccessor.js
@@ -56,9 +56,7 @@ function createAccessor(gltf, dataOrLength, type, componentType, target, id) {
         componentType : componentType,
         count : dataLength / numberOfComponents,
         extras : {
-            _pipeline : {
-                deleteExtras : true
-            }
+            _pipeline : {}
         },
         type : type
     };
@@ -69,9 +67,7 @@ function createAccessor(gltf, dataOrLength, type, componentType, target, id) {
         byteLength : bufferData.length,
         byteOffset : 0,
         extras : {
-            _pipeline : {
-                deleteExtras : true
-            }
+            _pipeline : {}
         },
         target : target
     };
@@ -82,7 +78,6 @@ function createAccessor(gltf, dataOrLength, type, componentType, target, id) {
         byteLength : bufferData.length,
         extras : {
             _pipeline : {
-                deleteExtras : true,
                 extension : '.bin',
                 source : bufferData
             }

--- a/lib/mergeBuffers.js
+++ b/lib/mergeBuffers.js
@@ -57,8 +57,7 @@ function mergeBuffers(gltf, bufferId) {
             "extras": {
                 "_pipeline": {
                     "source": source,
-                    "extension": ".bin",
-                    "deleteExtras": true
+                    "extension": ".bin"
                 }
             }
         };

--- a/lib/parseBinaryGltf.js
+++ b/lib/parseBinaryGltf.js
@@ -129,8 +129,7 @@ function parseBinaryGltf(data) {
                     "uri": "data:,",
                     "extras": {
                         "_pipeline": {
-                            "source": body.slice(viewStart, viewEnd),
-                            "deleteExtras": true //Move to addPipelineExtras
+                            "source": body.slice(viewStart, viewEnd)
                         }
                     }
                 };

--- a/lib/removePipelineExtras.js
+++ b/lib/removePipelineExtras.js
@@ -2,7 +2,6 @@
 var Cesium = require('cesium');
 
 var defined = Cesium.defined;
-var defaultValue = Cesium.defaultValue;
 
 module.exports = removePipelineExtras;
 /**
@@ -14,10 +13,9 @@ module.exports = removePipelineExtras;
 function removePipelineExtras(object) {
     if (defined(object) && typeof object === 'object') {
         if (defined(object.extras) && defined(object.extras._pipeline)) {
-            var deleteExtras = defaultValue(object.extras._pipeline.deleteExtras, true);
             delete object.extras._pipeline;
-            //Also delete extras if extras._pipeline is the only extras object
-            if (deleteExtras && Object.keys(object.extras).length === 0) {
+            // Also delete extras if extras._pipeline is the only extras object
+            if (Object.keys(object.extras).length === 0) {
                 delete object.extras;
             }
         }

--- a/lib/uninterleaveAndPackBuffers.js
+++ b/lib/uninterleaveAndPackBuffers.js
@@ -85,9 +85,7 @@ function packAccessorsForTarget(gltf, bufferId, target, accessorsByByteLength, s
         byteLength : packOffset - originalOffset,
         byteOffset : originalOffset,
         extras : {
-            _pipeline : {
-                deleteExtras : true
-            }
+            _pipeline : {}
         }
     };
     if (target > 0) {
@@ -106,7 +104,7 @@ function getPipelineExtras(object) {
     }
     var pipeline = extras._pipeline;
     if (!defined(pipeline)) {
-        pipeline = {deleteExtras : true};
+        pipeline = {};
         extras._pipeline = pipeline;
     }
     return pipeline;

--- a/specs/data/boxTexturedUnoptimized/CesiumTexturedBoxTestRemoveExtras.gltf
+++ b/specs/data/boxTexturedUnoptimized/CesiumTexturedBoxTestRemoveExtras.gltf
@@ -89,9 +89,7 @@
                 "shininess": 256
             },
             "extras": {
-                "_pipeline": {
-                    "deleteExtras": true
-                }
+                "_pipeline": {}
             }
         }
     },
@@ -109,16 +107,12 @@
                     "material": "Effect-Texture",
                     "mode": 4,
                     "extras": {
-                        "_pipeline": {
-                            "deleteExtras": true
-                        }
+                        "_pipeline": {}
                     }
                 }
             ],
             "extras": {
-                "_pipeline": {
-                    "deleteExtras": true
-                }
+                "_pipeline": {}
             }
         }
     },
@@ -130,9 +124,7 @@
             ],
             "name": "Mesh",
             "extras": {
-                "_pipeline": {
-                    "deleteExtras": true
-                }
+                "_pipeline": {}
             }
         }
     },
@@ -146,9 +138,7 @@
             "fragmentShader": "CesiumTexturedBoxTest0FS",
             "vertexShader": "CesiumTexturedBoxTest0VS",
             "extras": {
-                "_pipeline": {
-                    "deleteExtras": true
-                }
+                "_pipeline": {}
             }
         }
     },
@@ -159,9 +149,7 @@
             "wrapS": 10497,
             "wrapT": 10497,
             "extras": {
-                "_pipeline": {
-                    "deleteExtras": true
-                }
+                "_pipeline": {}
             }
         }
     },
@@ -172,9 +160,7 @@
                 "node_3"
             ],
             "extras": {
-                "_pipeline": {
-                    "deleteExtras": true
-                }
+                "_pipeline": {}
             }
         }
     },

--- a/specs/lib/addPipelineExtrasSpec.js
+++ b/specs/lib/addPipelineExtrasSpec.js
@@ -19,73 +19,44 @@ describe('addPipelineExtras', function() {
 
     it('added an extras object to objects without extras', function() {
         expect(gltf.accessors.accessor_21.extras._pipeline).toBeDefined();
-        expect(gltf.accessors.accessor_21.extras._pipeline.deleteExtras).toBe(true);
         expect(gltf.animations.animation_0.extras._pipeline).toBeDefined();
         expect(gltf.animations.animation_0.channels[0].extras._pipeline).toBeDefined();
-        expect(gltf.animations.animation_0.channels[0].extras._pipeline.deleteExtras).toBe(true);
         expect(gltf.animations.animation_0.channels[0].target.extras._pipeline).toBeDefined();
-        expect(gltf.animations.animation_0.channels[0].target.extras._pipeline.deleteExtras).toBe(true);
-        expect(gltf.animations.animation_0.extras._pipeline.deleteExtras).toBe(true);
         expect(gltf.animations.animation_0.samplers.sampler.extras._pipeline).toBeDefined();
-        expect(gltf.animations.animation_0.samplers.sampler.extras._pipeline.deleteExtras).toBe(true);
         expect(gltf.asset.extras._pipeline).toBeDefined();
-        expect(gltf.asset.extras._pipeline.deleteExtras).toBe(true);
         expect(gltf.asset.profile.extras._pipeline).toBeDefined();
-        expect(gltf.asset.profile.extras._pipeline.deleteExtras).toBe(true);
         expect(gltf.extras._pipeline).toBeDefined();
-        expect(gltf.extras._pipeline.deleteExtras).toBe(true);
         expect(gltf.buffers.CesiumTexturedBoxTest.extras._pipeline).toBeDefined();
-        expect(gltf.buffers.CesiumTexturedBoxTest.extras._pipeline.deleteExtras).toBe(true);
         expect(gltf.bufferViews.bufferView_29.extras._pipeline).toBeDefined();
-        expect(gltf.bufferViews.bufferView_29.extras._pipeline.deleteExtras).toBe(true);
         expect(gltf.cameras.camera_0.extras._pipeline).toBeDefined();
-        expect(gltf.cameras.camera_0.extras._pipeline.deleteExtras).toBe(true);
         expect(gltf.cameras.camera_0.orthographic.extras._pipeline).toBeDefined();
-        expect(gltf.cameras.camera_0.orthographic.extras._pipeline.deleteExtras).toBe(true);
         expect(gltf.cameras.camera_0.perspective.extras._pipeline).toBeDefined();
-        expect(gltf.cameras.camera_0.perspective.extras._pipeline.deleteExtras).toBe(true);
         expect(gltf.images.Image0001.extras._pipeline).toBeDefined();
-        expect(gltf.images.Image0001.extras._pipeline.deleteExtras).toBe(true);
     });
 
     it('added a _pipeline object to existing extras', function() {
         expect(gltf.materials.EffectTexture.extras._pipeline).toBeDefined();
-        expect(gltf.materials.EffectTexture.extras._pipeline.deleteExtras).toBe(false);
         expect(gltf.meshes.mesh002.extras._pipeline).toBeDefined();
-        expect(gltf.meshes.mesh002.extras._pipeline.deleteExtras).toBe(false);
         expect(gltf.meshes.mesh002.primitives[0].extras._pipeline).toBeDefined();
-        expect(gltf.meshes.mesh002.primitives[0].extras._pipeline.deleteExtras).toBe(false);
         expect(gltf.nodes.mesh002Node.extras._pipeline).toBeDefined();
-        expect(gltf.nodes.mesh002Node.extras._pipeline.deleteExtras).toBe(false);
         expect(gltf.programs.program_0.extras._pipeline).toBeDefined();
-        expect(gltf.programs.program_0.extras._pipeline.deleteExtras).toBe(false);
         expect(gltf.samplers.sampler_0.extras._pipeline).toBeDefined();
-        expect(gltf.samplers.sampler_0.extras._pipeline.deleteExtras).toBe(false);
         expect(gltf.scenes.defaultScene.extras._pipeline).toBeDefined();
-        expect(gltf.scenes.defaultScene.extras._pipeline.deleteExtras).toBe(false);
     });
 
     it('did not overwrite existing extras objects', function() {
         expect(gltf.shaders.CesiumTexturedBoxTest0FS.extras._pipeline).toBeDefined();
         expect(gltf.shaders.CesiumTexturedBoxTest0FS.extras.misc).toBeDefined();
-        expect(gltf.shaders.CesiumTexturedBoxTest0FS.extras._pipeline.deleteExtras).toBe(false);
         expect(gltf.skins.Armature_Cylinder_skin.extras._pipeline).toBeDefined();
         expect(gltf.skins.Armature_Cylinder_skin.extras.misc).toBeDefined();
-        expect(gltf.skins.Armature_Cylinder_skin.extras._pipeline.deleteExtras).toBe(false);
         expect(gltf.techniques.technique0.extras._pipeline).toBeDefined();
         expect(gltf.techniques.technique0.extras.misc).toBeDefined();
-        expect(gltf.techniques.technique0.extras._pipeline.deleteExtras).toBe(false);
-        expect(gltf.techniques.technique0.parameters.diffuse.extras._pipeline).toBeDefined();
         expect(gltf.techniques.technique0.parameters.diffuse.extras.misc).toBeDefined();
-        expect(gltf.techniques.technique0.parameters.diffuse.extras._pipeline.deleteExtras).toBe(false);
         expect(gltf.techniques.technique0.states.extras._pipeline).toBeDefined();
         expect(gltf.techniques.technique0.states.extras.misc).toBeDefined();
-        expect(gltf.techniques.technique0.states.extras._pipeline.deleteExtras).toBe(false);
         expect(gltf.techniques.technique0.states.functions.extras._pipeline).toBeDefined();
         expect(gltf.techniques.technique0.states.functions.extras.misc).toBeDefined();
-        expect(gltf.techniques.technique0.states.functions.extras._pipeline.deleteExtras).toBe(false);
         expect(gltf.textures.texture_Image0001.extras._pipeline).toBeDefined();
         expect(gltf.textures.texture_Image0001.extras.misc).toBeDefined();
-        expect(gltf.textures.texture_Image0001.extras._pipeline.deleteExtras).toBe(false);
     });
 });

--- a/specs/lib/mergeBuffersSpec.js
+++ b/specs/lib/mergeBuffersSpec.js
@@ -28,8 +28,7 @@ describe('mergeBuffers', function() {
                     "extras": {
                         "_pipeline": {
                           "source": buffer0,
-                          "extension": ".bin",
-                          "deleteExtras": true
+                          "extension": ".bin"
                         }
                     }
                 },
@@ -40,8 +39,7 @@ describe('mergeBuffers', function() {
                     "extras": {
                         "_pipeline": {
                           "source": buffer1,
-                          "extension": ".bin",
-                          "deleteExtras": true
+                          "extension": ".bin"
                         }
                     }
                 }
@@ -71,8 +69,7 @@ describe('mergeBuffers', function() {
                     "extras": {
                         "_pipeline": {
                           "source": bufferMerged,
-                          "extension": ".bin",
-                          "deleteExtras": true
+                          "extension": ".bin"
                         }
                     }
                 }

--- a/specs/lib/writeBuffersSpec.js
+++ b/specs/lib/writeBuffersSpec.js
@@ -28,8 +28,7 @@ describe('writeBuffers', function() {
                             "extras": {
                                 "_pipeline": {
                                     "source": bufferData,
-                                    "extension": '.bin',
-                                    "deleteExtras": true
+                                    "extension": '.bin'
                                 }
                             }
                         }

--- a/specs/lib/writeImagesSpec.js
+++ b/specs/lib/writeImagesSpec.js
@@ -28,8 +28,7 @@ describe('writeImages', function() {
                             "extras": {
                                 "_pipeline": {
                                     "source": imageData,
-                                    "extension": '.png',
-                                    "deleteExtras": true
+                                    "extension": '.png'
                                 }
                             }
                         }

--- a/specs/lib/writeShadersSpec.js
+++ b/specs/lib/writeShadersSpec.js
@@ -29,8 +29,7 @@ describe('writeShaders', function() {
                             "extras": {
                                 "_pipeline": {
                                     "source": fragmentShaderData,
-                                    "extension": '.glsl',
-                                    "deleteExtras": true
+                                    "extension": '.glsl'
                                 }
                             }
                         }


### PR DESCRIPTION
@lilleyse, can you look at this when you get a chance?

This reduces `addPipelineExtras` to not be quite so verbose. It also removes the `deleteExtras` qualification from removing pipeline extras, since there is currently no situation I am aware of where we want to export a gltf with pipeline extras.