### PR TITLE
Create initial dependency graph structure

### DIFF
--- a/lib/DependencyGraph.js
+++ b/lib/DependencyGraph.js
@@ -1,0 +1,154 @@
+'use strict';
+var Cesium = require('cesium');
+
+var defined = Cesium.defined;
+var defaultValue = Cesium.defaultValue;
+var DeveloperError = Cesium.DeveloperError;
+
+module.exports = DependencyGraph;
+
+/**
+ * A node for pipeline stage.
+ *
+ * @property {String} name Stores the stage function name.
+ * @property {Array} runBefore Stages that need to run at least once before this stage.
+ * @property {Array} runImmediatelyBefore Stages that need to run exactly before this stage, irrespective of whether they have run before or not.
+ * @property {Array} runImmediatelyAfter Stages that need to run exactly after this stage, irrespective of whether they have run before or not.
+ * @property {Array} runAfter Stages that need to run at least once after this stage.
+ * @property {Boolean} hasRun True if this stage has run at least once.
+ * @property {Boolean} needsToRun True if this stage needs to run at least once in the future.
+ *
+ * @constructor
+ *
+ * @see DependencyGraph
+ */
+function DependencyGraphNode() {
+    this.name = '';
+    this.runBefore = [];
+    this.runImmediatelyBefore = [];
+    this.runImmediatelyAfter = [];
+    this.runAfter = [];
+
+    // replace with enum this.state = [neverRun, hasRun, needsToRun]?
+    this.hasRun = false;
+    this.needsToRun = false;
+}
+
+/**
+ * A dependency graph to run the required stages.
+ *
+ * @property {Object} nodes An object mapping node names to DependencyGraphNodes.
+ * @property {Array} pipeline Stores the order of execution in an array of node names.
+ *
+ * @constructor
+ *
+ * @see DependencyGraphNode
+ */
+function DependencyGraph() {
+    this.nodes = {};
+
+    this.pipeline = [];
+}
+
+/**
+ * Add a node to the dependency graph which can then be invoked later using runStage().
+ *
+ * @property {Object} node A stage node to add to the dependency graph.
+ *
+ * @constructor
+ *
+ * @see DependencyGraphNode
+ * @see DependencyGraph.runStage
+ */
+DependencyGraph.prototype.addNode = function(node) {
+    var newNode = new DependencyGraphNode();
+
+    newNode.name = node.name;
+    newNode.runBefore = node.runBefore;
+    newNode.runImmediatelyBefore = node.runImmediatelyBefore;
+    newNode.runImmediatelyAfter = node.runImmediatelyAfter;
+    newNode.runAfter = node.runAfter;
+
+    newNode.hasRun = false;
+    newNode.needsToRun = false;
+
+    // Add newNode to nodes
+    this.nodes[newNode.name] = newNode;
+};
+
+DependencyGraph.prototype.runStage = function(node, gltf, options) {
+
+    if(!defined(node)) {
+        throw new DeveloperError('node has not been defined');
+    }
+
+    if(!this.nodes.hasOwnProperty(node.name)) {
+        throw new DeveloperError('node has not been added to Dependency Graph');
+    }
+
+    var currentNode = node;
+    var nodeName;
+    var i;
+
+    // runBefore: Stages that need to be run before the current stage
+    for(i = 0; i < currentNode.runBefore.length; ++i) {
+        nodeName = currentNode.runBefore[i];
+        if (!this.nodes[nodeName].hasRun || this.nodes[nodeName].needsToRun) {
+            this.runStage(this.nodes[nodeName], gltf, options);
+        }
+    }
+
+    // runImmediatelyBefore: Stages that should run immediately before the current stage
+    for(i = 0; i < currentNode.runImmediatelyBefore.length; ++i) {
+        nodeName = currentNode.runImmediatelyBefore[i];
+        this.runStage(this.nodes[nodeName], gltf, options);
+    }
+
+    // Now run this stage
+    if(!defined(options.dryRun)) {
+        // TODO figure out how to call the function
+        // The function is of the form 'currentNode.name' + '.run'
+        // On a browser it can be run using window, but this is not available in node.js
+        // "Bad" option is to use a giant switch case
+        console.log('Stage to execute : ' + currentNode.name);  // Here to avoid jsHint Warning
+    }
+    this.pipeline.push(currentNode.name);
+    currentNode.needsToRun = false;
+    currentNode.hasRun = true;
+
+    // runImmediatelyAfter: Stages that should be run immediately after the current stage
+    for(i = 0; i < currentNode.runImmediatelyAfter.length; ++i) {
+        nodeName = currentNode.runImmediatelyAfter[i];
+        this.runStage(this.nodes[nodeName], gltf, options);
+    }
+
+    // runAfter: Stages that need to be run after the current stage - Just set needsToRun = true
+    // Any stage with a needsToRun can only be evaluated by:
+    // * A runBefore or runImmediatelyBefore or runImmediatelyAfter call
+    // * An explicit call to that stage
+    // * End of the pipeline (finish()) -> Which makes an explicit call to that stage
+    for(i = 0; i < currentNode.runAfter.length; ++i) {
+        nodeName = currentNode.runAfter[i];
+        if(options.finishRunAfter) { // This option is needed for finish(). We do not want runAfter calls making other needsToRun options during finish
+            this.runStage(this.nodes[nodeName], gltf, options);
+        } else {
+            this.nodes[nodeName].needsToRun = true;
+        }
+    }
+};
+
+DependencyGraph.prototype.finish = function(gltf, options) {
+    // Add options.finishRunAfter to execute all other runAfters calls by runAfters currently in pipeline
+    options = defaultValue(options, {});
+    options.finishRunAfter = true;
+
+    var nodeName;
+    for(var i in this.nodes) {
+        if(this.nodes.hasOwnProperty(i)) {
+            nodeName = this.nodes[i].name;
+            if (this.nodes[nodeName].needsToRun) {
+                this.runStage(this.nodes[nodeName], gltf, options);
+            }
+        }
+    }
+};

--- a/specs/lib/DependencyGraphSpec.js
+++ b/specs/lib/DependencyGraphSpec.js
@@ -1,0 +1,81 @@
+'use strict';
+var DependencyGraph = require('../../lib/DependencyGraph');
+
+describe('DependencyGraph', function() {
+    var nodes = [];
+    var dg = new DependencyGraph();
+
+    beforeAll(function(done) {
+        var node0 = {
+            name : 'node0',
+            runBefore : [],
+            runImmediatelyBefore : [],
+            runImmediatelyAfter : [],
+            runAfter : []
+        };
+
+        var node1 = {
+            name : 'node1',
+            runBefore : ['node0'],
+            runImmediatelyBefore : [],
+            runImmediatelyAfter : [],
+            runAfter : ['node3']
+        };
+
+        var node2 = {
+            name : 'node2',
+            runBefore : ['node1'],
+            runImmediatelyBefore : ['node4'],
+            runImmediatelyAfter : ['node5'],
+            runAfter : []
+        };
+
+        var node3 = {
+            name : 'node3',
+            runBefore : ['node5', 'node0'],
+            runImmediatelyBefore : [],
+            runImmediatelyAfter : [],
+            runAfter : ['node4']
+        };
+
+        var node4 = {
+            name : 'node4',
+            runBefore : [],
+            runImmediatelyBefore : [],
+            runImmediatelyAfter : [],
+            runAfter : []
+        };
+
+        var node5 = {
+            name : 'node5',
+            runBefore : [],
+            runImmediatelyBefore : ['node0', 'node1'],
+            runImmediatelyAfter : [],
+            runAfter : []
+        };
+
+        dg.addNode(node0);
+        dg.addNode(node1);
+        dg.addNode(node2);
+        dg.addNode(node3);
+        dg.addNode(node4);
+        dg.addNode(node5);
+
+        done();
+    });
+
+    it('should return for simple pipeline', function(){
+        var options = {
+            dryRun: true
+        };
+
+        var pipelineBeforeFinish = ['node0', 'node1', 'node4', 'node2', 'node0', 'node1', 'node5'];
+        var pipelineAfterFinish = ['node0', 'node1', 'node4', 'node2', 'node0', 'node1', 'node5', 'node3', 'node4'];
+
+        dg.runStage(dg.nodes.node2, undefined, options);
+        expect(dg.pipeline).toEqual(pipelineBeforeFinish);
+
+        dg.finish(undefined, options);
+        expect(dg.pipeline).toEqual(pipelineAfterFinish);
+    });
+});


### PR DESCRIPTION
This PR contains an initial version of the dependency graph that will be used for #99.

The algorithm in summary is:
* For a given node, run any `runBefore` function based on 2 conditions:
  * If it has never been run before (marked by `hasRun`)
  * If the `runBefore` stage was a `runAfter` stage for another stage.
* Next, run the `runImmediatelyBefore` stages (always run - no conditions).
* Run the current stage. Mark `hasRun` to true and `needsToRun` to false.
* Run the `runImmediatelyAfter` stages (always run - no conditions).
* Lastly, for all `runAfter` stages, we only mark the `needsToRun` flag so that it can execute any time in the future. The following condition will make a `needsToRun` stage execute:
  * If it is a `runBefore`, `runImmediatelyBefore` or `runImmediatelyAfter` stage for any future stage.
  * If it is called explicitly.
  * If the pipeline is at an end, if will be forced to complete by the `finish` function.

The `finish` function acts like a destructor, ensuring that all stages finish.

I have discussed this with @lilleyse and it seems to hold good. I have added a test so that it can be seen in initial action.

The following are improvements that can/need to be made:
* Have a local `options` object in each node that will override any global options.
* Use an enum `state` to store one of `neverRun`, `hasRun`, or `needsToRun` flags. This will remove the need for the 2 booleans - `hasRun` and `needsToRun`.
* Figure out how to call the `run` function for each stage. On a browser it's easy but not so much in node.js. The **naive** option is to maintain a `switch-case` matching the `node.name` to the `run` function.

**This PR need not be merged. It is more for comments/review before we move forward.**