### PR TITLE
Update npm dependencies

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,7 +6,7 @@ var fsExtra = require('fs-extra');
 var gulp = require('gulp');
 var gulpJshint = require('gulp-jshint');
 var Jasmine = require('jasmine');
-var JasmineSpecReporter = require('jasmine-spec-reporter');
+var jasmineSpecReporter = require('jasmine-spec-reporter');
 var open = require('open');
 var path = require('path');
 var Promise = require('bluebird');
@@ -15,9 +15,6 @@ var yargs = require('yargs');
 var defined = Cesium.defined;
 var DeveloperError = Cesium.DeveloperError;
 var argv = yargs.argv;
-
-var fsExtraReadFile = Promise.promisify(fsExtra.readFile);
-var fsExtraOutputFile = Promise.promisify(fsExtra.outputFile);
 
 // Add third-party node module binaries to the system path
 // since some tasks need to call them directly.
@@ -67,7 +64,7 @@ gulp.task('test', function (done) {
         // Travis runs Ubuntu 12.04.5 which has glibc 2.15, while crunch requires glibc 2.22 or higher
         excludeCompressedTextures(jasmine);
     }
-    jasmine.addReporter(new JasmineSpecReporter({
+    jasmine.addReporter(new jasmineSpecReporter.SpecReporter({
         displaySuccessfulSpec: !defined(argv.suppressPassed) || !argv.suppressPassed
     }));
     jasmine.execute();
@@ -292,12 +289,12 @@ gulp.task('build-cesium', function () {
     };
     Promise.map(files, function(fileName) {
         var filePath = path.join(basePath, fileName);
-        return fsExtraReadFile(filePath)
+        return fsExtra.readFile(filePath)
             .then(function(buffer) {
                 var source = buffer.toString();
                 source = amdify(source, subDependencyMapping);
                 var outputPath = path.join(outputDir, fileName);
-                return fsExtraOutputFile(outputPath, source);
+                return fsExtra.outputFile(outputPath, source);
             });
     });
 });
@@ -310,12 +307,12 @@ gulp.task('build-cesium-combine', function () {
     ];
     Promise.map(files, function(fileName) {
         var filePath = path.join(basePath, fileName);
-        return fsExtraReadFile(filePath)
+        return fsExtra.readFile(filePath)
             .then(function(buffer) {
                 var source = buffer.toString();
                 source = combine(source);
                 var outputPath = path.join(outputDir, fileName);
-                return fsExtraOutputFile(outputPath, source);
+                return fsExtra.outputFile(outputPath, source);
             });
     });
 });

--- a/lib/compressTexture.js
+++ b/lib/compressTexture.js
@@ -9,11 +9,7 @@ var Promise = require('bluebird');
 var uuid = require('uuid');
 var getTempDirectory = require('./getTempDirectory');
 
-Jimp.prototype.getBufferAsync = Promise.promisify(Jimp.prototype.getBuffer);
-var fsExtraEnsureDir = Promise.promisify(fsExtra.ensureDir);
-var fxExtraReadFile = Promise.promisify(fsExtra.readFile);
-var fsExtraRemove = Promise.promisify(fsExtra.remove);
-fsExtra.writeFileAsync = Promise.promisify(fsExtra.writeFile);
+var jimpGetBuffer = Promise.promisify(Jimp.prototype.getBuffer);
 
 var CesiumMath = Cesium.Math;
 var combine = Cesium.combine;
@@ -177,7 +173,7 @@ function compressTexture(gltf, imageId, options) {
         }
     }
 
-    return fsExtraEnsureDir(tempDirectory)
+    return Promise.resolve(fsExtra.ensureDir(tempDirectory))
         .then(function() {
             if (compressRaw) {
                 // Save the raw image as a png and then send to the compression tool
@@ -191,7 +187,7 @@ function compressTexture(gltf, imageId, options) {
             }
         })
         .finally(function() {
-            return fsExtraRemove(tempDirectory);
+            return fsExtra.remove(tempDirectory);
         });
 }
 
@@ -227,7 +223,7 @@ function createProcess(compressToolPath, options) {
 
 function compressJimpImage(jimpImage, tempDirectory, compressFunction, options) {
     // Encode image as png since this is supported by all the compress tools
-    return jimpImage.getBufferAsync(Jimp.MIME_PNG)
+    return jimpGetBuffer.call(jimpImage, Jimp.MIME_PNG)
         .then(function(buffer) {
             return compressBuffer(buffer, '.png', tempDirectory, compressFunction, options);
         });
@@ -236,7 +232,7 @@ function compressJimpImage(jimpImage, tempDirectory, compressFunction, options) 
 function compressBuffer(buffer, extension, tempDirectory, compressFunction, options) {
     // Save temporary image file off to a temp directory
     var inputPath = getTempImagePath(tempDirectory, extension);
-    return fsExtra.writeFileAsync(inputPath, buffer)
+    return fsExtra.writeFile(inputPath, buffer)
         .then(function() {
             return compressFile(inputPath, tempDirectory, compressFunction, options);
         });
@@ -249,7 +245,7 @@ function compressFile(inputPath, tempDirectory, compressFunction, options) {
 function runCompressTool(path, options, outputPath) {
     return createProcess(path, options)
         .then(function () {
-            return fxExtraReadFile(outputPath);
+            return fsExtra.readFile(outputPath);
         });
 }
 

--- a/lib/directoryExists.js
+++ b/lib/directoryExists.js
@@ -1,8 +1,5 @@
 'use strict';
 var fsExtra = require('fs-extra');
-var Promise = require('bluebird');
-
-var fsExtraStat = Promise.promisify(fsExtra.stat);
 
 module.exports = directoryExists;
 
@@ -10,7 +7,7 @@ module.exports = directoryExists;
  * @private
  */
 function directoryExists(directory) {
-    return fsExtraStat(directory)
+    return fsExtra.stat(directory)
         .then(function(stats) {
             return stats.isDirectory();
         })

--- a/lib/encodeImages.js
+++ b/lib/encodeImages.js
@@ -2,7 +2,7 @@
 var Jimp = require('jimp');
 var Promise = require('bluebird');
 
-Jimp.prototype.getBufferAsync = Promise.promisify(Jimp.prototype.getBuffer);
+var jimpGetBuffer = Promise.promisify(Jimp.prototype.getBuffer);
 
 module.exports = encodeImages;
 
@@ -53,7 +53,7 @@ function encodeImages(gltf) {
 
 function loadImageSource(pipelineExtras, mime) {
     var image = pipelineExtras.jimpImage;
-    return image.getBufferAsync(mime)
+    return jimpGetBuffer.call(image, mime)
         .then(function(imageBuffer) {
             pipelineExtras.source = imageBuffer;
         });

--- a/lib/loadGltfUris.js
+++ b/lib/loadGltfUris.js
@@ -3,7 +3,7 @@ var Cesium = require('cesium');
 var Jimp = require('jimp');
 var Promise = require('bluebird');
 var dataUriToBuffer = require('data-uri-to-buffer');
-var fs = require('fs-extra');
+var fsExtra = require('fs-extra');
 var path = require('path');
 
 var defined = Cesium.defined;
@@ -11,8 +11,6 @@ var defaultValue = Cesium.defaultValue;
 var DeveloperError = Cesium.DeveloperError;
 
 var isDataUri = require('./isDataUri');
-
-var fsReadFile = Promise.promisify(fs.readFile);
 
 module.exports = loadGltfUris;
 
@@ -142,7 +140,7 @@ function isTransparent(image) {
 }
 
 function readFromFile(object, name, uriPath) {
-    return fsReadFile(uriPath)
+    return fsExtra.readFile(uriPath)
         .then(function(data) {
             if (name === 'shaders') {
                 object.extras._pipeline.source = data.toString();

--- a/lib/readGltf.js
+++ b/lib/readGltf.js
@@ -1,6 +1,6 @@
 'use strict';
 var Cesium = require('cesium');
-var fs = require('fs');
+var fsExtra = require('fs-extra');
 var path = require('path');
 var Promise = require('bluebird');
 
@@ -11,8 +11,6 @@ var DeveloperError = Cesium.DeveloperError;
 var parseBinaryGltf = require('./parseBinaryGltf');
 var addPipelineExtras = require('./addPipelineExtras');
 var loadGltfUris = require('./loadGltfUris');
-
-var fsReadFile = Promise.promisify(fs.readFile);
 
 module.exports = readGltf;
 
@@ -39,7 +37,8 @@ function readGltf(gltfPath, options) {
     if (fileExtension !== '.glb' && fileExtension !== '.gltf') {
         throw new DeveloperError('Invalid glTF file.');
     }
-    return fsReadFile(gltfPath)
+
+    return Promise.resolve(fsExtra.readFile(gltfPath))
         .then(function(data) {
             var gltf;
             if (fileExtension === '.glb') {

--- a/lib/writeBinaryGltf.js
+++ b/lib/writeBinaryGltf.js
@@ -10,8 +10,6 @@ var DeveloperError = Cesium.DeveloperError;
 var getBinaryGltf = require('./getBinaryGltf');
 var writeSource = require('./writeSource');
 
-fsExtra.outputFileAsync = Promise.promisify(fsExtra.outputFile);
-
 module.exports = writeBinaryGltf;
 
 /**
@@ -71,6 +69,6 @@ function writeBinaryGltf(gltf, options) {
         .then(function() {
             var glbData = getBinaryGltf(gltf, embed, embedImage);
             var glb = glbData.glb;
-            return fsExtra.outputFileAsync(outputPath, glb);
+            return fsExtra.outputFile(outputPath, glb);
         });
 }

--- a/lib/writeGltf.js
+++ b/lib/writeGltf.js
@@ -10,8 +10,6 @@ var DeveloperError = Cesium.DeveloperError;
 var removePipelineExtras = require('./removePipelineExtras');
 var writeSource = require('./writeSource');
 
-fsExtra.outputJsonAsync = Promise.promisify(fsExtra.outputJson);
-
 module.exports = writeGltf;
 
 /**
@@ -72,6 +70,6 @@ function writeGltf(gltf, options) {
     return Promise.all(writeSources)
         .then(function() {
             removePipelineExtras(gltf);
-            return fsExtra.outputJsonAsync(outputPath, gltf);
+            return fsExtra.outputJson(outputPath, gltf);
         });
 }

--- a/lib/writeSource.js
+++ b/lib/writeSource.js
@@ -8,8 +8,6 @@ var Promise = require('bluebird');
 var defaultValue = Cesium.defaultValue;
 var defined = Cesium.defined;
 
-var fsOutputFile = Promise.promisify(fsExtra.outputFile);
-
 module.exports = writeSource;
 
 /**
@@ -38,7 +36,7 @@ function writeSource(objects, name, basePath, embed, embedImage) {
                     var fileName = defaultValue(pipelineExtras.name, id) + extension;
                     object.uri = fileName;
                     var outputPath = path.join(basePath, fileName);
-                    promises.push(fsOutputFile(outputPath, source));
+                    promises.push(fsExtra.outputFile(outputPath, source));
                 }
             }
         }

--- a/package.json
+++ b/package.json
@@ -33,13 +33,13 @@
     "clone": "^2.1.0",
     "data-uri-to-buffer": "^0.0.4",
     "deep-equal": "^1.0.1",
-    "fs-extra": "^1.0.0",
+    "fs-extra": "^3.0.1",
     "image-size": "^0.5.0",
     "jimp": "^0.2.27",
     "jsonpath": "^0.2.9",
     "mime": "^1.3.4",
     "uuid": "^3.0.1",
-    "yargs": "^6.5.0"
+    "yargs": "^8.0.1"
   },
   "devDependencies": {
     "coveralls": "^2.11.15",
@@ -47,7 +47,7 @@
     "gulp-jshint": "^2.0.4",
     "istanbul": "^0.4.5",
     "jasmine": "^2.5.2",
-    "jasmine-spec-reporter": "^2.7.0",
+    "jasmine-spec-reporter": "^4.1.0",
     "jsdoc": "^3.4.3",
     "jshint": "^2.9.4",
     "jshint-stylish": "^2.2.1",

--- a/specs/lib/NodeHelpersSpec.js
+++ b/specs/lib/NodeHelpersSpec.js
@@ -1,13 +1,10 @@
 'use strict';
 var Cesium = require('cesium');
-var Promise = require('bluebird');
 var clone = require('clone');
-var fs = require('fs');
+var fsExtra = require('fs-extra');
 
 var Matrix4 = Cesium.Matrix4;
 var CesiumMath = Cesium.Math;
-
-var fsReadFile = Promise.promisify(fs.readFile);
 
 var NodeHelpers = require('../../lib/NodeHelpers');
 var fiveBoxPath = './specs/data/combineObjects/fiveBox.gltf';
@@ -177,7 +174,7 @@ describe('NodeHelpers', function() {
     });
 
     it('performs operations per primitive in a scene', function(done) {
-        fsReadFile(fiveBoxPath)
+        fsExtra.readFile(fiveBoxPath)
             .then(function(data) {
                 var gltf = JSON.parse(data);
                 var scene = gltf.scenes[gltf.scene];
@@ -204,9 +201,7 @@ describe('NodeHelpers', function() {
 
                 done();
             })
-            .catch(function(err) {
-                throw err;
-            });
+            .catch(done.fail);
     });
 
     it('maps meshes to nodes', function() {

--- a/specs/lib/PipelineSpec.js
+++ b/specs/lib/PipelineSpec.js
@@ -14,8 +14,6 @@ var processJSON = Pipeline.processJSON;
 var processJSONToDisk = Pipeline.processJSONToDisk;
 var processJSONWithExtras = Pipeline.processJSONWithExtras;
 
-var fsExtraReadFile = Promise.promisify(fsExtra.readFile);
-
 var gltfPath = './specs/data/boxTexturedUnoptimized/CesiumTexturedBoxTest.gltf';
 var gltfEmbeddedPath = './specs/data/boxTexturedUnoptimized/CesiumTexturedBoxTestEmbedded.gltf';
 var glbPath = './specs/data/boxTexturedUnoptimized/CesiumTexturedBoxTest.glb';
@@ -25,7 +23,7 @@ var outputGlbPath = './output/CesiumTexturedBoxTest.glb';
 describe('Pipeline', function() {
     it('optimizes a gltf JSON with embedded resources', function(done) {
         var gltfCopy;
-        expect(fsExtraReadFile(gltfEmbeddedPath)
+        expect(fsExtra.readFile(gltfEmbeddedPath)
             .then(function(data) {
                 var gltf = JSON.parse(data);
                 gltfCopy = clone(gltfCopy);
@@ -43,7 +41,7 @@ describe('Pipeline', function() {
             basePath : path.dirname(gltfPath)
         };
         var gltfCopy;
-        expect(fsExtraReadFile(gltfPath, options)
+        expect(fsExtra.readFile(gltfPath, options)
             .then(function(data) {
                 var gltf = JSON.parse(data);
                 gltfCopy = clone(gltfCopy);
@@ -85,7 +83,7 @@ describe('Pipeline', function() {
     });
 
     it('will write a file to the correct directory', function(done) {
-        var spy = spyOn(fsExtra, 'outputJsonAsync').and.callFake(function() {});
+        var spy = spyOn(fsExtra, 'outputJson').and.callFake(function() {});
         var options = {
             createDirectory : false
         };
@@ -99,7 +97,7 @@ describe('Pipeline', function() {
     });
 
     it('will write a binary file', function(done) {
-        var spy = spyOn(fsExtra, 'outputFileAsync').and.callFake(function() {});
+        var spy = spyOn(fsExtra, 'outputFile').and.callFake(function() {});
         var options = {
             binary : true,
             createDirectory : false
@@ -115,7 +113,7 @@ describe('Pipeline', function() {
     });
 
     it('will write a file from JSON', function(done) {
-        var spy = spyOn(fsExtra, 'outputJsonAsync').and.callFake(function() {});
+        var spy = spyOn(fsExtra, 'outputJson').and.callFake(function() {});
         var processOptions = {
             createDirectory : false,
             basePath : path.dirname(gltfPath)

--- a/specs/lib/RemoveUnusedPropertiesSpec.js
+++ b/specs/lib/RemoveUnusedPropertiesSpec.js
@@ -1,11 +1,8 @@
 'use strict';
 
-var Promise = require('bluebird');
-var fs = require('fs-extra');
+var fsExtra = require('fs-extra');
 
 var RemoveUnusedProperties = require('../../lib/RemoveUnusedProperties');
-
-var fsReadFile = Promise.promisify(fs.readFile);
 
 var gltfPath = './specs/data/boxTexturedUnoptimized/CesiumTexturedBoxTestUnusedTree.gltf';
 
@@ -1223,7 +1220,7 @@ describe('RemoveUnusedProperties', function() {
     var removeAll = RemoveUnusedProperties.removeAll;
     describe('removeAll', function() {
         it('removes a tree of objects', function (done) {
-            expect(fsReadFile(gltfPath)
+            expect(fsExtra.readFile(gltfPath)
                 .then(function (data) {
                     var gltf = JSON.parse(data);
                     removeAll(gltf);
@@ -1267,7 +1264,7 @@ describe('RemoveUnusedProperties', function() {
         });
 
         it('does not remove any objects', function (done) {
-            expect(fsReadFile(gltfPath)
+            expect(fsExtra.readFile(gltfPath)
                 .then(function (data) {
                     var gltf = JSON.parse(data);
                     gltf.scenes.defaultScene.nodes[0] = 'node_3';

--- a/specs/lib/addDefaultsSpec.js
+++ b/specs/lib/addDefaultsSpec.js
@@ -1,7 +1,7 @@
 'use strict';
 var Cesium = require('cesium');
 var clone = require('clone');
-var fs = require('fs');
+var fsExtra = require('fs-extra');
 var Promise = require('bluebird');
 
 var WebGLConstants = Cesium.WebGLConstants;
@@ -11,8 +11,6 @@ var addPipelineExtras = require('../../lib/addPipelineExtras');
 var loadGltfUris = require('../../lib/loadGltfUris');
 var readGltf = require('../../lib/readGltf');
 var removePipelineExtras = require('../../lib/removePipelineExtras');
-
-var fsReadFile = Promise.promisify(fs.readFile);
 
 var transparentImageUri = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAYAAADED76LAAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAA7DAAAOwwHHb6hkAAAAB3RJTUUH4AcGERIfpcOGjwAAAQZJREFUGNMFwcErQ3EAwPHv7+3JEw2FFe+lZ9vpTTnYiR2MsyKuE8VB/ojdlZuDg4sVyUU7TVK7KG05jFgWPdt6oqWI5/E87/l8RNO8zyoylF4EtTeB6wWMhH2mNMG3B3KHDMemxOFdQEj4qN3tPDoS9Q+HxaiPdNkS5G5+SUV1xoYG6VNcRvvh9ClMS+hIZ6aLocZY0M+Zj1X59CMcXXmsJUO4dh7Z0HTiEZvN3DQDvcNk5mrYyU5q5SUK1QuktGpxkE/x8OpSaVqUSxt81bfYKewxkVhF9h1BjxJHyBW84I/dk23ebVieWWF2fB1hNZ6zSlsXxdt9rhtFgsDH0CZJJzK43g//gYBjzrZ4jf0AAAAASUVORK5CYII=';
 var gltfTransparentPath = './specs/data/boxTexturedUnoptimized/CesiumTexturedBoxTestTransparent.gltf';
@@ -214,7 +212,7 @@ describe('addDefaults', function() {
     });
 
     it('modifies the material\'s technique to support alpha blending if the diffuse texture is transparent', function(done) {
-        expect(fsReadFile(gltfTransparentPath)
+        expect(fsExtra.readFile(gltfTransparentPath)
             .then(function(data) {
                 var gltf = JSON.parse(data);
                 var originalState = gltf.techniques[Object.keys(gltf.techniques)[0]].states;
@@ -229,7 +227,7 @@ describe('addDefaults', function() {
     });
 
     it('modifies the material\'s technique to support alpha blending if the diffuse color is transparent', function(done) {
-        expect(fsReadFile(gltfTransparentPath)
+        expect(fsExtra.readFile(gltfTransparentPath)
             .then(function(data) {
                 var gltf = JSON.parse(data);
                 var originalState = gltf.techniques[Object.keys(gltf.techniques)[0]].states;

--- a/specs/lib/compressTexturesSpec.js
+++ b/specs/lib/compressTexturesSpec.js
@@ -12,8 +12,6 @@ var directoryExists = require('../../lib/directoryExists');
 var Pipeline = require('../../lib/Pipeline');
 var readGltf = require('../../lib/readGltf');
 
-var fsExtraReadJson = Promise.promisify(fsExtra.readJson);
-
 var defined = Cesium.defined;
 var DeveloperError = Cesium.DeveloperError;
 var WebGLConstants = Cesium.WebGLConstants;
@@ -32,7 +30,7 @@ var decalPath = 'Cesium_Logo_Flat_Decal.png'; // Contains alpha channel
 var defaultImageUri = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+ip1sAAAAASUVORK5CYII='; // 1x1 white png
 
 function compressGltfTexture(gltfPath, imagePath, options) {
-    return fsExtraReadJson(gltfPath)
+    return fsExtra.readJson(gltfPath)
         .then(function(gltf) {
             var image = gltf.images.Image0001;
             if (defined(imagePath)) {
@@ -435,10 +433,10 @@ describe('compressTextures', function() {
     });
 
     it('tempDirectory is removed when compression succeeds', function(done) {
-        spyOn(fsExtra, 'writeFileAsync').and.callThrough();
+        spyOn(fsExtra, 'writeFile').and.callThrough();
         expect(verifyKTX(gltfPath, undefined, etc1Compression, etc1Format)
             .then(function() {
-                var tempDirectory = path.dirname(fsExtra.writeFileAsync.calls.argsFor(0)[0]);
+                var tempDirectory = path.dirname(fsExtra.writeFile.calls.argsFor(0)[0]);
                 return directoryExists(tempDirectory)
                     .then(function(exists) {
                         expect(exists).toBe(false);
@@ -448,7 +446,7 @@ describe('compressTextures', function() {
 
     it('tempDirectory is removed when compression fails', function(done) {
         var childProcessSpawn = child_process.spawn;
-        spyOn(fsExtra, 'writeFileAsync').and.callThrough();
+        spyOn(fsExtra, 'writeFile').and.callThrough();
         spyOn(child_process, 'spawn').and.callFake(function(command, args) {
             // Trigger a failure by sending in an invalid argument to the compress tool
             args.push('invalid_arg');
@@ -456,7 +454,7 @@ describe('compressTextures', function() {
         });
         expect(verifyKTX(gltfPath, undefined, etc1Compression, etc1Format)
             .then(function() {
-                var tempDirectory = path.dirname(fsExtra.writeFileAsync.calls.argsFor(0)[0]);
+                var tempDirectory = path.dirname(fsExtra.writeFile.calls.argsFor(0)[0]);
                 return directoryExists(tempDirectory)
                     .then(function(exists) {
                         expect(exists).toBe(false);
@@ -468,7 +466,7 @@ describe('compressTextures', function() {
         var options = {
             format : 'etc1'
         };
-        expect(fsExtraReadJson(gltfPath)
+        expect(fsExtra.readJson(gltfPath)
             .then(function(gltf) {
                 var sampler = gltf.samplers.sampler_0;
                 expect(sampler.minFilter).toBe(WebGLConstants.LINEAR_MIPMAP_LINEAR);

--- a/specs/lib/getBinaryGltfSpec.js
+++ b/specs/lib/getBinaryGltfSpec.js
@@ -1,13 +1,11 @@
 'use strict';
 var bufferEqual = require('buffer-equal');
 var clone = require('clone');
-var fs = require('fs');
+var fsExtra = require('fs-extra');
 var Promise = require('bluebird');
 
 var getBinaryGltf = require('../../lib/getBinaryGltf');
 var readGltf = require('../../lib/readGltf');
-
-var fsReadFile = Promise.promisify(fs.readFile);
 
 var gltfPath = './specs/data/boxTexturedUnoptimized/CesiumTexturedBoxTest_BinaryInput.gltf';
 var scenePath = './specs/data/boxTexturedUnoptimized/CesiumTexturedBoxTest_BinaryCheck.gltf';
@@ -30,16 +28,16 @@ describe('getBinaryGltf', function() {
         expect(readGltf(gltfPath)
             .then(function(gltf) {
                 testData.gltf = gltf;
-                return fsReadFile(scenePath);
+                return fsExtra.readFile(scenePath);
             })
             .then(function(data) {
                 testData.scene = JSON.parse(data);
 
                 var readFiles = [
-                    fsReadFile(testData.image),
-                    fsReadFile(testData.buffer),
-                    fsReadFile(testData.fragmentShader),
-                    fsReadFile(testData.vertexShader)
+                    fsExtra.readFile(testData.image),
+                    fsExtra.readFile(testData.buffer),
+                    fsExtra.readFile(testData.fragmentShader),
+                    fsExtra.readFile(testData.vertexShader)
                 ];
                 return Promise.all(readFiles);
             })

--- a/specs/lib/loadBufferUrisSpec.js
+++ b/specs/lib/loadBufferUrisSpec.js
@@ -1,9 +1,6 @@
 'use strict';
-var Promise = require('bluebird');
-var fs = require('fs');
+var fsExtra = require('fs-extra');
 var bufferEqual = require('buffer-equal');
-
-var fsReadFile = Promise.promisify(fs.readFile);
 
 var addPipelineExtras = require('../../lib/addPipelineExtras');
 var loadGltfUris = require('../../lib/loadGltfUris');
@@ -19,14 +16,12 @@ describe('loadBufferUris', function() {
     };
 
     beforeAll(function(done) {
-        fsReadFile(bufferPath)
+        fsExtra.readFile(bufferPath)
             .then(function(data) {
                 bufferData = data;
                 done();
             })
-            .catch(function(err) {
-                throw err;
-            });
+            .catch(done.fail);
     });
 
     it('loads an external buffer', function(done) {

--- a/specs/lib/loadImageUrisSpec.js
+++ b/specs/lib/loadImageUrisSpec.js
@@ -1,9 +1,6 @@
 'use strict';
-var Promise = require('bluebird');
-var fs = require('fs');
+var fsExtra = require('fs-extra');
 var bufferEqual = require('buffer-equal');
-
-var fsReadFile = Promise.promisify(fs.readFile);
 
 var addPipelineExtras = require('../../lib/addPipelineExtras');
 var loadGltfUris = require('../../lib/loadGltfUris');
@@ -20,7 +17,7 @@ describe('loadImageUris', function() {
     };
 
     beforeAll(function(done) {
-        fsReadFile(imagePath)
+        fsExtra.readFile(imagePath)
             .then(function(data) {
                 imageData = data;
                 done();

--- a/specs/lib/loadShaderUrisSpec.js
+++ b/specs/lib/loadShaderUrisSpec.js
@@ -1,9 +1,5 @@
 'use strict';
-var Promise = require('bluebird');
-var fs = require('fs');
-var bufferEqual = require('buffer-equal');
-
-var fsReadFile = Promise.promisify(fs.readFile);
+var fsExtra = require('fs-extra');
 
 var addPipelineExtras = require('../../lib/addPipelineExtras');
 var loadGltfUris = require('../../lib/loadGltfUris');
@@ -19,15 +15,13 @@ describe('loadShaderUris', function() {
     };
 
     beforeAll(function(done) {
-        fsReadFile(fragmentShaderPath)
+        fsExtra.readFile(fragmentShaderPath)
             .then(function(data){
                 fragmentShaderData = data.toString();
                 fragmentShaderUri = 'data:text/plain;base64,' + new Buffer(fragmentShaderData).toString('base64');
                 done();
             })
-            .catch(function(err) {
-                throw err;
-            });
+            .catch(done.fail);
     });
 
     it('loads an external shader', function(done) {

--- a/specs/lib/writeBinaryGltfSpec.js
+++ b/specs/lib/writeBinaryGltfSpec.js
@@ -14,7 +14,7 @@ var invalidPath = './specs/data/boxTexturedUnoptimized/CesiumTexturedBoxTest.exe
 
 describe('writeBinaryGltf', function() {
     it('will write a file to the correct directory', function(done) {
-        var spy = spyOn(fsExtra, 'outputFileAsync').and.callFake(function() {});
+        var spy = spyOn(fsExtra, 'outputFile').and.callFake(function() {});
         var writeOptions = {
             outputPath : outputGltfPath,
             embed : true,

--- a/specs/lib/writeBuffersSpec.js
+++ b/specs/lib/writeBuffersSpec.js
@@ -1,12 +1,9 @@
 'use strict';
 var bufferEqual = require('buffer-equal');
 var clone = require('clone');
-var fs = require('fs');
-var Promise = require('bluebird');
+var fsExtra = require('fs-extra');
 
 var writeGltf = require('../../lib/writeGltf');
-
-var fsReadFile = Promise.promisify(fs.readFile);
 
 var bufferPath = './specs/data/boxTexturedUnoptimized/CesiumTexturedBoxTest.bin';
 var bufferUri = 'data:application/octet-stream;base64,AAABAAIAAwACAAEABAAFAAYABwAGAAUACAAJAAoACwAKAAkADAANAA4ADwAOAA0AEAARABIAEwASABEAFAAVABYAFwAWABUAAAAAvwAAAL8AAAA/AAAAPwAAAL8AAAA/AAAAvwAAAD8AAAA/AAAAPwAAAD8AAAA/AAAAPwAAAD8AAAA/AAAAPwAAAL8AAAA/AAAAPwAAAD8AAAC/AAAAPwAAAL8AAAC/AAAAvwAAAD8AAAA/AAAAPwAAAD8AAAA/AAAAvwAAAD8AAAC/AAAAPwAAAD8AAAC/AAAAPwAAAL8AAAA/AAAAvwAAAL8AAAA/AAAAPwAAAL8AAAC/AAAAvwAAAL8AAAC/AAAAvwAAAL8AAAA/AAAAvwAAAD8AAAA/AAAAvwAAAL8AAAC/AAAAvwAAAD8AAAC/AAAAvwAAAL8AAAC/AAAAvwAAAD8AAAC/AAAAPwAAAL8AAAC/AAAAPwAAAD8AAAC/AAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AACAPwAAAAAAAAAAAACAPwAAAAAAAAAAAACAPwAAAAAAAAAAAACAPwAAAAAAAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAAAAAAAAgL8AAAAAAAAAAAAAgL8AAAAAAAAAAAAAgL8AAAAAAAAAAAAAgL8AAAAAAACAvwAAAAAAAAAAAACAvwAAAAAAAAAAAACAvwAAAAAAAAAAAACAvwAAAAAAAAAAAAAAAAAAAAAAAIC/AAAAAAAAAAAAAIC/AAAAAAAAAAAAAIC/AAAAAAAAAAAAAIC/AADAQAAAAAAAAKBAAAAAAAAAwED+/38/AACgQP7/fz8AAIBAAAAAAAAAoEAAAAAAAACAQAAAgD8AAKBAAACAPwAAAEAAAAAAAACAPwAAAAAAAABAAACAPwAAgD8AAIA/AABAQAAAAAAAAIBAAAAAAAAAQEAAAIA/AACAQAAAgD8AAEBAAAAAAAAAAEAAAAAAAABAQAAAgD8AAABAAACAPwAAAAAAAAAAAAAAAP7/fz8AAIA/AAAAAAAAgD/+/38/';
@@ -18,7 +15,7 @@ describe('writeBuffers', function() {
     var testGltf;
 
     beforeAll(function(done) {
-        expect(fsReadFile(bufferPath)
+        expect(fsExtra.readFile(bufferPath)
             .then(function(data) {
                 bufferData = data;
                 testGltf = {
@@ -50,7 +47,7 @@ describe('writeBuffers', function() {
             .then(function() {
                 expect(gltf.buffers.CesiumTexturedBoxTest.extras).not.toBeDefined();
                 expect(gltf.buffers.CesiumTexturedBoxTest.uri).toEqual('CesiumTexturedBoxTest.bin');
-                return fsReadFile(outputBufferPath);
+                return fsExtra.readFile(outputBufferPath);
             })
             .then(function(outputData) {
                 expect(bufferEqual(outputData, bufferData)).toBe(true);

--- a/specs/lib/writeGltfSpec.js
+++ b/specs/lib/writeGltfSpec.js
@@ -11,7 +11,7 @@ var invalidPath = './specs/data/boxTexturedUnoptimized/CesiumTexturedBoxTest.exe
 
 describe('writeGltf', function() {
     it('will write a file to the correct directory', function(done) {
-        var spy = spyOn(fsExtra, 'outputJsonAsync').and.callFake(function() {});
+        var spy = spyOn(fsExtra, 'outputJson').and.callFake(function() {});
         var writeOptions = {
             outputPath : outputGltfPath,
             embed : true,

--- a/specs/lib/writeImagesSpec.js
+++ b/specs/lib/writeImagesSpec.js
@@ -1,12 +1,9 @@
 'use strict';
 var bufferEqual = require('buffer-equal');
 var clone = require('clone');
-var fs = require('fs');
-var Promise = require('bluebird');
+var fsExtra = require('fs-extra');
 
 var writeGltf = require('../../lib/writeGltf');
-
-var fsReadFile = Promise.promisify(fs.readFile);
 
 var imagePath = './specs/data/boxTexturedUnoptimized/Cesium_Logo_Flat_Low.png';
 var imageUri = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAIAAABLbSncAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAADTSURBVBhXAcgAN/8B49/cCAQAyukB2vAB+vz/Ig7+QR0B+PwAAezj3LDfAqnZ/wMB/xwPBwUEAiMK91Uj/gLN6wGj1fs9IyEwGxoUCPotFQC75g7rASECvd/6KxwkVCHFUiTX9P4Xq9L8ZjUD+vWyAaHK+CUX+pujFBYRH1NR2vUAANrLX8zXyAJCHOWnsj3d7frR4+XLymz24Y6ZuKI7LGUE/vcBEAglAQTR/P/9nbmV8fUAYURiTjRqAeXi6AgFDMDWptPiwP///isdPEIsXvr8+Tj0Y5s8qCp8AAAAAElFTkSuQmCC';
@@ -18,7 +15,7 @@ describe('writeImages', function() {
     var testGltf;
 
     beforeAll(function(done) {
-        expect(fsReadFile(imagePath)
+        expect(fsExtra.readFile(imagePath)
             .then(function(data) {
                 imageData = data;
                 testGltf = {
@@ -50,7 +47,7 @@ describe('writeImages', function() {
             .then(function() {
                 expect(gltf.images.Cesium_Logo_Flat_Low.extras).not.toBeDefined();
                 expect(gltf.images.Cesium_Logo_Flat_Low.uri).toEqual('Cesium_Logo_Flat_Low.png');
-                return fsReadFile(outputImagePath);
+                return fsExtra.readFile(outputImagePath);
             })
             .then(function (outputData) {
                 expect(bufferEqual(outputData, imageData)).toBe(true);

--- a/specs/lib/writeShadersSpec.js
+++ b/specs/lib/writeShadersSpec.js
@@ -1,12 +1,9 @@
 'use strict';
 var clone = require('clone');
-var fs = require('fs');
-var Promise = require('bluebird');
+var fsExtra = require('fs-extra');
 
 var bufferEqual = require('buffer-equal');
 var writeGltf = require('../../lib/writeGltf');
-
-var fsReadFile = Promise.promisify(fs.readFile);
 
 var fragmentShaderPath = './specs/data/boxTexturedUnoptimized/CesiumTexturedBoxTest0FS.glsl';
 var outputPath = './specs/data/boxTexturedUnoptimized/output.gltf';
@@ -18,7 +15,7 @@ describe('writeShaders', function() {
     var testGltf;
 
     beforeAll(function(done) {
-        expect(fsReadFile(fragmentShaderPath)
+        expect(fsExtra.readFile(fragmentShaderPath)
             .then(function(data) {
                 fragmentShaderData = data;
                 testGltf = {
@@ -52,7 +49,7 @@ describe('writeShaders', function() {
             .then(function() {
                 expect(gltf.shaders.CesiumTexturedBoxTest0FS.extras).not.toBeDefined();
                 expect(gltf.shaders.CesiumTexturedBoxTest0FS.uri).toEqual('CesiumTexturedBoxTest0FS.glsl');
-                return fsReadFile(outputFragmentShaderPath);
+                return fsExtra.readFile(outputFragmentShaderPath);
             })
             .then(function(outputData) {
                 expect(bufferEqual(outputData, fragmentShaderData)).toBe(true);


### PR DESCRIPTION
A few npm dependencies were major versions behind, so this updates `yargs`, `fs-extra`, and `jasmin-spec-reporter` to their latest versions.

The major change here is `fs-extra`, which now has promise implementations of all functions by default, this means there's no reason to manually `Promisify` a function any more, the result is less code overall.

There is one important edge case, `fs-extra` uses built-in native Node promises, which do not have a `finally` function. If you start a promise change with an `fs-extra` function, you need to wrap it in `Promise.resolve` in order to make use of finally at the end (assuming you are using finally at all, if not you don't need to worry about it. The upside is that your code will always error if you forget to do this.