### PR TITLE
Uniform template function for encode images stage

### DIFF
--- a/lib/EncodeImagesStage.js
+++ b/lib/EncodeImagesStage.js
@@ -4,7 +4,18 @@ var Promise = require('bluebird');
 
 Jimp.prototype.getBufferAsync = Promise.promisify(Jimp.prototype.getBuffer);
 
-module.exports = encodeImages;
+module.exports = EncodeImagesStage;
+
+/**
+ * Encodes Jimp images in pipeline extras to buffers.
+ *
+ * The glTF asset must be initialized for the pipeline.
+ */
+function EncodeImagesStage() {
+    this.name = 'encodeImages';
+    this.before = ['quantizeAttributes'];
+    this.after = [];
+}
 
 /**
  * Encodes Jimp images in pipeline extras to buffers.
@@ -12,12 +23,13 @@ module.exports = encodeImages;
  * The glTF asset must be initialized for the pipeline.
  *
  * @param {Object} gltf A javascript object containing a glTF asset.
+ * @param {Object} options A javascript object containing options for this stage. Currently not used.
  * @returns {Promise} A promise that resolves to the glTF asset when encoding is complete for all images.
  *
  * @see addPipelineExtras
  * @see loadGltfUris
  */
-function encodeImages(gltf) {
+EncodeImagesStage.prototype.run = function(gltf, options) {
     var images = gltf.images;
     var promises = [];
     for (var imageId in images) {
@@ -45,11 +57,8 @@ function encodeImages(gltf) {
             }
         }
     }
-    return Promise.all(promises)
-        .then(function() {
-            return gltf;
-        });
-}
+    return Promise.all(promises);
+};
 
 function loadImageSource(pipelineExtras, mime) {
     var image = pipelineExtras.jimpImage;

--- a/lib/Pipeline.js
+++ b/lib/Pipeline.js
@@ -3,6 +3,7 @@ var Cesium = require('cesium');
 var Promise = require('bluebird');
 var path = require('path');
 
+var EncodeImagesStage = require('./EncodeImagesStage');
 var MergeDuplicateProperties = require('./MergeDuplicateProperties');
 var RemoveUnusedProperties = require('./RemoveUnusedProperties');
 var addDefaults = require('./addDefaults');
@@ -14,7 +15,6 @@ var combinePrimitives = require('./combinePrimitives');
 var compressIntegerAccessors = require('./compressIntegerAccessors');
 var compressTextureCoordinates = require('./compressTextureCoordinates');
 var convertDagToTree = require('./convertDagToTree');
-var encodeImages = require('./encodeImages');
 var generateModelMaterialsCommon = require('./generateModelMaterialsCommon');
 var generateNormals = require('./generateNormals');
 var generateTangentsBitangents = require('./generateTangentsBitangents');
@@ -152,7 +152,8 @@ Pipeline.processJSONWithExtras  = function(gltfWithExtras, options) {
                 }
                 quantizeAttributes(gltfWithExtras, quantizedOptions);
             }
-            return encodeImages(gltfWithExtras);
+            var encodeImages = new EncodeImagesStage();
+            return encodeImages.run(gltfWithExtras);
         })
         .then(function() {
             var kmcOptions = options.kmcOptions;

--- a/specs/lib/EncodeImagesStageSpec.js
+++ b/specs/lib/EncodeImagesStageSpec.js
@@ -6,7 +6,7 @@ var bufferEqual = require('buffer-equal');
 var dataUriToBuffer = require('data-uri-to-buffer');
 
 var addPipelineExtras = require('../../lib/addPipelineExtras');
-var encodeImages = require('../../lib/encodeImages');
+var EncodeImagesStage = require('../../lib/EncodeImagesStage');
 var loadGltfUris = require('../../lib/loadGltfUris');
 
 var imageUri = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAIAAABLbSncAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAADTSURBVBhXAcgAN/8B49/cCAQAyukB2vAB+vz/Ig7+QR0B+PwAAezj3LDfAqnZ/wMB/xwPBwUEAiMK91Uj/gLN6wGj1fs9IyEwGxoUCPotFQC75g7rASECvd/6KxwkVCHFUiTX9P4Xq9L8ZjUD+vWyAaHK+CUX+pujFBYRH1NR2vUAANrLX8zXyAJCHOWnsj3d7frR4+XLymz24Y6ZuKI7LGUE/vcBEAglAQTR/P/9nbmV8fUAYURiTjRqAeXi6AgFDMDWptPiwP///isdPEIsXvr8+Tj0Y5s8qCp8AAAAAElFTkSuQmCC';
@@ -41,7 +41,8 @@ describe('encodeImages', function() {
                 var pipelineExtras0001 = gltfClone.images.Image0001.extras._pipeline;
                 var pipelineExtras0002 = gltfClone.images.Image0002.extras._pipeline;
 
-                encodeImages(gltfClone)
+                var encodeImages = new EncodeImagesStage();
+                encodeImages.run(gltfClone)
                     .then(function() {
                         expect(bufferEqual(pipelineExtras0001.source, imageBuffer)).toBe(true);
                         expect(bufferEqual(pipelineExtras0002.source, imageBuffer)).toBe(true);
@@ -65,7 +66,8 @@ describe('encodeImages', function() {
                 var jimpImage002 = pipelineExtras0002.jimpImage;
                 pipelineExtras0002.imageChanged = true;
 
-                encodeImages(gltfClone)
+                var encodeImages = new EncodeImagesStage();
+                encodeImages.run(gltfClone)
                     .then(function() {
                         expect(jimpImage001.bitmap.width).toEqual(10);
                         expect(jimpImage001.bitmap.height).toEqual(10);


### PR DESCRIPTION
This is an initial PR for #99.

I picked `encodeImages` to start with as it was a simple function and already returned promises.
I wanted to get feedback on how these uniform templates should be structured etc based on the comments in #99.

One of the things that I need answered is whether for a function like `EncodeImagesStage.run` we should keep the `options` parameter around as it will generate an unused function warning in jsHint.  My guess is that the answer is no and we can add the `options` parameter when needed. The counter argument to that is it would no create a uniform parameter list for all the uniform templates in.

Once I have more feedback on this, I'll work on the other stages.