### PR TITLE
Enable OS X builds on Travis. Change coveralls -> coverage in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,22 @@
+os:
+  - linux
+  - osx
+
 language: node_js
+
 node_js:
   - "4"
   - "6"
+
 script:
   - npm run jsHint -- --failTaskOnError
-  - npm run test -- --failTaskOnError --suppressPassed --excludeCompressedTextures
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]];
+    then npm run test -- --failTaskOnError --suppressPassed --excludeCompressedTextures;
+    else npm run test -- --failTaskOnError --suppressPassed;
+    fi
+
 after_success:
-## We only need to run coveralls for one node version (doesn't matter which one).
-## We also ignore publishing failures, since restarting an existing travis build would otherwise break.
-  - if node --version | grep -q ^v6 ; npm run coveralls ; fi
+  ## We only need to run coveralls for one node version (doesn't matter which one).
+  ## We also ignore publishing failures, since restarting an existing travis build would otherwise break.
+  ## Run coverage on OSX and not on linux as Linux will run compressed texture tests which will fail.
+  - if [[ "$TRAVIS_OS_NAME" == "osx" && $(node --version) == v6* ]]; then npm run coverage; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ after_success:
   ## We only need to run coveralls for one node version (doesn't matter which one).
   ## We also ignore publishing failures, since restarting an existing travis build would otherwise break.
   ## Run coverage on OSX and not on linux as Linux will run compressed texture tests which will fail.
-  - if [[ "$TRAVIS_OS_NAME" == "osx" && $(node --version) == v6* ]]; then npm run coverage; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" && $(node --version) == v6* ]]; then npm run coverage && npm run coveralls; fi

--- a/specs/lib/compressTexturesSpec.js
+++ b/specs/lib/compressTexturesSpec.js
@@ -74,6 +74,29 @@ function verifyCrunch(gltfPath, imagePath, options) {
         });
 }
 
+function setFormatQuality(gltfPath, pngPath, format, done) {
+    var promises = [];
+    function compareUris(uris) {
+        expect(uris[0]).not.toEqual(uris[1]);
+    }
+
+    var lowQuality = {
+        format : format,
+        quality : 1
+    };
+    var highQuality = {
+        format : format,
+        quality : 5
+    };
+
+    promises.push(Promise.all([
+        compressGltfTexture(gltfPath, pngPath, lowQuality),
+        compressGltfTexture(gltfPath, pngPath, highQuality)
+    ]).then(compareUris));
+
+    expect(Promise.all(promises), done).toResolve();
+}
+
 // etc2comp only supports png input so this is a good test case for handling different input image formats
 var etc1Compression = {
     format : 'etc1'
@@ -371,36 +394,45 @@ describe('compressTextures', function() {
         expect(verifyKTX(gltfPath, pngPath, options, expectedFormat), done).toResolve();
     });
 
-    var formats = ['pvrtc1', 'pvrtc2', 'etc1', 'etc2', 'astc', 'dxt1', 'dxt3', 'dxt5', 'crunch-dxt1', 'crunch-dxt5'];
+    it('sets quality for format pvrtc1', function(done) {
+        setFormatQuality(gltfPath, pngPath, 'pvrtc1', done);
+    });
 
-    function addSetsQualityTest(format) {
-        it('sets quality for format ' + format, function(done) {
-            var promises = [];
-            function compareUris(uris) {
-                expect(uris[0]).not.toEqual(uris[1]);
-            }
+    it('sets quality for format pvrtc2', function(done) {
+        setFormatQuality(gltfPath, pngPath, 'pvrtc2', done);
+    });
 
-            var lowQuality = {
-                format : format,
-                quality : 1
-            };
-            var highQuality = {
-                format : format,
-                quality : 5
-            };
+    it('sets quality for format etc1', function(done) {
+        setFormatQuality(gltfPath, pngPath, 'etc1', done);
+    });
 
-            promises.push(Promise.all([
-                compressGltfTexture(gltfPath, pngPath, lowQuality),
-                compressGltfTexture(gltfPath, pngPath, highQuality)
-            ]).then(compareUris));
+    it('sets quality for format etc2', function(done) {
+        setFormatQuality(gltfPath, pngPath, 'etc2', done);
+    });
 
-            expect(Promise.all(promises), done).toResolve();
-        });
-    }
+    it('sets quality for format astc', function(done) {
+        setFormatQuality(gltfPath, pngPath, 'astc', done);
+    });
 
-    for(var i = 0; i < formats.length; ++i) {
-        addSetsQualityTest(formats[i]);
-    }
+    it('sets quality for format dxt1', function(done) {
+        setFormatQuality(gltfPath, pngPath, 'dxt1', done);
+    });
+
+    it('sets quality for format dxt3', function(done) {
+        setFormatQuality(gltfPath, pngPath, 'dxt3', done);
+    });
+
+    it('sets quality for format dxt5', function(done) {
+        setFormatQuality(gltfPath, pngPath, 'dxt5', done);
+    });
+
+    it('sets quality for format crunch-dxt1', function(done) {
+        setFormatQuality(gltfPath, pngPath, 'crunch-dxt1', done);
+    });
+
+    it('sets quality for format crunch-dxt5', function(done) {
+        setFormatQuality(gltfPath, pngPath, 'crunch-dxt5', done);
+    });
 
     it('tempDirectory is removed when compression succeeds', function(done) {
         spyOn(fsExtra, 'writeFileAsync').and.callThrough();

--- a/specs/lib/compressTexturesSpec.js
+++ b/specs/lib/compressTexturesSpec.js
@@ -371,18 +371,15 @@ describe('compressTextures', function() {
         expect(verifyKTX(gltfPath, pngPath, options, expectedFormat), done).toResolve();
     });
 
-    it('sets quality', function(done) {
-        var formats = ['pvrtc1', 'pvrtc2', 'etc1', 'etc2', 'astc', 'dxt1', 'dxt3', 'dxt5', 'crunch-dxt1', 'crunch-dxt5'];
-        var promises = [];
-        var length = formats.length;
+    var formats = ['pvrtc1', 'pvrtc2', 'etc1', 'etc2', 'astc', 'dxt1', 'dxt3', 'dxt5', 'crunch-dxt1', 'crunch-dxt5'];
 
-        function compareUris(uris) {
-            expect(uris[0]).not.toEqual(uris[1]);
-        }
+    function addSetsQualityTest(format) {
+        it('sets quality for format ' + format, function(done) {
+            var promises = [];
+            function compareUris(uris) {
+                expect(uris[0]).not.toEqual(uris[1]);
+            }
 
-        // For each texture format encode at low and medium quality and compare results
-        for (var i = 0; i < length; ++i) {
-            var format = formats[i];
             var lowQuality = {
                 format : format,
                 quality : 1
@@ -391,14 +388,19 @@ describe('compressTextures', function() {
                 format : format,
                 quality : 5
             };
+
             promises.push(Promise.all([
                 compressGltfTexture(gltfPath, pngPath, lowQuality),
                 compressGltfTexture(gltfPath, pngPath, highQuality)
             ]).then(compareUris));
-        }
 
-        expect(Promise.all(promises), done).toResolve();
-    });
+            expect(Promise.all(promises), done).toResolve();
+        });
+    }
+
+    for(var i = 0; i < formats.length; ++i) {
+        addSetsQualityTest(formats[i]);
+    }
 
     it('tempDirectory is removed when compression succeeds', function(done) {
         spyOn(fsExtra, 'writeFileAsync').and.callThrough();


### PR DESCRIPTION
* Run all tests on OSX. Skip compressed textures on linux
* Run coverage on OSX and not linux because linux will fail the compress texture tests.
* Previously, travis was running `npm run coveralls`, however, this should run `npm run coverage` to generate the report. That said, **should this run `coverage` AND `coveralls`**? 

The reason for this being the original PR where this was added https://github.com/AnalyticalGraphicsInc/gltf-pipeline/pull/4/files.

I believe the workflow was to run `npm run test`, which would then run `jsHint` and `coverage` and then `coveralls` would upload this. However, now, `test` does not run coverage and there are no files for `coveralls` target to upload.

Another evidence of this is that the coveralls report has not been updated since [Jul 13, 2016](https://coveralls.io/builds/6996014).