### PR TITLE
Make findAccessorMinMax browser friendly

### DIFF
--- a/lib/findAccessorMinMax.js
+++ b/lib/findAccessorMinMax.js
@@ -1,12 +1,11 @@
 'use strict';
 var Cesium = require('cesium');
 
+var ComponentDatatype = Cesium.ComponentDatatype;
 var defined = Cesium.defined;
 
-var byteLengthForComponentType = require('./byteLengthForComponentType');
 var getAccessorByteStride = require('./getAccessorByteStride');
 var numberOfComponentsForType = require('./numberOfComponentsForType');
-var readBufferComponent = require('./readBufferComponent');
 
 module.exports = findAccessorMinMax;
 
@@ -35,15 +34,16 @@ function findAccessorMinMax(gltf, accessor) {
         if (defined(bufferId) && defined(buffers) && buffers.hasOwnProperty(bufferId)) {
             var buffer = buffers[bufferId];
             var source = buffer.extras._pipeline.source;
+
             var count = accessor.count;
             var byteStride = getAccessorByteStride(accessor);
             var byteOffset = accessor.byteOffset + bufferView.byteOffset;
             var componentType = accessor.componentType;
-            var componentByteLength = byteLengthForComponentType(componentType);
 
             for (var i = 0; i < count; i++) {
+                var typedArray = ComponentDatatype.createArrayBufferView(componentType, source.buffer, byteOffset, numberOfComponents);
                 for (var j = 0; j < numberOfComponents; j++) {
-                    var value = readBufferComponent(source, componentType, byteOffset + j * componentByteLength);
+                    var value = typedArray[j];
                     min[j] = Math.min(min[j], value);
                     max[j] = Math.max(max[j], value);
                 }


### PR DESCRIPTION
@lilleyse, can you look at this when you get a chance?

This makes `findAccessorMinMax` use `ComponentDatatype` from Cesium so that it works in the browser.