### PR TITLE
Support shader generation for different joint and weight types

### DIFF
--- a/lib/addPipelineExtras.js
+++ b/lib/addPipelineExtras.js
@@ -10,8 +10,11 @@ module.exports = addPipelineExtras;
 var exceptions = {
     attributes: true,
     uniforms: true,
-    extensions: true
+    extensions: true,
+    values: true,
+    samplers: true
 };
+
 /**
  * Adds extras._pipeline to each object that can have extras in the glTF asset.
  *
@@ -20,62 +23,31 @@ var exceptions = {
  */
 function addPipelineExtras(gltf) {
     var objectStack = [];
-    gltf.extras = defaultValue(gltf.extras, {});
-    gltf.extras._pipeline = defaultValue(gltf.extras._pipeline, {});
     for (var rootObjectId in gltf) {
         if (gltf.hasOwnProperty(rootObjectId)) {
             var rootObject = gltf[rootObjectId];
-            for (var topLevelObjectId in rootObject) {
-                if (rootObject.hasOwnProperty(topLevelObjectId)) {
-                    var topLevelObject = rootObject[topLevelObjectId];
-                    if (defined(topLevelObject) && typeof topLevelObject === 'object') {
-                        objectStack.push(topLevelObject);
-                    }
-                }
-            }
-        }
-    }
-    if (defined(gltf.asset)) {
-        objectStack.push(gltf.asset);
-    }
-    // Add pipeline extras to compressed textures
-    var images = gltf.images;
-    for (var imageId in images) {
-        if (images.hasOwnProperty(imageId)) {
-            var image = images[imageId];
-            if (defined(image.extras) && defined(image.extras.compressedImage3DTiles)) {
-                var compressedImages = image.extras.compressedImage3DTiles;
-                for (var compressedImageId in compressedImages) {
-                    if (compressedImages.hasOwnProperty(compressedImageId)) {
-                        objectStack.push(compressedImages[compressedImageId]);
-                    }
-                }
-            }
+            objectStack.push(rootObject);
         }
     }
     while (objectStack.length > 0) {
         var object = objectStack.pop();
-        if (Array.isArray(object)) {
-            var length = object.length;
-            for (var i = 0; i < length; i++) {
-                var item = object[i];
-                if (defined(item) && typeof item === 'object') {
-                    objectStack.push(item);
-                }
-            }
-        } else {
-            object.extras = defaultValue(object.extras, {});
-            object.extras._pipeline = defaultValue(object.extras._pipeline, {});
-            for (var propertyId in object) {
-                if (object.hasOwnProperty(propertyId)) {
-                    var property = object[propertyId];
-                    if (defined(property) && typeof property === 'object' && propertyId !== 'extras' && !exceptions[propertyId]) {
-                        objectStack.push(property);
+        for (var propertyId in object) {
+            if (object.hasOwnProperty(propertyId)) {
+                var property = object[propertyId];
+                if (defined(property) && typeof property === 'object' && propertyId !== 'extras') {
+                    objectStack.push(property);
+                    if (!exceptions[propertyId] && !Array.isArray(property)) {
+                        property.extras = defaultValue(property.extras, {});
+                        property.extras._pipeline = defaultValue(property.extras._pipeline, {});
                     }
                 }
             }
         }
     }
-
+    gltf.extras = defaultValue(gltf.extras, {});
+    gltf.extras._pipeline = defaultValue(gltf.extras._pipeline, {});
+    gltf.asset = defaultValue(gltf.asset, {});
+    gltf.asset.extras = defaultValue(gltf.asset.extras, {});
+    gltf.asset.extras._pipeline = defaultValue(gltf.asset.extras._pipeline, {});
     return gltf;
 }

--- a/lib/generateNormals.js
+++ b/lib/generateNormals.js
@@ -198,7 +198,10 @@ function generateMaterial(gltf, primitive, generatedMaterials) {
             extensions : {
                 KHR_materials_common : {
                     technique : 'BLINN',
-                    values : values
+                    values : values,
+                    extras: {
+                        _pipeline: {}
+                    }
                 }
             }
         };

--- a/lib/processModelMaterialsCommon.js
+++ b/lib/processModelMaterialsCommon.js
@@ -1,10 +1,13 @@
 'use strict';
 var Cesium = require('cesium');
-var WebGLConstants = Cesium.WebGLConstants;
+var getUniqueId = require('./getUniqueId');
+var numberOfComponentsForType = require('./numberOfComponentsForType');
+var techniqueParameterForSemantic = require('./techniqueParameterForSemantic');
+
+var clone = Cesium.clone;
 var defined = Cesium.defined;
 var defaultValue = Cesium.defaultValue;
-
-var techniqueParameterForSemantic = require('./techniqueParameterForSemantic');
+var WebGLConstants = Cesium.WebGLConstants;
 
 module.exports = modelMaterialsCommon;
 
@@ -26,6 +29,27 @@ function webGLConstantToGlslType(webGLValue) {
             return 'mat4';
         case WebGLConstants.SAMPLER_2D:
             return 'sampler2D';
+    }
+}
+
+function glslTypeToWebGLConstant(glslType) {
+    switch (glslType) {
+        case 'float':
+            return WebGLConstants.FLOAT;
+        case 'vec2':
+            return WebGLConstants.FLOAT_VEC2;
+        case 'vec3':
+            return WebGLConstants.FLOAT_VEC3;
+        case 'vec4':
+            return WebGLConstants.FLOAT_VEC4;
+        case 'mat2':
+            return WebGLConstants.FLOAT_MAT2;
+        case 'mat3':
+            return WebGLConstants.FLOAT_MAT3;
+        case 'mat4':
+            return WebGLConstants.FLOAT_MAT4;
+        case 'sampler2D':
+            return WebGLConstants.SAMPLER_2D;
     }
 }
 
@@ -168,8 +192,12 @@ function generateTechnique(gltf, khrMaterialsCommon, lightParameters, optimizeFo
         lights = gltf.extensions.KHR_materials_common.lights;
     }
     var parameterValues = khrMaterialsCommon.values;
-    var jointCount = defaultValue(parameterValues.jointCount, 0);
-    var hasSkinning = (jointCount > 0);
+    var jointCount = defaultValue(khrMaterialsCommon.jointCount, 0);
+    var hasSkinning = jointCount > 0;
+    var skinningInfo = {};
+    if (hasSkinning) {
+        skinningInfo = khrMaterialsCommon.extras._pipeline.skinning;
+    }
 
     var vertexShader = 'precision highp float;\n';
     var fragmentShader = 'precision highp float;\n';
@@ -262,10 +290,34 @@ function generateTechnique(gltf, khrMaterialsCommon, lightParameters, optimizeFo
     // Add attributes with semantics
     var vertexShaderMain = '';
     if (hasSkinning) {
-        vertexShaderMain += '  mat4 skinMat = a_weight.x * u_jointMatrix[int(a_joint.x)];\n';
-        vertexShaderMain += '  skinMat += a_weight.y * u_jointMatrix[int(a_joint.y)];\n';
-        vertexShaderMain += '  skinMat += a_weight.z * u_jointMatrix[int(a_joint.z)];\n';
-        vertexShaderMain += '  skinMat += a_weight.w * u_jointMatrix[int(a_joint.w)];\n';
+        var i, j;
+        var numberOfComponents = numberOfComponentsForType(skinningInfo.type);
+        var matrix = false;
+        if (skinningInfo.type.indexOf('MAT') === 0) {
+            matrix = true;
+            numberOfComponents = Math.sqrt(numberOfComponents);
+        }
+        if (!matrix) {
+            for (i = 0; i < numberOfComponents; i++) {
+                if (i === 0) {
+                    vertexShaderMain += '  mat4 skinMat = ';
+                } else {
+                    vertexShaderMain += '  skinMat += ';
+                }
+                vertexShaderMain += 'a_weight[' + i + '] * u_jointMatrix[int(a_joint[' + i + '])];\n';
+            }
+        } else {
+            for (i = 0; i < numberOfComponents; i++) {
+                for (j = 0; j < numberOfComponents; j++) {
+                    if (i === 0 && j === 0) {
+                        vertexShaderMain += '  mat4 skinMat = ';
+                    } else {
+                        vertexShaderMain += '  skinMat += ';
+                    }
+                    vertexShaderMain += 'a_weight[' + i + '][' + j + '] * u_jointMatrix[int(a_joint[' + i + '][' + j + '])];\n';
+                }
+            }
+        }
     }
 
     // Add position always
@@ -324,18 +376,21 @@ function generateTechnique(gltf, khrMaterialsCommon, lightParameters, optimizeFo
 
     if (hasSkinning) {
         techniqueAttributes.a_joint = 'joint';
+        var attributeType = getShaderVariable(skinningInfo.type);
+        var webGLConstant = glslTypeToWebGLConstant(attributeType);
+
         techniqueParameters.joint = {
             semantic: 'JOINT',
-            type: WebGLConstants.FLOAT_VEC4
+            type: webGLConstant
         };
         techniqueAttributes.a_weight = 'weight';
         techniqueParameters.weight = {
             semantic: 'WEIGHT',
-            type: WebGLConstants.FLOAT_VEC4
+            type: webGLConstant
         };
 
-        vertexShader += 'attribute vec4 a_joint;\n';
-        vertexShader += 'attribute vec4 a_weight;\n';
+        vertexShader += 'attribute ' + attributeType + ' a_joint;\n';
+        vertexShader += 'attribute ' + attributeType + ' a_weight;\n';
     }
 
     var hasSpecular = hasNormals && ((lightingModel === 'BLINN') || (lightingModel === 'PHONG')) &&
@@ -641,20 +696,22 @@ function getTechniqueKey(khrMaterialsCommon) {
     var keysCount = keys.length;
     for (var i = 0; i < keysCount; ++i) {
         var name = keys[i];
-        //generate first part of key using shader parameters for KHR_materials_common attributes
-        //(including a check, because some boolean flags should not be used as shader parameters)
-        if (values.hasOwnProperty(name) && (name !== 'transparent') && (name !== 'doubleSided')) {
+        if (values.hasOwnProperty(name)) {
             techniqueKey += name + ':' + getKHRMaterialsCommonValueType(name, values[name]);
             techniqueKey += ';';
         }
     }
 
-    var doubleSided = defaultValue(values.doubleSided, false);
+    var doubleSided = defaultValue(khrMaterialsCommon.doubleSided, false);
     techniqueKey += doubleSided.toString() + ';';
-    var transparent = defaultValue(values.transparent, false);
+    var transparent = defaultValue(khrMaterialsCommon.transparent, false);
     techniqueKey += transparent.toString() + ';';
-    var jointCount = defaultValue(values.jointCount, 0);
+    var jointCount = defaultValue(khrMaterialsCommon.jointCount, 0);
     techniqueKey += jointCount.toString() + ';';
+    if (jointCount > 0) {
+        var skinningInfo = khrMaterialsCommon.extras._pipeline.skinning;
+        techniqueKey += skinningInfo.type + ';';
+    }
 
     return techniqueKey;
 }
@@ -729,8 +786,7 @@ function lightDefaults(gltf) {
     }
 }
 
-function getShaderVariable(accessor) {
-    var type = accessor.type;
+function getShaderVariable(type) {
     if (type === 'SCALAR') {
         return 'float';
     }
@@ -765,7 +821,7 @@ function ensureSemanticExistenceForPrimitive(gltf, primitive) {
                 program.attributes.push(attributeName);
                 var pipelineExtras = vertexShader.extras._pipeline;
                 var shaderText = pipelineExtras.source;
-                shaderText = 'attribute ' + getShaderVariable(accessor) + ' ' + attributeName + ';\n' + shaderText;
+                shaderText = 'attribute ' + getShaderVariable(accessor.type) + ' ' + attributeName + ';\n' + shaderText;
                 pipelineExtras.source = shaderText;
             }
         }
@@ -785,6 +841,60 @@ function ensureSemanticExistence(gltf) {
         }
     }
 }
+
+function splitIncompatibleSkins(gltf) {
+    var accessors = gltf.accessors;
+    var materials = gltf.materials;
+    var meshes = gltf.meshes;
+    for (var meshId in meshes) {
+        if (meshes.hasOwnProperty(meshId)) {
+            var mesh = meshes[meshId];
+            var primitives = mesh.primitives;
+            var primitivesLength = primitives.length;
+            for (var j = 0; j < primitivesLength; j++) {
+                var primitive = primitives[j];
+
+                var materialId = primitive.material;
+                var material = materials[materialId];
+
+                if (defined(material.extensions) && defined(material.extensions.KHR_materials_common)) {
+                    var khrMaterialsCommon = material.extensions.KHR_materials_common;
+                    var jointAccessorId = primitive.attributes.JOINT;
+                    var componentType;
+                    var type;
+                    if (defined(jointAccessorId)) {
+                        var jointAccessor = accessors[jointAccessorId];
+                        componentType = jointAccessor.componentType;
+                        type = jointAccessor.type;
+                    }
+                    var isSkinned = defined(jointAccessorId);
+
+                    var skinningInfo = khrMaterialsCommon.extras._pipeline.skinning;
+                    if (!defined(skinningInfo)) {
+                        khrMaterialsCommon.extras._pipeline.skinning = {
+                            skinned: isSkinned,
+                            componentType: componentType,
+                            type: type
+                        };
+                    } else if ((skinningInfo.skinned !== isSkinned) || (skinningInfo.type !== type)) {
+                        // This primitive uses the same material as another one that either isn't skinned or uses a different type to store joints and weights
+                        materialId = getUniqueId(gltf, materialId);
+                        primitive.material = materialId;
+                        // Split this off as a separate material
+                        var clonedMaterial = clone(material, true);
+                        clonedMaterial.extensions.KHR_materials_common.extras._pipeline.skinning = {
+                            skinned: isSkinned,
+                            componentType: componentType,
+                            type: type
+                        };
+                        materials[materialId] = clonedMaterial;
+                    }
+                }
+            }
+        }
+    }
+}
+
 
 /**
  * @private
@@ -824,11 +934,14 @@ function modelMaterialsCommon(gltf, options) {
 
         var lightParameters = generateLightParameters(gltf);
 
+        // Pre-processing to assign skinning info and address incompatibilities
+        splitIncompatibleSkins(gltf);
+
         var techniques = {};
         var materials = gltf.materials;
-        for (var name in materials) {
-            if (materials.hasOwnProperty(name)) {
-                var material = materials[name];
+        for (var materialId in materials) {
+            if (materials.hasOwnProperty(materialId)) {
+                var material = materials[materialId];
                 if (defined(material.extensions) && defined(material.extensions.KHR_materials_common)) {
                     var khrMaterialsCommon = material.extensions.KHR_materials_common;
                     var techniqueKey = getTechniqueKey(khrMaterialsCommon);

--- a/specs/lib/generateNormalsSpec.js
+++ b/specs/lib/generateNormalsSpec.js
@@ -1,6 +1,7 @@
 'use strict';
 var clone = require('clone');
 var fs = require('fs');
+var addPipelineExtras = require('../../lib/addPipelineExtras');
 var readGltf = require('../../lib/readGltf');
 var generateNormals = require('../../lib/generateNormals');
 
@@ -15,10 +16,12 @@ describe('generateNormals', function(){
         readGltf(gltfNoNormalsPath)
             .then(function(gltf) {
                 gltfNoNormals = gltf;
+                addPipelineExtras(gltfNoNormals);
                 return readGltf(gltfNormalsPath);
             })
             .then(function(gltf) {
                 gltfNormals = gltf;
+                addPipelineExtras(gltfNormals);
                 done();
             });
     });

--- a/specs/lib/processModelMaterialsCommonSpec.js
+++ b/specs/lib/processModelMaterialsCommonSpec.js
@@ -1,9 +1,11 @@
 'use strict';
 var Cesium = require('cesium');
 var addDefaults = require('../../lib/addDefaults');
+var addPipelineExtras = require('../../lib/addPipelineExtras');
 var processModelMaterialsCommon = require('../../lib/processModelMaterialsCommon');
 
 var clone = Cesium.clone;
+var WebGLConstants = Cesium.WebGLConstants;
 
 describe('processModelMaterialsCommon', function() {
     it('generates techniques and nodes for KHR_materials_common lights', function() {
@@ -105,6 +107,7 @@ describe('processModelMaterialsCommon', function() {
             transparency: 1.0
         };
         addDefaults(gltf);
+        addPipelineExtras(gltf);
         processModelMaterialsCommon(gltf);
         expect(Object.keys(gltf.materials).length > 0).toEqual(true);
         expect(Object.keys(gltf.techniques).length > 0).toEqual(true);
@@ -137,6 +140,7 @@ describe('processModelMaterialsCommon', function() {
             optimizeForCesium : true
         };
         addDefaults(gltfClone, options);
+        addPipelineExtras(gltfClone);
         processModelMaterialsCommon(gltfClone, options);
 
         // Uses the Cesium sun as its default light source
@@ -149,6 +153,7 @@ describe('processModelMaterialsCommon', function() {
 
         gltfClone = clone(gltf, true);
         addDefaults(gltfClone);
+        addPipelineExtras(gltfClone);
         processModelMaterialsCommon(gltfClone);
 
         fragmentShaderSource = gltfClone.shaders.fragmentShader0.extras._pipeline.source;
@@ -207,6 +212,7 @@ describe('processModelMaterialsCommon', function() {
 
         var gltfClone = clone(gltf);
         addDefaults(gltfClone);
+        addPipelineExtras(gltfClone);
         processModelMaterialsCommon(gltfClone);
 
         var material = gltfClone.materials.material1;
@@ -219,5 +225,78 @@ describe('processModelMaterialsCommon', function() {
 
         var vertexShaderSource = gltfClone.shaders[program.vertexShader].extras._pipeline.source.toString();
         expect(vertexShaderSource.indexOf('a_batchid') > -1).toBe(true);
+    });
+
+    it('splits two materials with different types for JOINT and WEIGHT', function() {
+        var gltf = {
+            accessors: {
+                jointAccessor_0: {
+                    componentType: WebGLConstants.FLOAT,
+                    type: 'VEC4'
+                },
+                weightAccessor_0: {
+                    componentType: WebGLConstants.FLOAT,
+                    type: 'VEC4'
+                },
+                jointAccessor_1: {
+                    componentType: WebGLConstants.FLOAT,
+                    type: 'MAT3'
+                },
+                weightAccessor_1: {
+                    componentType: WebGLConstants.FLOAT,
+                    type: 'MAT3'
+                }
+            },
+            extensionsUsed: [
+                'KHR_materials_common'
+            ],
+            materials: {
+                material: {
+                    extensions: {
+                        KHR_materials_common: {
+                            jointCount: 14,
+                            technique: 'BLINN'
+                        }
+                    }
+                }
+            },
+            meshes: {
+                meshVec4: {
+                    primitives: [{
+                        attributes: {
+                            JOINT: 'jointAccessor_0',
+                            WEIGHT: 'weightAccessor_0'
+                        },
+                        material: 'material'
+                    }]
+                },
+                meshMat3: {
+                    primitives: [{
+                        attributes: {
+                            JOINT: 'jointAccessor_1',
+                            WEIGHT: 'weightAccessor_1'
+                        },
+                        material: 'material'
+                    }]
+                }
+            }
+        };
+        addDefaults(gltf);
+        addPipelineExtras(gltf);
+        processModelMaterialsCommon(gltf);
+
+        var meshes = gltf.meshes;
+        var primitiveVec4 = meshes.meshVec4.primitives[0];
+        var primitiveMat3 = meshes.meshMat3.primitives[0];
+        var materialVec4Id = primitiveVec4.material;
+        var materialMat3Id = primitiveMat3.material;
+        expect(materialVec4Id).not.toEqual(materialMat3Id);
+
+        var materials = gltf.materials;
+        var techniques = gltf.techniques;
+        var techniqueVec4 = techniques[materials[materialVec4Id].technique];
+        var techniqueMat3 = techniques[materials[materialMat3Id].technique];
+        expect(techniqueVec4.parameters.joint.type).toEqual(WebGLConstants.FLOAT_VEC4);
+        expect(techniqueMat3.parameters.joint.type).toEqual(WebGLConstants.FLOAT_MAT3);
     });
 });


### PR DESCRIPTION
Makes `processModelMaterialsCommon` handle cases where `JOINT` and `WEIGHT` are not `vec4` (they don't have to be), and cases where two primitives use the same `KHR_materials_common` but have different `type`s for `JOINT` and `WEIGHT`.

See: https://github.com/KhronosGroup/glTF/tree/2.0/specification/2.0#skinned-mesh-attributes

```
Implementation note: The number of joints that influence one vertex is usually limited to 4, so that the joint indices and weights can be stored in vec4 elements.
```

This doesn't work in Cesium yet; I'll take a look at that after the model converter PR is in.

Also, Pulls in some `addPipelineExtras` improvements from `updateVersion`. I'm not getting any failing tests without the texture compression shim that was added, but someone should probably check to make sure removing it isn't breaking anything.