### PR TITLE
Add `mergeVertices` option and disable by default

### DIFF
--- a/lib/Pipeline.js
+++ b/lib/Pipeline.js
@@ -83,6 +83,7 @@ Pipeline.processJSON = function(gltf, options) {
  * @param {Object} [options.compressTextureCoordinates=false] Flag to run compressTextureCoordinates stage.
  * @param {Object} [options.kmcOptions=undefined] Options to pass to the generateModelMaterialsCommon stage, if undefined, stage is not run.
  * @param {Object} [options.quantize] Flag to run quantizeAttributes stage.
+ * @param {Boolean} [options.mergeVertices = false} Flag to merge duplicate vertices, which can produce a smaller model size but greatly increases conversion time.
  * @param {Object|Object[]} [options.textureCompressionOptions=undefined] Options to pass to the compressTextures stage. If an array of options is given, the textures will be compressed in multiple formats. If undefined, stage is not run.
  * @returns {Promise} A promise that resolves to the processed glTF asset.
  */
@@ -112,7 +113,9 @@ Pipeline.processJSONWithExtras  = function(gltfWithExtras, options) {
         generateNormals(gltfWithExtras, options);
     }
     if (!shouldPreserve) {
-        mergeDuplicateVertices(gltfWithExtras);
+        if (options.mergeVertices) {
+            mergeDuplicateVertices(gltfWithExtras);
+        }
         MergeDuplicateProperties.mergeAll(gltfWithExtras);
         RemoveUnusedProperties.removeAll(gltfWithExtras);
         removeDuplicatePrimitives(gltfWithExtras);

--- a/lib/Pipeline.js
+++ b/lib/Pipeline.js
@@ -113,8 +113,10 @@ Pipeline.processJSONWithExtras  = function(gltfWithExtras, options) {
     if (smoothNormals || faceNormals) {
         generateNormals(gltfWithExtras, options);
     }
+
+    var mergeVertices = defaultValue(options.mergeVertices, false);
     if (!shouldPreserve) {
-        if (options.mergeVertices) {
+        if (mergeVertices) {
             mergeDuplicateVertices(gltfWithExtras);
         }
         MergeDuplicateProperties.mergeAll(gltfWithExtras);

--- a/lib/Pipeline.js
+++ b/lib/Pipeline.js
@@ -83,7 +83,8 @@ Pipeline.processJSON = function(gltf, options) {
  * @param {Object} [options.compressTextureCoordinates=false] Flag to run compressTextureCoordinates stage.
  * @param {Object} [options.kmcOptions=undefined] Options to pass to the generateModelMaterialsCommon stage, if undefined, stage is not run.
  * @param {Object} [options.quantize] Flag to run quantizeAttributes stage.
- * @param {Boolean} [options.mergeVertices = false} Flag to merge duplicate vertices, which can produce a smaller model size but greatly increases conversion time.
+ * @param {Object} [options.preserve=false] Flag to turn optimization pipeline stages on/off to preserve the original glTF hierarchy.
+ * @param {Boolean} [options.mergeVertices=false} Flag to merge duplicate vertices, which can produce a smaller model size but greatly increases conversion time. This setting only applies when options.preserve is false.
  * @param {Object|Object[]} [options.textureCompressionOptions=undefined] Options to pass to the compressTextures stage. If an array of options is given, the textures will be compressed in multiple formats. If undefined, stage is not run.
  * @returns {Promise} A promise that resolves to the processed glTF asset.
  */

--- a/lib/Pipeline.js
+++ b/lib/Pipeline.js
@@ -84,7 +84,7 @@ Pipeline.processJSON = function(gltf, options) {
  * @param {Object} [options.kmcOptions=undefined] Options to pass to the generateModelMaterialsCommon stage, if undefined, stage is not run.
  * @param {Object} [options.quantize] Flag to run quantizeAttributes stage.
  * @param {Object} [options.preserve=false] Flag to turn optimization pipeline stages on/off to preserve the original glTF hierarchy.
- * @param {Boolean} [options.mergeVertices=false} Flag to merge duplicate vertices, which can produce a smaller model size but greatly increases conversion time. This setting only applies when options.preserve is false.
+ * @param {Boolean} [options.mergeVertices=false] Flag to merge duplicate vertices, which can produce a smaller model size but greatly increases conversion time. This setting only applies when options.preserve is false.
  * @param {Object|Object[]} [options.textureCompressionOptions=undefined] Options to pass to the compressTextures stage. If an array of options is given, the textures will be compressed in multiple formats. If undefined, stage is not run.
  * @returns {Promise} A promise that resolves to the processed glTF asset.
  */

--- a/lib/mergeDuplicateVertices.js
+++ b/lib/mergeDuplicateVertices.js
@@ -25,6 +25,10 @@ module.exports = mergeDuplicateVertices;
  * @see removeUnusedVertices
  */
 function mergeDuplicateVertices(gltf) {
+    return mergeDuplicateVertices._implementation(gltf);
+}
+
+mergeDuplicateVertices._implementation = function (gltf) {
     var meshes = gltf.meshes;
     var indexAccessors = {};
     for (var meshId in meshes) {
@@ -37,7 +41,7 @@ function mergeDuplicateVertices(gltf) {
     mergeDuplicateVerticesFromMapping(gltf, indexAccessors);
     removeUnusedVertices(gltf);
     return gltf;
-}
+};
 
 function mergeDuplicateVerticesFromMapping(gltf, indexAccessors) {
     var accessors = gltf.accessors;

--- a/lib/parseArguments.js
+++ b/lib/parseArguments.js
@@ -72,6 +72,10 @@ function parseArguments(args) {
                 describe: 'Compress the testure coordinates of this glTF asset.',
                 type: 'boolean'
             },
+            'mergeVertices': {
+                describe: 'Merges duplicate vertices, which can produce a smaller model size but greatly increases conversion time.',
+                type: 'boolean'
+            },
             'removeNormals': {
                 alias: 'r',
                 describe: 'Strips off existing normals, allowing them to be regenerated.',
@@ -261,6 +265,7 @@ function parseArguments(args) {
         preserve: argv.p,
         quantize: argv.q,
         removeNormals: argv.r,
-        textureCompressionOptions: textureCompressionOptions
+        textureCompressionOptions: textureCompressionOptions,
+        mergeVertices: argv.mergeVertices
     };
 }

--- a/lib/parseArguments.js
+++ b/lib/parseArguments.js
@@ -73,7 +73,7 @@ function parseArguments(args) {
                 type: 'boolean'
             },
             'mergeVertices': {
-                describe: 'Merges duplicate vertices, which can produce a smaller model size but greatly increases conversion time.',
+                describe: 'Merges duplicate vertices, which can produce a smaller model size but greatly increases conversion time. This setting only applies when preserve is false.',
                 type: 'boolean'
             },
             'removeNormals': {

--- a/specs/lib/PipelineSpec.js
+++ b/specs/lib/PipelineSpec.js
@@ -4,6 +4,7 @@ var fsExtra = require('fs-extra');
 var path = require('path');
 var Promise = require('bluebird');
 
+var mergeDuplicateVertices = require('../../lib/mergeDuplicateVertices');
 var Pipeline = require('../../lib/Pipeline');
 var readGltf = require('../../lib/readGltf');
 
@@ -11,6 +12,7 @@ var processFile = Pipeline.processFile;
 var processFileToDisk = Pipeline.processFileToDisk;
 var processJSON = Pipeline.processJSON;
 var processJSONToDisk = Pipeline.processJSONToDisk;
+var processJSONWithExtras = Pipeline.processJSONWithExtras;
 
 var fsExtraReadFile = Promise.promisify(fsExtra.readFile);
 
@@ -158,5 +160,29 @@ describe('Pipeline', function() {
                 var finalUri = testBuffer.uri;
                 expect(initialUri).not.toEqual(finalUri);
             }), done).toResolve();
+    });
+
+    it('processJSONWithExtras does not merge duplicate vertices by default', function (done) {
+        spyOn(mergeDuplicateVertices, '_implementation').and.callThrough();
+        var promise = readGltf(gltfPath)
+            .then(function (gltf) {
+                return processJSONWithExtras(gltf);
+            })
+            .then(function () {
+                expect(mergeDuplicateVertices._implementation).not.toHaveBeenCalled();
+            });
+        expect(promise, done).toResolve();
+    });
+
+    it('processJSONWithExtras can merge duplicate vertices.', function (done) {
+        spyOn(mergeDuplicateVertices, '_implementation').and.callThrough();
+        var promise = readGltf(gltfPath)
+            .then(function (gltf) {
+                return processJSONWithExtras(gltf, {mergeVertices: true}).thenReturn(gltf);
+            })
+            .then(function (gltf) {
+                expect(mergeDuplicateVertices._implementation).toHaveBeenCalledWith(gltf);
+            });
+        expect(promise, done).toResolve();
     });
 });

--- a/specs/lib/PipelineSpec.js
+++ b/specs/lib/PipelineSpec.js
@@ -178,7 +178,7 @@ describe('Pipeline', function() {
         spyOn(mergeDuplicateVertices, '_implementation').and.callThrough();
         var promise = readGltf(gltfPath)
             .then(function (gltf) {
-                return processJSONWithExtras(gltf, {mergeVertices: true}).thenReturn(gltf);
+                return processJSONWithExtras(gltf, {mergeVertices: true});
             })
             .then(function (gltf) {
                 expect(mergeDuplicateVertices._implementation).toHaveBeenCalledWith(gltf);


### PR DESCRIPTION
This works around #161 by adding a `mergeVertices` and disabling it by default.  Once `mergeDuplicateVertices` is refactored to use less memory and be orders of magnitude faster, we can take out the option and just always do it.

CC @lilleyse 