### PR TITLE
Optimize mergeBuffers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 Change Log
 ==========
 
+### 0.1.0-alpha11 - ??
+* Optimized `mergeBuffers` to avoid repeated copies, drastically improving performance when there are lots of buffers to merge.
+
 ### 0.1.0-alpha10 - 2017-01-10
 * Added `tangentsBitangents` generation option
 

--- a/lib/mergeBuffers.js
+++ b/lib/mergeBuffers.js
@@ -24,7 +24,8 @@ function mergeBuffers(gltf, bufferId) {
     var bufferViewsForBuffers = getBufferViewsForBuffers(gltf);
 
     if (defined(buffers)) {
-        var source = new Buffer(0);
+        var buffersToMerge = [];
+        var lengthSoFar = 0;
         for (var gltfBufferId in buffers) {
             if (buffers.hasOwnProperty(gltfBufferId)) {
                 //Add the buffer to the merged source
@@ -36,13 +37,16 @@ function mergeBuffers(gltf, bufferId) {
                 for (var bufferViewId in bufferViewIds) {
                     if (bufferViewIds.hasOwnProperty(bufferViewId)) {
                         var bufferView = bufferViews[bufferViewId];
-                        bufferView.byteOffset += source.length;
+                        bufferView.byteOffset += lengthSoFar;
                         bufferView.buffer = bufferId;
                     }
                 }
-                source = Buffer.concat([source, buffer.extras._pipeline.source]);
+                buffersToMerge.push(buffer.extras._pipeline.source);
+                lengthSoFar += buffer.extras._pipeline.source.length;
             }
         }
+
+        var source = Buffer.concat(buffersToMerge, lengthSoFar);
 
         if (!defined(bufferId)) {
             bufferId = getUniqueId(gltf, 'buffer');


### PR DESCRIPTION
Optimized `mergeBuffers` to avoid repeated copies, drastically improving performance when there are lots of buffers to merge.