### PR TITLE
`processModelMaterialsCommon` fix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 Change Log
 ==========
 
+### 0.1.0-alpha13 - ??
+* Fixed a bug in `processModelMaterialsCommon` that produced out-of-spec technique states.
+
 ### 0.1.0-alpha12 - 2017-04-13
 * Fixed issue with ambient occlusion not working correctly with other stages. [#267](https://github.com/AnalyticalGraphicsInc/gltf-pipeline/pull/267)
 * Fixed handling of binary glTF with special characters. [#253](https://github.com/AnalyticalGraphicsInc/gltf-pipeline/pull/253)

--- a/lib/processModelMaterialsCommon.js
+++ b/lib/processModelMaterialsCommon.js
@@ -586,8 +586,8 @@ function generateTechnique(gltf, khrMaterialsCommon, lightParameters, optimizeFo
                 WebGLConstants.DEPTH_TEST,
                 WebGLConstants.BLEND
             ],
-            depthMask: false,
             functions: {
+                depthMask : [false],
                 blendEquationSeparate: [
                     WebGLConstants.FUNC_ADD,
                     WebGLConstants.FUNC_ADD


### PR DESCRIPTION
The `processModelMaterialsCommon` for generating glTF shaders/materials/techniques based on the `KH_model_materials_common` extension used to produce slightly out-of-spec glTF techniques.

I only caught this while trying to run a model with the extension through the pipeline twice, which caused a bizarre crash in `addDefaults`.