### PR TITLE
fs to fs-extra for loadGltfUris

### DIFF
--- a/lib/loadGltfUris.js
+++ b/lib/loadGltfUris.js
@@ -3,7 +3,7 @@ var Cesium = require('cesium');
 var Jimp = require('jimp');
 var Promise = require('bluebird');
 var dataUriToBuffer = require('data-uri-to-buffer');
-var fs = require('fs');
+var fs = require('fs-extra');
 var path = require('path');
 
 var defined = Cesium.defined;


### PR DESCRIPTION
Fixes https://github.com/AnalyticalGraphicsInc/gltf-pipeline/issues/282.

Fixes a crash in the somewhat atypical use case where a gltf references a huge number of files.