### PR TITLE
Add regex to remove leading underscore from shader identifiers

### DIFF
--- a/lib/processModelMaterialsCommon.js
+++ b/lib/processModelMaterialsCommon.js
@@ -812,7 +812,9 @@ function ensureSemanticExistenceForPrimitive(gltf, primitive) {
                 var accessorId = attributes[semantic];
                 var accessor = accessors[accessorId];
                 var lowerCase = semantic.toLowerCase();
+                lowerCase = lowerCase.replace(/^_*/g, '');  // Remove all starting _ from name. GLSL does not allow __ double underscores
                 var attributeName = 'a_' + lowerCase;
+
                 technique.parameters[lowerCase] = {
                     semantic: semantic,
                     type: accessor.componentType


### PR DESCRIPTION
This fixes attributes names that have leading underscores, ex. `_batchid`, which then cause attribute names to be `a__batchid`.
The double underscore is reserved in GLSL and is not allowed for identifiers.