### PR TITLE
Fix issue with transparent diffuse texture setting the technique state

### DIFF
--- a/lib/addDefaults.js
+++ b/lib/addDefaults.js
@@ -347,6 +347,42 @@ function addDefaultTechnique(gltf) {
     }
 }
 
+function isTechniqueShared(gltf, techniqueId) {
+    var users = 0;
+    var materials = gltf.materials;
+    for (var materialId in materials) {
+        if (materials.hasOwnProperty(materialId)) {
+            var material = materials[materialId];
+            if (material.technique === techniqueId) {
+                ++users;
+            }
+        }
+    }
+    return users > 1;
+}
+
+function makeTechniqueTransparent(technique) {
+    technique.states = {
+        enable: [
+            WebGLConstants.DEPTH_TEST,
+            WebGLConstants.BLEND
+        ],
+        depthMask: false,
+        functions: {
+            blendEquationSeparate: [
+                WebGLConstants.FUNC_ADD,
+                WebGLConstants.FUNC_ADD
+            ],
+            blendFuncSeparate: [
+                WebGLConstants.ONE,
+                WebGLConstants.ONE_MINUS_SRC_ALPHA,
+                WebGLConstants.ONE,
+                WebGLConstants.ONE_MINUS_SRC_ALPHA
+            ]
+        }
+    };
+}
+
 function enableDiffuseTransparency(gltf) {
     var materials = gltf.materials;
     var techniques = gltf.techniques;
@@ -364,30 +400,23 @@ function enableDiffuseTransparency(gltf) {
                     diffuseTransparent = diffuse[3] < 1.0;
                 }
 
-                var technique = techniques[material.technique];
+                var techniqueId = material.technique;
+                var technique = techniques[techniqueId];
                 var blendingEnabled = technique.states.enable.indexOf(WebGLConstants.BLEND) > -1;
 
                 // Override the technique's states if blending isn't already enabled
                 if (diffuseTransparent && !blendingEnabled) {
-                    technique.states = {
-                        enable: [
-                            WebGLConstants.DEPTH_TEST,
-                            WebGLConstants.BLEND
-                        ],
-                        depthMask: false,
-                        functions: {
-                            blendEquationSeparate: [
-                                WebGLConstants.FUNC_ADD,
-                                WebGLConstants.FUNC_ADD
-                            ],
-                            blendFuncSeparate: [
-                                WebGLConstants.ONE,
-                                WebGLConstants.ONE_MINUS_SRC_ALPHA,
-                                WebGLConstants.ONE,
-                                WebGLConstants.ONE_MINUS_SRC_ALPHA
-                            ]
+                    if (isTechniqueShared(gltf, techniqueId)) {
+                        var transparentTechniqueId = techniqueId + '_transparent';
+                        if (!defined(techniques[transparentTechniqueId])) {
+                            technique = clone(technique, true);
+                            makeTechniqueTransparent(technique);
+                            gltf.techniques[transparentTechniqueId] = technique;
                         }
-                    };
+                        material.technique = transparentTechniqueId;
+                    } else {
+                        makeTechniqueTransparent(technique);
+                    }
                 }
             }
         }

--- a/lib/addDefaults.js
+++ b/lib/addDefaults.js
@@ -348,17 +348,20 @@ function addDefaultTechnique(gltf) {
 }
 
 function isTechniqueShared(gltf, techniqueId) {
-    var users = 0;
+    var referenced = false;
     var materials = gltf.materials;
     for (var materialId in materials) {
         if (materials.hasOwnProperty(materialId)) {
             var material = materials[materialId];
             if (material.technique === techniqueId) {
-                ++users;
+                if (referenced) {
+                    return true;
+                }
+                referenced = true;
             }
         }
     }
-    return users > 1;
+    return false;
 }
 
 function makeTechniqueTransparent(technique) {


### PR DESCRIPTION
In `addDefaults.enabledDiffuseTransparency` it checks if any materials have a transparent diffuse texture and if so sets the alpha render state for that technique. The problem occurs when multiple materials share the same technique and one transparent texture causes the whole model to be transparent.

The solution was to check if the technique has other users, and if so copy the technique before messing with the render state.

Sample models that show the problem are here: https://groups.google.com/forum/#!topic/cesium-dev/4cG1nDU_QwU