### PR TITLE
Simplify and getStatistics

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,8 @@ Change Log
 * Fixed a bug in `addPipelineExtras` that made it try to add extras to null objects.
 * Expose `triangleAxisAlignedBoundingBoxOverlap`, an implementation of Tomas Akenine-Möller algorithm for determining if a triangle overlaps an axis aligned bounding box.
 * Merged [gltf-statistics](https://github.com/AnalyticalGraphicsInc/gltf-statistics) as a stage in the pipeline.
-* Added `updateVersion` stage for patching glTF `0.8` -> `1.0` changes; `addDefaults` no longer calls `processModelMaterialsCommon`. [#223](https://github.com/AnalyticalGraphicsInc/gltf-pipeline/pull/223) 
+* Added `updateVersion` stage for patching glTF `0.8` -> `1.0` changes; `addDefaults` no longer calls `processModelMaterialsCommon`. [#223](https://github.com/AnalyticalGraphicsInc/gltf-pipeline/pull/223)
+* Added `build-cesium-combined` command to gulp file for generating simple files for other projects. [#231](https://github.com/AnalyticalGraphicsInc/gltf-pipeline/pull/231).
 
 ### 0.1.0-alpha10 - 2017-01-10
 * Added `tangentsBitangents` generation option

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ npm run build-cesium
 
 This will output a portion of the gltf-pipeline code into the `dist/cesium` folder, reformatted into AMD style for use with RequireJS and Cesium in the browser.
 
-### Building for Other integration
+### Building for other integration
 
 Some functionality of gltf-pipeline is used by other projects along with Cesium as a third party library. The necessary files can be generated using:
 ```

--- a/README.md
+++ b/README.md
@@ -77,6 +77,15 @@ npm run build-cesium
 
 This will output a portion of the gltf-pipeline code into the `dist/cesium` folder, reformatted into AMD style for use with RequireJS and Cesium in the browser.
 
+### Building for Other integration
+
+Some functionality of gltf-pipeline is used by other projects along with Cesium as a third party library. The necessary files can be generated using:
+```
+npm run build-cesium-combine
+```
+
+This will output a portion of the gltf-pipeline code into the `dist/cesium-combined` folder, reformatted into self-contained file. Currently, only files that have no other local dependencies are allowed.
+
 ### Running Test Coverage
 
 Coverage uses [istanbul](https://github.com/gotwarlost/istanbul).  Run:

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -182,7 +182,7 @@ function amdify(source, subDependencyMapping) {
     return outputSource;
 }
 
-function simplify(source) {
+function combine(source) {
     var fullMatch;
     var variableName;
     var requirePath;
@@ -215,7 +215,7 @@ function simplify(source) {
         findRequire = findRequireRegex.exec(source);
     }
 
-    // simplify source
+    // combine source
     // indent
     outputSource = outputSource.replace(/\n/g, '\n    ');
     // wrap define header
@@ -273,9 +273,9 @@ gulp.task('build-cesium', function () {
     });
 });
 
-gulp.task('build-cesium-simplify', function () {
+gulp.task('build-cesium-combine', function () {
     var basePath = 'lib';
-    var outputDir = 'dist/cesium-simple';
+    var outputDir = 'dist/cesium-combined';
     var files = [
         'getStatistics.js'
     ];
@@ -284,7 +284,7 @@ gulp.task('build-cesium-simplify', function () {
         return fsExtraReadFile(filePath)
             .then(function(buffer) {
                 var source = buffer.toString();
-                source = simplify(source);
+                source = combine(source);
                 var outputPath = path.join(outputDir, fileName);
                 return fsExtraOutputFile(outputPath, source);
             });

--- a/lib/getStatistics.js
+++ b/lib/getStatistics.js
@@ -63,7 +63,7 @@ function isDataUri(uri) {
         return false;
     }
 
-    //Return true if the uri is a data uri
+    // Return true if the uri is a data uri
     return /^data\:/i.test(uri);
 }
 
@@ -118,82 +118,10 @@ function getNumberOfProperties(object) {
     return Object.keys(object).length;
 }
 
-function getDrawCallStatisticsForNode(gltf, nodeId) {
-    var numberOfDrawCalls = 0;
+function getNumberOfRenderedPrimitives(gltf, primitives) {
     var numberOfRenderedPrimitives = 0;
 
-    var nodes = gltf.nodes;
-    var meshes = gltf.meshes;
-    var accessors = gltf.accessors;
-
-    var nodeStack = [];
-
-    var n = nodes[nodeId];
-    nodeStack.push(n);
-
-    while (nodeStack.length > 0) {
-        n = nodeStack.pop();
-
-        var nodeNeshes = defaultValue(n.meshes, defined(n.instanceSkin) ? n.instanceSkin.meshes : undefined);
-        if (defined(nodeNeshes)) {
-            var meshesLength = nodeNeshes.length;
-            for (var j = 0; j < meshesLength; ++j) {
-                var primitives = meshes[nodeNeshes[j]].primitives;
-                var primitivesLength = primitives.length;
-                for (var m = 0; m < primitivesLength; ++m) {
-                    var primitive = primitives[m];
-                    var indices = primitive.indices;
-                    var indicesCount = accessors[indices].count;
-
-                    switch(primitive.mode) {
-                        case 0: // POINTS
-                            numberOfRenderedPrimitives += indicesCount;
-                            break;
-                        case 1: // LINES
-                            numberOfRenderedPrimitives += (indicesCount / 2);
-                            break;
-                        case 2: // LINE_LOOP
-                            numberOfRenderedPrimitives += indicesCount;
-                            break;
-                        case 3: // LINE_STRIP
-                            numberOfRenderedPrimitives += Math.max(indicesCount - 1, 0);
-                            break;
-                        case 4: // TRIANGLES
-                            numberOfRenderedPrimitives += (indicesCount / 3);
-                            break;
-                        case 5: // TRIANGLE_STRIP
-                        case 6: // TRIANGLE_FAN
-                            numberOfRenderedPrimitives += Math.max(indicesCount - 2, 0);
-                            break;
-                    }
-                }
-                numberOfDrawCalls += primitivesLength;
-            }
-        }
-
-        var children = n.children;
-        var childrenLength = children.length;
-        for (var k = 0; k < childrenLength; ++k) {
-            var child = nodes[children[k]];
-            nodeStack.push(child);
-        }
-    }
-
-    return {
-        numberOfDrawCalls : numberOfDrawCalls,
-        numberOfRenderedPrimitives : numberOfRenderedPrimitives
-    };
-}
-
-function getDrawCallStatistics(gltf) {
-    var numberOfDrawCalls = 0;
-    var numberOfRenderedPrimitives = 0;
-
-    var primitives = getAllPrimitives(gltf);
     var primitivesLength = primitives.length;
-
-    numberOfDrawCalls += primitivesLength;
-
     for (var m = 0; m < primitivesLength; ++m) {
         var primitive = primitives[m];
         var indices = primitive.indices;
@@ -222,6 +150,58 @@ function getDrawCallStatistics(gltf) {
         }
     }
 
+    return numberOfRenderedPrimitives;
+}
+
+function getDrawCallStatisticsForNode(gltf, nodeId) {
+    var numberOfDrawCalls = 0;
+    var numberOfRenderedPrimitives = 0;
+
+    var nodes = gltf.nodes;
+    var meshes = gltf.meshes;
+
+    var nodeStack = [];
+
+    var n = nodes[nodeId];
+    nodeStack.push(n);
+
+    while (nodeStack.length > 0) {
+        n = nodeStack.pop();
+
+        var nodeNeshes = defaultValue(n.meshes, defined(n.instanceSkin) ? n.instanceSkin.meshes : undefined);
+        if (defined(nodeNeshes)) {
+            var meshesLength = nodeNeshes.length;
+            for (var j = 0; j < meshesLength; ++j) {
+                var primitives = meshes[nodeNeshes[j]].primitives;
+
+                numberOfDrawCalls += primitives.length;
+                numberOfRenderedPrimitives += getNumberOfRenderedPrimitives(gltf, primitives);
+            }
+        }
+
+        var children = n.children;
+        var childrenLength = children.length;
+        for (var k = 0; k < childrenLength; ++k) {
+            var child = nodes[children[k]];
+            nodeStack.push(child);
+        }
+    }
+
+    return {
+        numberOfDrawCalls : numberOfDrawCalls,
+        numberOfRenderedPrimitives : numberOfRenderedPrimitives
+    };
+}
+
+function getDrawCallStatistics(gltf) {
+    var numberOfDrawCalls = 0;
+    var numberOfRenderedPrimitives = 0;
+
+    var primitives = getAllPrimitives(gltf);
+
+    numberOfDrawCalls += primitives.length;
+    numberOfRenderedPrimitives += getNumberOfRenderedPrimitives(gltf, primitives);
+
     return {
         numberOfDrawCalls : numberOfDrawCalls,
         numberOfRenderedPrimitives : numberOfRenderedPrimitives
@@ -244,7 +224,7 @@ function getStatistics(gltf, nodeId) {
 
     var statistics = new Statistics();
 
-    if(defined(nodeId)) {   // Only do draw call statistics
+    if (defined(nodeId)) {   // Only do draw call statistics
         var drawStatsNode = getDrawCallStatisticsForNode(gltf, nodeId);
 
         statistics.numberOfDrawCalls = drawStatsNode.numberOfDrawCalls;

--- a/lib/getStatistics.js
+++ b/lib/getStatistics.js
@@ -1,10 +1,8 @@
 'use strict';
 var Cesium = require('cesium');
-var DeveloperError = Cesium.DeveloperError;
-var isDataUri = require('./isDataUri');
-var PrimitiveHelpers = require('./PrimitiveHelpers');
 
 var defined = Cesium.defined;
+var DeveloperError = Cesium.DeveloperError;
 
 module.exports = getStatistics;
 
@@ -58,6 +56,28 @@ Statistics.prototype.toString = function() {
     return output;
 };
 
+function isDataUri(uri) {
+    //Return false if the uri is undefined
+    if (!defined(uri)) {
+        return false;
+    }
+
+    //Return true if the uri is a data uri
+    return /^data\:/i.test(uri);
+}
+
+function getAllPrimitives(gltf) {
+    var primitives = [];
+    var meshes = gltf.meshes;
+    for (var meshId in meshes) {
+        if (meshes.hasOwnProperty(meshId)) {
+            var mesh = meshes[meshId];
+            primitives = primitives.concat(mesh.primitives);
+        }
+    }
+    return primitives;
+}
+
 function getBuffersSize(buffers) {
     var size = 0;
     for (var id in buffers) {
@@ -101,7 +121,7 @@ function getDrawCallStatistics(gltf) {
     var numberOfDrawCalls = 0;
     var numberOfRenderedPrimitives = 0;
 
-    var primitives = PrimitiveHelpers.getAllPrimitives(gltf);
+    var primitives = getAllPrimitives(gltf);
     var primitivesLength = primitives.length;
 
     numberOfDrawCalls += primitivesLength;

--- a/lib/getStatistics.js
+++ b/lib/getStatistics.js
@@ -2,6 +2,7 @@
 var Cesium = require('cesium');
 
 var defined = Cesium.defined;
+var defaultValue = Cesium.defaultValue;
 var DeveloperError = Cesium.DeveloperError;
 
 module.exports = getStatistics;
@@ -117,6 +118,73 @@ function getNumberOfProperties(object) {
     return Object.keys(object).length;
 }
 
+function getDrawCallStatisticsForNode(gltf, nodeId) {
+    var numberOfDrawCalls = 0;
+    var numberOfRenderedPrimitives = 0;
+
+    var nodes = gltf.nodes;
+    var meshes = gltf.meshes;
+    var accessors = gltf.accessors;
+
+    var nodeStack = [];
+
+    var n = nodes[nodeId];
+    nodeStack.push(n);
+
+    while (nodeStack.length > 0) {
+        n = nodeStack.pop();
+
+        var nodeNeshes = defaultValue(n.meshes, defined(n.instanceSkin) ? n.instanceSkin.meshes : undefined);
+        if (defined(nodeNeshes)) {
+            var meshesLength = nodeNeshes.length;
+            for (var j = 0; j < meshesLength; ++j) {
+                var primitives = meshes[nodeNeshes[j]].primitives;
+                var primitivesLength = primitives.length;
+                for (var m = 0; m < primitivesLength; ++m) {
+                    var primitive = primitives[m];
+                    var indices = primitive.indices;
+                    var indicesCount = accessors[indices].count;
+
+                    switch(primitive.mode) {
+                        case 0: // POINTS
+                            numberOfRenderedPrimitives += indicesCount;
+                            break;
+                        case 1: // LINES
+                            numberOfRenderedPrimitives += (indicesCount / 2);
+                            break;
+                        case 2: // LINE_LOOP
+                            numberOfRenderedPrimitives += indicesCount;
+                            break;
+                        case 3: // LINE_STRIP
+                            numberOfRenderedPrimitives += Math.max(indicesCount - 1, 0);
+                            break;
+                        case 4: // TRIANGLES
+                            numberOfRenderedPrimitives += (indicesCount / 3);
+                            break;
+                        case 5: // TRIANGLE_STRIP
+                        case 6: // TRIANGLE_FAN
+                            numberOfRenderedPrimitives += Math.max(indicesCount - 2, 0);
+                            break;
+                    }
+                }
+                numberOfDrawCalls += primitivesLength;
+            }
+        }
+
+        var children = n.children;
+        var childrenLength = children.length;
+        for (var k = 0; k < childrenLength; ++k) {
+            var child = nodes[children[k]];
+            nodeStack.push(child);
+        }
+    }
+
+    return {
+        numberOfDrawCalls : numberOfDrawCalls,
+        numberOfRenderedPrimitives : numberOfRenderedPrimitives
+    };
+}
+
 function getDrawCallStatistics(gltf) {
     var numberOfDrawCalls = 0;
     var numberOfRenderedPrimitives = 0;
@@ -164,18 +232,29 @@ function getDrawCallStatistics(gltf) {
  * Returns an object containing the statistics for the glTF asset.
  *
  * @param {Object} gltf A javascript object containing a glTF asset with extras and defaults.
+ * @param {Object} [nodeId] If defined, statistics will only process number of draw calls and rendered primitives for the specified node.
  * @returns {Statistics} Object containing the statistics of the glTF asset.
  *
  * @see Statistics
  */
-function getStatistics(gltf) {
+function getStatistics(gltf, nodeId) {
     if (!defined(gltf)) {
         throw new DeveloperError('gltf must be defined');
     }
 
+    var statistics = new Statistics();
+
+    if(defined(nodeId)) {   // Only do draw call statistics
+        var drawStatsNode = getDrawCallStatisticsForNode(gltf, nodeId);
+
+        statistics.numberOfDrawCalls = drawStatsNode.numberOfDrawCalls;
+        statistics.numberOfRenderedPrimitives = drawStatsNode.numberOfRenderedPrimitives;
+
+        return statistics;
+    }
+
     var drawStats = getDrawCallStatistics(gltf);
 
-    var statistics = new Statistics();
     statistics.buffersSizeInBytes = getBuffersSize(gltf.buffers);
     statistics.numberOfImages = getNumberOfProperties(gltf.images);
     statistics.numberOfExternalRequests = getNumberOfExternalRequests(gltf);

--- a/lib/getStatistics.js
+++ b/lib/getStatistics.js
@@ -58,7 +58,7 @@ Statistics.prototype.toString = function() {
 };
 
 function isDataUri(uri) {
-    //Return false if the uri is undefined
+    // Return false if the uri is undefined
     if (!defined(uri)) {
         return false;
     }
@@ -168,11 +168,11 @@ function getDrawCallStatisticsForNode(gltf, nodeId) {
     while (nodeStack.length > 0) {
         n = nodeStack.pop();
 
-        var nodeNeshes = defaultValue(n.meshes, defined(n.instanceSkin) ? n.instanceSkin.meshes : undefined);
-        if (defined(nodeNeshes)) {
-            var meshesLength = nodeNeshes.length;
+        var nodeMeshes = defaultValue(n.meshes, defined(n.instanceSkin) ? n.instanceSkin.meshes : undefined);
+        if (defined(nodeMeshes)) {
+            var meshesLength = nodeMeshes.length;
             for (var j = 0; j < meshesLength; ++j) {
-                var primitives = meshes[nodeNeshes[j]].primitives;
+                var primitives = meshes[nodeMeshes[j]].primitives;
 
                 numberOfDrawCalls += primitives.length;
                 numberOfRenderedPrimitives += getNumberOfRenderedPrimitives(gltf, primitives);

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
   },
   "scripts": {
     "build-cesium": "gulp build-cesium",
+    "build-cesium-simplify": "gulp build-cesium-simplify",
     "prepublish": "typings install",
     "jsdoc": "jsdoc ./lib -R ./README.md -d doc",
     "jsHint": "gulp jsHint",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "scripts": {
     "build-cesium": "gulp build-cesium",
-    "build-cesium-simplify": "gulp build-cesium-simplify",
+    "build-cesium-combine": "gulp build-cesium-combine",
     "prepublish": "typings install",
     "jsdoc": "jsdoc ./lib -R ./README.md -d doc",
     "jsHint": "gulp jsHint",


### PR DESCRIPTION
Based on @pjcozzi suggestion, this PR does 2 things:

* Removed `PrimitiveHelpers.js` and `isDataUri.js` as dependencies of `getStatistics`
  * This require duplicating a few lines of code.
* Adds a `gulp` command `build-cesium-simplify` that exports the listed files into a independent class format that only depends on Cesium already being imported (no require).
  * The files eligible for this must only depend on Cesium and no other files.
  * This can probably be expanded in the future to require local files as well.

Note: The nomenclature (`simple`/`simplify`) maybe naive. So if there is a technical term for it, then I can change it to that.