### PR TITLE
KHR_materials_common transparency fix

### DIFF
--- a/lib/generateModelMaterialsCommon.js
+++ b/lib/generateModelMaterialsCommon.js
@@ -72,10 +72,10 @@ function generateModelMaterialsCommon(gltf, kmcOptions) {
                         materialsCommon.light = lightId;
                         var lightColor = techniqueParameters[lightId + 'Color'];
                         var light = {
-                            name : lightId,
-                            type : 'directional',
-                            directional : {
-                                color : defaultValue(lightColor.value, [1, 1, 1])
+                            name: lightId,
+                            type: 'directional',
+                            directional: {
+                                color: defaultValue(lightColor.value, [1, 1, 1])
                             }
                         };
                         lights[lightId] = light;
@@ -102,9 +102,12 @@ function generateModelMaterialsCommon(gltf, kmcOptions) {
             }
 
             var materialValues = material.values;
-            var diffuseColor = materialValues.diffuse;
-            var transparency = materialValues.transparency;
-            materialsCommon.values = materialValues;
+            var diffuseColor, transparency;
+            if (defined(materialValues)) {
+                diffuseColor = materialValues.diffuse;
+                transparency = materialValues.transparency;
+                materialsCommon.values = materialValues;
+            }
 
             // Check if we have transparency and set transparent flag
             if ((defined(transparency) && transparency < 1.0) ||

--- a/lib/generateModelMaterialsCommon.js
+++ b/lib/generateModelMaterialsCommon.js
@@ -100,7 +100,17 @@ function generateModelMaterialsCommon(gltf, kmcOptions) {
             if (defined(jointCount)) {
                 materialsCommon.jointCount = jointCount;
             }
-            materialsCommon.values = material.values;
+
+            var materialValues = material.values;
+            var diffuseColor = materialValues.diffuse;
+            var transparency = materialValues.transparency;
+            materialsCommon.values = materialValues;
+
+            // Check if we have transparency and set transparent flag
+            if ((defined(transparency) && transparency < 1.0) ||
+                (defined(diffuseColor) && Array.isArray(diffuseColor) && diffuseColor[3] < 1.0)) {
+                materialsCommon.values.transparent = true;
+            }
             delete material.values;
         }
     }

--- a/lib/generateNormals.js
+++ b/lib/generateNormals.js
@@ -194,6 +194,16 @@ function generateMaterial(gltf, primitive, generatedMaterials) {
         generatedMaterialId = getUniqueId(gltf, materialId + '-common');
         var values = clone(material.values);
         values.doubleSided = true;
+
+        var diffuseColor = values.diffuse;
+        var transparency = values.transparency;
+
+        // Check if we have transparency and set transparent flag
+        if ((defined(transparency) && transparency < 1.0) ||
+            (defined(diffuseColor) && Array.isArray(diffuseColor) && diffuseColor[3] < 1.0)) {
+            values.transparent = true;
+        }
+
         materials[generatedMaterialId] = {
             extensions : {
                 KHR_materials_common : {

--- a/specs/lib/generateModelMaterialsCommonSpec.js
+++ b/specs/lib/generateModelMaterialsCommonSpec.js
@@ -1,12 +1,12 @@
 'use strict';
 var generateModelMaterialsCommon = require('../../lib/generateModelMaterialsCommon');
 
-describe('generateModelMaterialsCommon', function() {
-    it('removes techniques, programs, and shaders', function() {
+describe('generateModelMaterialsCommon', function () {
+    it('removes techniques, programs, and shaders', function () {
         var gltf = {
-            techniques : {},
-            programs : {},
-            shaders : {}
+            techniques: {},
+            programs: {},
+            shaders: {}
         };
         generateModelMaterialsCommon(gltf);
         expect(gltf.extensionsUsed).toEqual(['KHR_materials_common']);
@@ -15,27 +15,27 @@ describe('generateModelMaterialsCommon', function() {
         expect(gltf.shaders).not.toBeDefined();
     });
 
-    it('generates a KHR_materials_common material with values', function() {
+    it('generates a KHR_materials_common material with values', function () {
         var gltf = {
-            materials : {
-                material : {
-                    values : {
-                        ambient : [0, 0, 0, 1],
-                        otherAttribute : true
+            materials: {
+                material: {
+                    values: {
+                        ambient: [0, 0, 0, 1],
+                        otherAttribute: true
                     },
                     technique: 'technique'
                 }
             },
-            techniques : {
-                technique : {
-                    parameters : {}
+            techniques: {
+                technique: {
+                    parameters: {}
                 }
             }
         };
         generateModelMaterialsCommon(gltf, {
-            technique : 'PHONG',
-            doubleSided : true,
-            someAttribute : true
+            technique: 'PHONG',
+            doubleSided: true,
+            someAttribute: true
         });
         expect(gltf.extensionsUsed).toEqual(['KHR_materials_common']);
         var material = gltf.materials.material;
@@ -48,25 +48,79 @@ describe('generateModelMaterialsCommon', function() {
         expect(values.otherAttribute).toBe(true);
     });
 
-    it('generates lights from a technique', function() {
+    it('generates a KHR_materials_common with correct transparent flag set if diffuse alpha is less than 1', function () {
         var gltf = {
-            materials : {
-               material : {
-                   technique : 'technique'
-               }
+            materials: {
+                material: {
+                    values: {
+                        diffuse: [1, 0, 0, 0.5]
+                    },
+                    technique: 'technique'
+                }
             },
-            nodes : {
-                lightNode : {}
+            techniques: {
+                technique: {
+                    parameters: {}
+                }
+            }
+        };
+        generateModelMaterialsCommon(gltf);
+        expect(gltf.extensionsUsed).toEqual(['KHR_materials_common']);
+        var material = gltf.materials.material;
+        var materialsCommon = material.extensions.KHR_materials_common;
+        expect(materialsCommon.technique).toBe('PHONG');
+        var values = materialsCommon.values;
+        expect(values.diffuse).toEqual([1, 0, 0, 0.5]);
+        expect(values.transparent).toBe(true);
+    });
+
+    it('generates a KHR_materials_common with correct transparent flag set if transparency less than 1', function () {
+        var gltf = {
+            materials: {
+                material: {
+                    values: {
+                        diffuse: [1, 0, 0, 1],
+                        transparency: 0.5
+                    },
+                    technique: 'technique'
+                }
             },
-            techniques : {
-                technique : {
-                    parameters : {
-                        ambient : {},
-                        light0Color : {
-                            value : [1, 1, 0.5]
+            techniques: {
+                technique: {
+                    parameters: {}
+                }
+            }
+        };
+        generateModelMaterialsCommon(gltf);
+        expect(gltf.extensionsUsed).toEqual(['KHR_materials_common']);
+        var material = gltf.materials.material;
+        var materialsCommon = material.extensions.KHR_materials_common;
+        expect(materialsCommon.technique).toBe('PHONG');
+        var values = materialsCommon.values;
+        expect(values.diffuse).toEqual([1, 0, 0, 1]);
+        expect(values.transparency).toEqual(0.5);
+        expect(values.transparent).toBe(true);
+    });
+
+    it('generates lights from a technique', function () {
+        var gltf = {
+            materials: {
+                material: {
+                    technique: 'technique'
+                }
+            },
+            nodes: {
+                lightNode: {}
+            },
+            techniques: {
+                technique: {
+                    parameters: {
+                        ambient: {},
+                        light0Color: {
+                            value: [1, 1, 0.5]
                         },
-                        light0Transform : {
-                            node : 'lightNode'
+                        light0Transform: {
+                            node: 'lightNode'
                         }
                     }
                 }
@@ -80,43 +134,43 @@ describe('generateModelMaterialsCommon', function() {
         expect(gltf.techniques).not.toBeDefined();
     });
 
-    it('declares jointCount for skinned nodes', function() {
+    it('declares jointCount for skinned nodes', function () {
         var gltf = {
-            accessors : {
-                accessor : {
-                    count : 4
+            accessors: {
+                accessor: {
+                    count: 4
                 }
             },
-            materials : {
-                material : {
-                    technique : 'technique'
+            materials: {
+                material: {
+                    technique: 'technique'
                 }
             },
-            meshes : {
-                mesh : {
-                    primitives : [
+            meshes: {
+                mesh: {
+                    primitives: [
                         {
-                            material : 'material'
+                            material: 'material'
                         }
                     ]
                 }
             },
-            nodes : {
-                skinnedNode : {
-                    meshes : [
+            nodes: {
+                skinnedNode: {
+                    meshes: [
                         'mesh'
                     ],
-                    skin : 'skin'
+                    skin: 'skin'
                 }
             },
-            skins : {
-                skin : {
-                    inverseBindMatrices : 'accessor'
+            skins: {
+                skin: {
+                    inverseBindMatrices: 'accessor'
                 }
             },
-            techniques : {
-                technique : {
-                    parameters : {}
+            techniques: {
+                technique: {
+                    parameters: {}
                 }
             }
         };


### PR DESCRIPTION
The spec says that there should be a `transparent` bool set if the material has transparency. When we were generating KMC materials we weren't ever setting that flag. The caused models that needed normals generated and had transparency to be rendered opaque.