### PR TITLE
Fix output path and handle directories as output path

### DIFF
--- a/lib/Pipeline.js
+++ b/lib/Pipeline.js
@@ -292,7 +292,7 @@ function writeFile(gltf, outputPath, options) {
     var binary = defaultValue(options.binary, false);
     var embed = defaultValue(options.embed, true);
     var embedImage = defaultValue(options.embedImage, true);
-    var createDirectory = defaultValue(options.createDirectory, true);
+    var createDirectory = defaultValue(options.createDirectory, !(embed && embedImage));
     var writeOptions = {
         outputPath : outputPath,
         embed : embed,

--- a/lib/parseArguments.js
+++ b/lib/parseArguments.js
@@ -229,7 +229,7 @@ function parseArguments(args) {
         return;
     }
 
-    var createDirectory = !args.s && !argv.t;
+    var createDirectory = argv.s || argv.t;
 
     var outputFileExtension;
     var fileExtension;
@@ -244,7 +244,8 @@ function parseArguments(args) {
         fileName = path.basename(gltfPath, fileExtension);
         var filePath = path.dirname(gltfPath);
         // Default output.  For example, path/asset.gltf becomes path/asset-optimized.gltf
-        outputPath = path.join(filePath, fileName + '-optimized' + outputFileExtension);
+        var outputFileName = fileName + (createDirectory ? '' : '-optimized') + outputFileExtension;
+        outputPath = path.join(filePath, outputFileName);
     } else if(path.extname(outputPath) === '') { // Handle the case where output path is directory
         createDirectory = false;
         if (argv.b) {

--- a/lib/parseArguments.js
+++ b/lib/parseArguments.js
@@ -222,7 +222,7 @@ function parseArguments(args) {
     }
 
     var gltfPath = defaultValue(argv.i, argv._[0]);
-    var outputPath = defaultValue(argv.o, argv._[1]);
+    var outputPath = defaultValue(argv.o, argv._[defined(argv.i) ? 0 : 1]);
 
     if (!defined(gltfPath)) {
         yargs.showHelp();
@@ -231,18 +231,31 @@ function parseArguments(args) {
 
     var createDirectory = !args.s && !argv.t;
 
+    var outputFileExtension;
+    var fileExtension;
+    var fileName;
     if (!defined(outputPath)) {
-        var outputFileExtension;
         if (argv.b) {
             outputFileExtension = '.glb';
         } else {
             outputFileExtension = '.gltf';
         }
-        var fileExtension = path.extname(gltfPath);
-        var fileName = path.basename(gltfPath, fileExtension);
+        fileExtension = path.extname(gltfPath);
+        fileName = path.basename(gltfPath, fileExtension);
         var filePath = path.dirname(gltfPath);
         // Default output.  For example, path/asset.gltf becomes path/asset-optimized.gltf
         outputPath = path.join(filePath, fileName + '-optimized' + outputFileExtension);
+    } else if(path.extname(outputPath) === '') { // Handle the case where output path is directory
+        createDirectory = false;
+        if (argv.b) {
+            outputFileExtension = '.glb';
+        } else {
+            outputFileExtension = '.gltf';
+        }
+        fileExtension = path.extname(gltfPath);
+        fileName = path.basename(gltfPath, fileExtension);
+        // For example. path/asset.gltf becomes outputPath/asset-optimized.gltf
+        outputPath = path.join(outputPath, fileName + outputFileExtension);
     }
 
     return {

--- a/lib/parseArguments.js
+++ b/lib/parseArguments.js
@@ -229,6 +229,8 @@ function parseArguments(args) {
         return;
     }
 
+    var createDirectory = !args.s && !argv.t;
+
     if (!defined(outputPath)) {
         var outputFileExtension;
         if (argv.b) {
@@ -247,6 +249,7 @@ function parseArguments(args) {
         aoOptions: aoOptions,
         binary: argv.b,
         compressTextureCoordinates: argv.c,
+        createDirectory : createDirectory,
         embed: !argv.s,
         embedImage: !argv.s && !argv.t,
         encodeNormals: argv.n,


### PR DESCRIPTION
This PR changes the following behavior with respect to output location
* If embed options are true, the output is specified by filename, it does not create a new "output" directory.
* If either embed options are false, then "output" directory is created (even if output is specified by filename).
* If output is not specified and embed are true, the then output file name is `/path/to/input-optimized.gltf` (from `/path/to/input.gltf`)
* If output is not specified and embed are false, the then output file name is `/path/to/output/input.gltf` (from `/path/to/input.gltf`)

This PR also introduces handling directories as output. In this case,
* Create directory is always false (irrespective of embed).
* The output path is `outputDir/input.gltf` (from `-i /path/to/input.gltf -o outputDir`)

I have also introduced code to handle the arguments like `-i input output` correctly. (`input -o output` was handled correctly by default before).

Fixes #244 