### PR TITLE
Don't try to add extras to null objects.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 Change Log
 ==========
 
+### 0.1.0-alpha11 - ??
+* Fixed a bug in `addPipelineExtras` that made it try to add extras to null objects.
+
 ### 0.1.0-alpha10 - 2017-01-10
 * Added `tangentsBitangents` generation option
 

--- a/lib/addPipelineExtras.js
+++ b/lib/addPipelineExtras.js
@@ -44,7 +44,7 @@ function addPipelineExtras(gltf) {
             var length = object.length;
             for (var i = 0; i < length; i++) {
                 var item = object[i];
-                if (typeof item === 'object') {
+                if (defined(item) && typeof item === 'object') {
                     objectStack.push(item);
                 }
             }

--- a/specs/data/boxTexturedUnoptimized/CesiumTexturedBoxTestAddExtras.gltf
+++ b/specs/data/boxTexturedUnoptimized/CesiumTexturedBoxTestAddExtras.gltf
@@ -6,23 +6,6 @@
             "componentType": 5123,
             "count": 36,
             "type": "SCALAR"
-        },
-        "accessor_25": {
-            "bufferView": "bufferView_29",
-            "byteOffset": 0,
-            "componentType": 5123,
-            "count": 36,
-            "type": "SCALAR",
-            "min": [
-                null,
-                null,
-                null
-            ],
-            "max": [
-                null,
-                null,
-                null
-            ]
         }
     },
     "animations": {

--- a/specs/data/boxTexturedUnoptimized/CesiumTexturedBoxTestAddExtras.gltf
+++ b/specs/data/boxTexturedUnoptimized/CesiumTexturedBoxTestAddExtras.gltf
@@ -6,6 +6,23 @@
             "componentType": 5123,
             "count": 36,
             "type": "SCALAR"
+        },
+        "accessor_25": {
+            "bufferView": "bufferView_29",
+            "byteOffset": 0,
+            "componentType": 5123,
+            "count": 36,
+            "type": "SCALAR",
+            "min": [
+                null,
+                null,
+                null
+            ],
+            "max": [
+                null,
+                null,
+                null
+            ]
         }
     },
     "animations": {

--- a/specs/lib/addPipelineExtrasSpec.js
+++ b/specs/lib/addPipelineExtrasSpec.js
@@ -59,4 +59,26 @@ describe('addPipelineExtras', function() {
         expect(gltf.textures.texture_Image0001.extras._pipeline).toBeDefined();
         expect(gltf.textures.texture_Image0001.extras.misc).toBeDefined();
     });
+
+    it('does not attempt to add extras to null objects', function() {
+        gltf.accessors.accessor_25 = {
+            "bufferView": "bufferView_29",
+            "byteOffset": 0,
+            "componentType": 5123,
+            "count": 36,
+            "type": "SCALAR",
+            "min": [
+                null,
+                null,
+                null
+            ],
+            "max": [
+                null,
+                null,
+                null
+            ]
+        };
+        addPipelineExtras(gltf);
+        expect(gltf.accessors.accessor_25).toBeDefined();
+    });
 });


### PR DESCRIPTION
Surprisingly, `typeof null === 'object'`.  I modified `CesiumTexturedBoxTestAddExtras.gltf` to trigger the bug fixed by this PR.  I realize it's kinda dodgy glTF, but I ran into it in a real model.