### PR TITLE
updated getBinaryGltf for gltfs with special characters

### DIFF
--- a/lib/getBinaryGltf.js
+++ b/lib/getBinaryGltf.js
@@ -32,7 +32,7 @@ function updateBinaryObject(gltf, objects, name, pipelineExtras, state) {
                     state.currentBinaryView++;
                 }
 
-                var objectSource = new Buffer(object.extras._pipeline.source);
+                var objectSource = Buffer.from(object.extras._pipeline.source);
                 var bufferViewId = 'binary_bufferView' + state.currentBinaryView;
                 KHR_binary_glTF.bufferView = bufferViewId; //Create bufferview
                 bufferViews[bufferViewId] = {
@@ -120,7 +120,7 @@ function getBinaryGltf(gltf, embed, embedImage) {
 
     // Create padded binary scene buffer and calculate total length
     var sceneString = JSON.stringify(gltf);
-    var sceneBuffer = Buffer.alloc(Buffer.byteLength(sceneString), sceneString);
+    var sceneBuffer = Buffer.from(sceneString);
     var sceneLength = sceneBuffer.length;
     var paddingLength = 4 - (sceneLength % 4); // pad out to 4 bytes as per glb specification
     sceneLength += paddingLength;

--- a/lib/getBinaryGltf.js
+++ b/lib/getBinaryGltf.js
@@ -123,7 +123,6 @@ function getBinaryGltf(gltf, embed, embedImage) {
     var sceneBuffer = new Buffer(sceneString);
     var sceneLength = sceneBuffer.length;
     var paddingLength = 4 - (sceneLength % 4); // pad out to 4 bytes as per glb specification
-    console.log(paddingLength);
     sceneLength += paddingLength;
     var paddingBuffer = new Buffer(paddingLength).fill(' ');
     var scene = (Buffer.concat([sceneBuffer, paddingBuffer]));

--- a/lib/getBinaryGltf.js
+++ b/lib/getBinaryGltf.js
@@ -118,12 +118,16 @@ function getBinaryGltf(gltf, embed, embedImage) {
     // Remove extras objects before writing
     removePipelineExtras(gltf);
 
-    // Create padded binary scene string and calculate total length
+    // Create padded binary scene buffer and calculate total length
     var sceneString = JSON.stringify(gltf);
-    var sceneLength = Buffer.byteLength(sceneString);
-    sceneLength += 4 - (sceneLength % 4);
-    var padding = new Array(sceneLength + 1).join(' ');
-    sceneString = (sceneString + padding).substring(0, sceneLength);
+    var sceneBuffer = new Buffer(sceneString);
+    var sceneLength = sceneBuffer.length;
+    var paddingLength = 4 - (sceneLength % 4); // pad out to 4 bytes as per glb specification
+    console.log(paddingLength);
+    sceneLength += paddingLength;
+    var paddingBuffer = new Buffer(paddingLength).fill(' ');
+    var scene = (Buffer.concat([sceneBuffer, paddingBuffer]));
+
     var bodyOffset = 20 + sceneLength;
     var glbLength = bodyOffset + body.length;
 
@@ -135,8 +139,7 @@ function getBinaryGltf(gltf, embed, embedImage) {
     header.writeUInt32LE(sceneLength, 12);
     header.writeUInt32LE(0, 16);
 
-    // Create scene buffer and overall buffer
-    var scene = new Buffer(sceneString);
+    // Create overall buffer
     var glb = Buffer.concat([header, scene, body], glbLength);
 
     return {

--- a/lib/getBinaryGltf.js
+++ b/lib/getBinaryGltf.js
@@ -120,18 +120,18 @@ function getBinaryGltf(gltf, embed, embedImage) {
 
     // Create padded binary scene buffer and calculate total length
     var sceneString = JSON.stringify(gltf);
-    var sceneBuffer = new Buffer(sceneString);
+    var sceneBuffer = Buffer.alloc(Buffer.byteLength(sceneString), sceneString);
     var sceneLength = sceneBuffer.length;
     var paddingLength = 4 - (sceneLength % 4); // pad out to 4 bytes as per glb specification
     sceneLength += paddingLength;
-    var paddingBuffer = new Buffer(paddingLength).fill(' ');
-    var scene = (Buffer.concat([sceneBuffer, paddingBuffer]));
+    var paddingBuffer = Buffer.alloc(paddingLength, ' ');
+    var scene = Buffer.concat([sceneBuffer, paddingBuffer]);
 
     var bodyOffset = 20 + sceneLength;
     var glbLength = bodyOffset + body.length;
 
     // Write binary glTF header (magic, version, length, sceneLength, sceneFormat)
-    var header = new Buffer(20);
+    var header = Buffer.alloc(20);
     header.write('glTF', 0);
     header.writeUInt32LE(1, 4);
     header.writeUInt32LE(glbLength, 8);

--- a/specs/lib/getBinaryGltfSpec.js
+++ b/specs/lib/getBinaryGltfSpec.js
@@ -51,7 +51,7 @@ describe('getBinaryGltf', function() {
             }), done).toResolve();
     });
 
-    fit('writes a valid binary gltf header with embedded resources', function () {
+    it('writes a valid binary gltf header with embedded resources', function () {
         var gltf = clone(testData.gltf);
         var glbData = getBinaryGltf(gltf, true, true);
         var header = glbData.header;
@@ -63,7 +63,7 @@ describe('getBinaryGltf', function() {
         expect(header.readUInt32LE(16)).toEqual(0);
     });
 
-    fit('writes a valid binary gltf header with separate resources', function () {
+    it('writes a valid binary gltf header with separate resources', function () {
         var gltf = clone(testData.gltf);
         var glbData = getBinaryGltf(gltf, false, false);
         var header = glbData.header;
@@ -75,14 +75,14 @@ describe('getBinaryGltf', function() {
         expect(header.readUInt32LE(16)).toEqual(0);
     });
 
-    fit('writes the correct binary scene', function () {
+    it('writes the correct binary scene', function () {
         var gltf = clone(testData.gltf);
         var glbData = getBinaryGltf(gltf, true, true);
         var scene = glbData.scene;
         expect(JSON.parse(scene.toString())).toEqual(testData.scene);
     });
 
-    fit('writes the correct binary body with embedded resources', function () {
+    it('writes the correct binary body with embedded resources', function () {
         var gltf = clone(testData.gltf);
         var glbData = getBinaryGltf(gltf, true, true);
         var body = glbData.body;
@@ -91,7 +91,7 @@ describe('getBinaryGltf', function() {
         expect(bufferEqual(binaryBody, body)).toBe(true);
     });
 
-    fit('writes the correct binary body with separate images', function () {
+    it('writes the correct binary body with separate images', function () {
         var gltf = clone(testData.gltf);
         var glbData = getBinaryGltf(gltf, true, false);
         var body = glbData.body;
@@ -100,7 +100,7 @@ describe('getBinaryGltf', function() {
         expect(bufferEqual(binaryBody, body)).toBe(true);
     });
 
-    fit('writes the correct binary body with separate resources except images', function () {
+    it('writes the correct binary body with separate resources except images', function () {
         var gltf = clone(testData.gltf);
         var glbData = getBinaryGltf(gltf, false, true);
         var body = glbData.body;
@@ -109,7 +109,7 @@ describe('getBinaryGltf', function() {
         expect(bufferEqual(binaryBody, body)).toBe(true);
     });
 
-    fit('writes the correct binary body with separate resources', function () {
+    it('writes the correct binary body with separate resources', function () {
         var gltf = clone(testData.gltf);
         var glbData = getBinaryGltf(gltf, false, false);
         var body = glbData.body;

--- a/specs/lib/getBinaryGltfSpec.js
+++ b/specs/lib/getBinaryGltfSpec.js
@@ -51,7 +51,7 @@ describe('getBinaryGltf', function() {
             }), done).toResolve();
     });
 
-    it('writes a valid binary gltf header with embedded resources', function () {
+    fit('writes a valid binary gltf header with embedded resources', function () {
         var gltf = clone(testData.gltf);
         var glbData = getBinaryGltf(gltf, true, true);
         var header = glbData.header;
@@ -63,7 +63,7 @@ describe('getBinaryGltf', function() {
         expect(header.readUInt32LE(16)).toEqual(0);
     });
 
-    it('writes a valid binary gltf header with separate resources', function () {
+    fit('writes a valid binary gltf header with separate resources', function () {
         var gltf = clone(testData.gltf);
         var glbData = getBinaryGltf(gltf, false, false);
         var header = glbData.header;
@@ -75,14 +75,14 @@ describe('getBinaryGltf', function() {
         expect(header.readUInt32LE(16)).toEqual(0);
     });
 
-    it('writes the correct binary scene', function () {
+    fit('writes the correct binary scene', function () {
         var gltf = clone(testData.gltf);
         var glbData = getBinaryGltf(gltf, true, true);
         var scene = glbData.scene;
         expect(JSON.parse(scene.toString())).toEqual(testData.scene);
     });
 
-    it('writes the correct binary body with embedded resources', function () {
+    fit('writes the correct binary body with embedded resources', function () {
         var gltf = clone(testData.gltf);
         var glbData = getBinaryGltf(gltf, true, true);
         var body = glbData.body;
@@ -91,7 +91,7 @@ describe('getBinaryGltf', function() {
         expect(bufferEqual(binaryBody, body)).toBe(true);
     });
 
-    it('writes the correct binary body with separate images', function () {
+    fit('writes the correct binary body with separate images', function () {
         var gltf = clone(testData.gltf);
         var glbData = getBinaryGltf(gltf, true, false);
         var body = glbData.body;
@@ -100,7 +100,7 @@ describe('getBinaryGltf', function() {
         expect(bufferEqual(binaryBody, body)).toBe(true);
     });
 
-    it('writes the correct binary body with separate resources except images', function () {
+    fit('writes the correct binary body with separate resources except images', function () {
         var gltf = clone(testData.gltf);
         var glbData = getBinaryGltf(gltf, false, true);
         var body = glbData.body;
@@ -109,7 +109,7 @@ describe('getBinaryGltf', function() {
         expect(bufferEqual(binaryBody, body)).toBe(true);
     });
 
-    it('writes the correct binary body with separate resources', function () {
+    fit('writes the correct binary body with separate resources', function () {
         var gltf = clone(testData.gltf);
         var glbData = getBinaryGltf(gltf, false, false);
         var body = glbData.body;


### PR DESCRIPTION
`getBinaryGltf` used to have a problem where gltfs with special characters would cause weird byte offset issues, since the stringified gltf's string length wouldn't be the same as the byte length.