### PR TITLE
Add missing documentation for exported functions

### DIFF
--- a/lib/PrimitiveHelpers.js
+++ b/lib/PrimitiveHelpers.js
@@ -186,10 +186,10 @@ function transformPrimitives(gltf, primitives, transform) {
 }
 
 /**
- * Returns primitives sorted by material.
+ * Returns primitives mapped to mode mapped to material.
  *
- * @param {Object[]} primitives An array containing the primitive to sort.
- * @returns {Object} An object mapping material ids to an array of primitives.
+ * @param {Object[]} primitives An array containing the primitives to sort.
+ * @returns {Object} An object mapping material ids to mode to an array of primitives.
  */
 function getPrimitivesByMaterialMode(primitives) {
     var primitivesLength = primitives.length;
@@ -216,9 +216,9 @@ function getPrimitivesByMaterialMode(primitives) {
 /**
  * Return primitives that share attribute accessors with a given primitive.
  *
- * @param {Object[]} primitives An array of primitive objects to compare the primitve against.
- * @param {Object} primitive The primitve to compare for conflicts.
- * @returns {Number[]} An array conmtaining indices of primitives that have attribute accessor conflicts.
+ * @param {Object[]} primitives An array of primitive objects to compare the primitive against.
+ * @param {Object} primitive The primitive to compare for conflicts.
+ * @returns {Number[]} An array containing indices of primitives that have attribute accessor conflicts.
  */
 function getPrimitiveConflicts(primitives, primitive) {
     var primitivesLength = primitives.length;
@@ -233,10 +233,10 @@ function getPrimitiveConflicts(primitives, primitive) {
 }
 
 /**
- * Return all the primitives in its meshes.
+ * Return all the primitives in the meshes of the glTF asset.
  *
  * @param {Object} gltf A javascript object containing a glTF asset.
- * @returns {Object[]} An array conmtaining all the primitives.
+ * @returns {Object[]} An array containing all the primitives.
  */
 function getAllPrimitives(gltf) {
     var primitives = [];

--- a/lib/PrimitiveHelpers.js
+++ b/lib/PrimitiveHelpers.js
@@ -22,7 +22,7 @@ module.exports = {
 };
 
 /**
- * Compare two primitives to check if they share an arrtibute.
+ * Compare two primitives to check if they share an attribute accessor.
  *
  * @param {Object} primitive The first primitive to compare.
  * @param {Object} comparePrimitive The second primitive to compare.
@@ -79,12 +79,11 @@ function primitivesHaveOverlappingIndexAccessors(gltf, primitive, comparePrimiti
 }
 
 /**
- * Compare two primitives to check if they have an overlapping index accessor.
+ * Apply a given transform to an array of primitives.
  *
  * @param {Object} gltf A javascript object containing a glTF asset.
- * @param {Array} primitives An array containing the primitives that need to be transformed.
+ * @param {Object[]} primitives An array containing the primitives that need to be transformed.
  * @param {Matrix4} transform The transform to apply to the primitives.
- * @returns {Boolean} True if primitives have an overlapping index accessor, false otherwise.
  */
 function transformPrimitives(gltf, primitives, transform) {
     var inverseTranspose = new Matrix4();
@@ -187,12 +186,10 @@ function transformPrimitives(gltf, primitives, transform) {
 }
 
 /**
- * Get a hash table like object with the material as the hash and the
- * primitives that use the material in an array as the bucket.
+ * Returns primitives sorted by material.
  *
- * @param {Array} primitives An array containing the primitive to sort.
- * @returns {Object} An object with properties names of material types where
- * each property is an array conmtaining all the primitives that use that material.
+ * @param {Object[]} primitives An array containing the primitive to sort.
+ * @returns {Object} An object mapping material ids to an array of primitives.
  */
 function getPrimitivesByMaterialMode(primitives) {
     var primitivesLength = primitives.length;
@@ -217,11 +214,11 @@ function getPrimitivesByMaterialMode(primitives) {
 }
 
 /**
- * Process the glTF asset primitives and return primitives that share attribute accessors.
+ * Return primitives that share attribute accessors with a given primitive.
  *
- * @param {Array} primitives An array of primitive objects to compare the primitve against.
+ * @param {Object[]} primitives An array of primitive objects to compare the primitve against.
  * @param {Object} primitive The primitve to compare for conflicts.
- * @returns {Array} An array conmtaining all the primitives that share attribute accessor.
+ * @returns {Number[]} An array conmtaining indices of primitives that have attribute accessor conflicts.
  */
 function getPrimitiveConflicts(primitives, primitive) {
     var primitivesLength = primitives.length;
@@ -236,10 +233,10 @@ function getPrimitiveConflicts(primitives, primitive) {
 }
 
 /**
- * Process the glTF asset and return all the primitives in its meshes.
+ * Return all the primitives in its meshes.
  *
- * @param {Object} gltf a javascript object containing a glTF asset.
- * @returns {Array} An array conmtaining all the primitives.
+ * @param {Object} gltf A javascript object containing a glTF asset.
+ * @returns {Object[]} An array conmtaining all the primitives.
  */
 function getAllPrimitives(gltf) {
     var primitives = [];

--- a/lib/PrimitiveHelpers.js
+++ b/lib/PrimitiveHelpers.js
@@ -21,6 +21,13 @@ module.exports = {
     transformPrimitives : transformPrimitives
 };
 
+/**
+ * Compare two primitives to check if they share an arrtibute.
+ *
+ * @param {Object} primitive The first primitive to compare.
+ * @param {Object} comparePrimitive The second primitive to compare.
+ * @returns {Boolean} True if primitives share an attribute, false otherwise.
+ */
 function primitivesShareAttributeAccessor(primitive, comparePrimitive) {
     var attributes = primitive.attributes;
     var compareAttributes = comparePrimitive.attributes;
@@ -36,6 +43,14 @@ function primitivesShareAttributeAccessor(primitive, comparePrimitive) {
     return false;
 }
 
+/**
+ * Compare two primitives to check if they have an overlapping index accessor.
+ *
+ * @param {Object} gltf A javascript object containing a glTF asset.
+ * @param {Object} primitive The first primitive to compare.
+ * @param {Object} comparePrimitive The second primitive to compare.
+ * @returns {Boolean} True if primitives have an overlapping index accessor, false otherwise.
+ */
 function primitivesHaveOverlappingIndexAccessors(gltf, primitive, comparePrimitive) {
     var accessors = gltf.accessors;
     var indexAccessorId = primitive.indices;
@@ -63,6 +78,14 @@ function primitivesHaveOverlappingIndexAccessors(gltf, primitive, comparePrimiti
     return false;
 }
 
+/**
+ * Compare two primitives to check if they have an overlapping index accessor.
+ *
+ * @param {Object} gltf A javascript object containing a glTF asset.
+ * @param {Array} primitives An array containing the primitives that need to be transformed.
+ * @param {Matrix4} transform The transform to apply to the primitives.
+ * @returns {Boolean} True if primitives have an overlapping index accessor, false otherwise.
+ */
 function transformPrimitives(gltf, primitives, transform) {
     var inverseTranspose = new Matrix4();
     if (Matrix4.equals(transform, Matrix4.IDENTITY)) {
@@ -163,6 +186,14 @@ function transformPrimitives(gltf, primitives, transform) {
     }
 }
 
+/**
+ * Get a hash table like object with the material as the hash and the
+ * primitives that use the material in an array as the bucket.
+ *
+ * @param {Array} primitives An array containing the primitive to sort.
+ * @returns {Object} An object with properties names of material types where
+ * each property is an array conmtaining all the primitives that use that material.
+ */
 function getPrimitivesByMaterialMode(primitives) {
     var primitivesLength = primitives.length;
     var primitivesByMaterialMode = {};
@@ -185,6 +216,13 @@ function getPrimitivesByMaterialMode(primitives) {
     return primitivesByMaterialMode;
 }
 
+/**
+ * Process the glTF asset primitives and return primitives that share attribute accessors.
+ *
+ * @param {Array} primitives An array of primitive objects to compare the primitve against.
+ * @param {Object} primitive The primitve to compare for conflicts.
+ * @returns {Array} An array conmtaining all the primitives that share attribute accessor.
+ */
 function getPrimitiveConflicts(primitives, primitive) {
     var primitivesLength = primitives.length;
     var conflicts = [];
@@ -197,6 +235,12 @@ function getPrimitiveConflicts(primitives, primitive) {
     return conflicts;
 }
 
+/**
+ * Process the glTF asset and return all the primitives in its meshes.
+ *
+ * @param {Object} gltf a javascript object containing a glTF asset.
+ * @returns {Array} An array conmtaining all the primitives.
+ */
 function getAllPrimitives(gltf) {
     var primitives = [];
     var meshes = gltf.meshes;
@@ -209,6 +253,13 @@ function getAllPrimitives(gltf) {
     return primitives;
 }
 
+/**
+ * Compare two primitives to check if they are equal.
+ *
+ * @param {Object} primitiveOne The first primitive to compare.
+ * @param {Object} primitiveTwo The second primitive to compare.
+ * @returns {Boolean} True if primitives are the same, false otherwise.
+ */
 function primitiveEquals(primitiveOne, primitiveTwo) {
     return primitiveOne.mode === primitiveTwo.mode &&
             primitiveOne.material === primitiveTwo.material &&

--- a/lib/techniqueAttributeForParameter.js
+++ b/lib/techniqueAttributeForParameter.js
@@ -2,11 +2,13 @@
 module.exports = techniqueAttributeForParameter;
 
 /**
- * Retrieves the primitive attributes that has a given parameter name.
+ * Retrieves the technique attributes that has a given parameter name.
  *
  * @param {Object} technique A javascript object containing a glTF technique.
  * @param {String} parameterName The search string for parameter.
- * @returns {Array.<string>} The primitive attribute with matching paramerterName.
+ * @returns {String} The primitive attribute with matching parameterName.
+ *
+ * @private
  */
 function techniqueAttributeForParameter(technique, parameterName) {
     var attributes = technique.attributes;

--- a/lib/techniqueAttributeForParameter.js
+++ b/lib/techniqueAttributeForParameter.js
@@ -1,6 +1,13 @@
 'use strict';
 module.exports = techniqueAttributeForParameter;
 
+/**
+ * Retrieves the primitive attributes that has a given parameter name.
+ *
+ * @param {Object} technique A javascript object containing a glTF technique.
+ * @param {String} parameterName The search string for parameter.
+ * @returns {Array.<string>} The primitive attribute with matching paramerterName.
+ */
 function techniqueAttributeForParameter(technique, parameterName) {
     var attributes = technique.attributes;
     for (var attributeName in attributes) {

--- a/lib/techniqueAttributeForParameter.js
+++ b/lib/techniqueAttributeForParameter.js
@@ -2,7 +2,7 @@
 module.exports = techniqueAttributeForParameter;
 
 /**
- * Retrieves the technique attributes that has a given parameter name.
+ * Retrieves the technique attribute that has a given parameter name.
  *
  * @param {Object} technique A javascript object containing a glTF technique.
  * @param {String} parameterName The search string for parameter.

--- a/lib/techniqueParameterForSemantic.js
+++ b/lib/techniqueParameterForSemantic.js
@@ -5,6 +5,13 @@ var defined = Cesium.defined;
 
 module.exports = techniqueParameterForSemantic;
 
+/**
+ * Retrieves the technique parameter that has a matching semantic.
+ *
+ * @param {Object} technique A javascript object containing a glTF technique.
+ * @param {String} semantic The search string for semantics.
+ * @returns {Array.<string>} The technique semantics with matching semantic.
+ */
 function techniqueParameterForSemantic(technique, semantic) {
     var parameters = technique.parameters;
     for (var parameterName in parameters) {

--- a/lib/techniqueParameterForSemantic.js
+++ b/lib/techniqueParameterForSemantic.js
@@ -10,7 +10,9 @@ module.exports = techniqueParameterForSemantic;
  *
  * @param {Object} technique A javascript object containing a glTF technique.
  * @param {String} semantic The search string for semantics.
- * @returns {Array.<string>} The technique semantics with matching semantic.
+ * @returns {String} The technique semantics with matching semantic.
+ *
+ * @private
  */
 function techniqueParameterForSemantic(technique, semantic) {
     var parameters = technique.parameters;

--- a/lib/techniqueParameterForSemantic.js
+++ b/lib/techniqueParameterForSemantic.js
@@ -10,7 +10,7 @@ module.exports = techniqueParameterForSemantic;
  *
  * @param {Object} technique A javascript object containing a glTF technique.
  * @param {String} semantic The search string for semantics.
- * @returns {String} The technique semantics with matching semantic.
+ * @returns {String} The technique parameter with matching semantic.
  *
  * @private
  */


### PR DESCRIPTION
This is probably a very naive version of the docs. I've tried to fill in as much as I could with my knowledge.

I did not add documentation for any functions marked `@private` and did not add for `addDefaults` as that is undergoing restructuring as a part of #223.

Part of #163 