### PR TITLE
Fix errors from ESLint shared config 2.0

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,7 @@
 {
-  "extends": "cesium/node"
+  "extends": "cesium/node",
+  "rules": {
+    "no-buffer-constructor": "off",
+    "quotes": "off"
+  }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,6 @@
 {
   "extends": "cesium/node",
   "rules": {
-    "no-buffer-constructor": "off",
     "quotes": "off"
   }
 }

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+/*eslint-disable global-require*/
 'use strict';
 module.exports = {
     AccessorReader : require('./lib/AccessorReader'),

--- a/lib/Pipeline.js
+++ b/lib/Pipeline.js
@@ -173,9 +173,8 @@ Pipeline.processJSONWithExtras  = function(gltfWithExtras, options) {
             var textureCompressionOptions = options.textureCompressionOptions;
             if (defined(textureCompressionOptions)) {
                 return compressTextures(gltfWithExtras, textureCompressionOptions);
-            } else {
-                return encodeImages(gltfWithExtras);
             }
+            return encodeImages(gltfWithExtras);
         })
         .then(function() {
             var kmcOptions = options.kmcOptions;

--- a/lib/PrimitiveHelpers.js
+++ b/lib/PrimitiveHelpers.js
@@ -174,12 +174,10 @@ function transformPrimitives(gltf, primitives, transform) {
                 } else {
                     keepReading = false;
                 }
+            } else if (!positionAccessorReader.pastEnd() && !normalAccessorReader.pastEnd()) {
+                index++;
             } else {
-                if (!positionAccessorReader.pastEnd() && !normalAccessorReader.pastEnd()) {
-                    index++;
-                } else {
-                    keepReading = false;
-                }
+                keepReading = false;
             }
         }
     }

--- a/lib/StaticUniformGrid.js
+++ b/lib/StaticUniformGrid.js
@@ -83,7 +83,8 @@ function StaticUniformGrid(items, cellWidth, compareItemBoundingBox, cellCheck) 
 
     // Find the min/max bounds and resolution of the uniform grid
     var itemsCount = items.length;
-    for (var i = 0; i < itemsCount; ++i) {
+    var i;
+    for (i = 0; i < itemsCount; ++i) {
         compareItemBoundingBox(items[i], min, max);
     }
 

--- a/lib/bakeAmbientOcclusion.js
+++ b/lib/bakeAmbientOcclusion.js
@@ -329,7 +329,7 @@ function addVertexData(gltf, options) {
         type: 'arraybuffer',
         extras: {
             _pipeline: {
-                source: new Buffer(new Float32Array(allAOData).buffer),
+                source: Buffer.from(new Float32Array(allAOData).buffer),
                 extension: '.bin'
             }
         }

--- a/lib/changeAccessorComponentType.js
+++ b/lib/changeAccessorComponentType.js
@@ -42,7 +42,7 @@ function changeAccessorComponentType(gltf, accessor, newComponentType) {
         var numberOfComponents = numberOfComponentsForType(accessor.type);
         var writeBuffer;
         if (newComponentByteLength > componentByteLength) {
-            writeBuffer = new Buffer(accessor.count * numberOfComponents * newComponentByteLength);
+            writeBuffer = Buffer.allocUnsafe(accessor.count * numberOfComponents * newComponentByteLength);
         }
         var accessorReader = new AccessorReader(gltf, accessor);
         var components = [];

--- a/lib/compressTexture.js
+++ b/lib/compressTexture.js
@@ -181,10 +181,9 @@ function compressTexture(gltf, imageId, options) {
             } else if (defined(absolutePath)) {
                 // The external image can be sent directly to the compression tool
                 return compressFile(absolutePath, tempDirectory, compressFunction, compressOptions);
-            } else {
-                // The embedded image can be saved as-is and then sent to the compression tool
-                return compressBuffer(source, extension, tempDirectory, compressFunction, compressOptions);
             }
+            // The embedded image can be saved as-is and then sent to the compression tool
+            return compressBuffer(source, extension, tempDirectory, compressFunction, compressOptions);
         })
         .finally(function() {
             return fsExtra.remove(tempDirectory);
@@ -391,9 +390,8 @@ function numberToString(number) {
     if (number % 1 === 0) {
         // Add a .0 to whole numbers
         return number.toFixed(1);
-    } else {
-        return number.toString();
     }
+    return number.toString();
 }
 
 function compressWithAstcenc(inputPath, tempDirectory, options) {

--- a/lib/compressTexture.js
+++ b/lib/compressTexture.js
@@ -459,7 +459,7 @@ function astcToKtx(astcBuffer) {
     var imageData = astcBuffer.slice(16);
     var imageSize = imageData.length;
 
-    var ktxHeader = new Buffer(68);
+    var ktxHeader = Buffer.allocUnsafe(68);
 
     var indentifier = [0xAB, 0x4B, 0x54, 0x58, 0x20, 0x31, 0x31, 0xBB, 0x0D, 0x0A, 0x1A, 0x0A];
     for (var i = 0; i < 12; ++i) {

--- a/lib/createAccessor.js
+++ b/lib/createAccessor.js
@@ -43,7 +43,7 @@ function createAccessor(gltf, dataOrLength, type, componentType, target, id) {
     }
     var bufferViewId = getUniqueId(gltf, 'bufferView');
     var bufferId = getUniqueId(gltf, 'buffer');
-    var bufferData = new Buffer(dataLength * componentByteLength);
+    var bufferData = Buffer.allocUnsafe(dataLength * componentByteLength);
     if (defined(data)) {
         for (var i = 0; i < data.length; i++) {
             writeBufferComponent(bufferData, componentType, data[i], i * componentByteLength);

--- a/lib/parseBinaryGltf.js
+++ b/lib/parseBinaryGltf.js
@@ -239,7 +239,5 @@ function getBinaryImageFormat(header) {
     else if (bufferEqual(header, new Uint8Array([72, 120]))) { //.crn 48 78
         return '.crn';
     }
-    else {
-        throw new DeveloperError('Binary image does not have valid header');
-    }
+    throw new DeveloperError('Binary image does not have valid header');
 }

--- a/lib/processModelMaterialsCommon.js
+++ b/lib/processModelMaterialsCommon.js
@@ -540,12 +540,10 @@ function generateTechnique(gltf, khrMaterialsCommon, lightParameters, optimizeFo
         } else {
             finalColorComputation = '  gl_FragColor = vec4(color * diffuse.a, diffuse.a);\n';
         }
+    } else if (defined(techniqueParameters.transparency)) {
+        finalColorComputation = '  gl_FragColor = vec4(color * u_transparency, u_transparency);\n';
     } else {
-        if (defined(techniqueParameters.transparency)) {
-            finalColorComputation = '  gl_FragColor = vec4(color * u_transparency, u_transparency);\n';
-        } else {
-            finalColorComputation = '  gl_FragColor = vec4(color, 1.0);\n';
-        }
+        finalColorComputation = '  gl_FragColor = vec4(color, 1.0);\n';
     }
 
     if (defined(techniqueParameters.emission)) {

--- a/lib/uninterleaveAndPackBuffers.js
+++ b/lib/uninterleaveAndPackBuffers.js
@@ -70,7 +70,7 @@ function packGltfBuffer(gltf, bufferId, packBufferViews) {
             }
         }
     }
-    packBuffer = new Buffer(new Uint8Array(packBuffer.buffer, 0, offset));
+    packBuffer = Buffer.from(new Uint8Array(packBuffer.buffer, 0, offset));
     buffer.extras._pipeline.source = packBuffer;
     buffer.byteLength = packBuffer.length;
 }

--- a/lib/writeSource.js
+++ b/lib/writeSource.js
@@ -25,7 +25,7 @@ function writeSource(objects, name, basePath, embed, embedImage) {
 
                 if (embed && (embedImage || name !== 'images') || !defined(basePath)) {
                     if (name === 'shaders') {
-                        object.uri = 'data:text/plain;base64,' + new Buffer(source).toString('base64');
+                        object.uri = 'data:text/plain;base64,' + Buffer.from(source).toString('base64');
                     } else {
                         // .crn (Crunch) is not a supported mime type, so add it
                         mime.define({'image/crn' : ['crn']});

--- a/specs/lib/MergeDuplicatePropertiesSpec.js
+++ b/specs/lib/MergeDuplicatePropertiesSpec.js
@@ -64,7 +64,7 @@ describe('MergeDuplicateProperties', function() {
             }
         };
         it('merges a single duplicate accessor', function () {
-            var buffer = new Buffer([1, 2, 3, 1, 2, 3]);
+            var buffer = Buffer.from([1, 2, 3, 1, 2, 3]);
             var gltf = clone(testGltf);
             var gltfBuffer = gltf.buffers.buffer;
             gltfBuffer.extras._pipeline.source = buffer;
@@ -76,7 +76,7 @@ describe('MergeDuplicateProperties', function() {
         });
 
         it ('merges multiple duplicate accessors', function () {
-            var buffer = new Buffer([1, 2, 3, 1, 2, 3, 1, 2, 3]);
+            var buffer = Buffer.from([1, 2, 3, 1, 2, 3, 1, 2, 3]);
             var gltf = clone(testGltf);
             var gltfBuffer = gltf.buffers.buffer;
             gltfBuffer.extras._pipeline.source = buffer;
@@ -106,7 +106,7 @@ describe('MergeDuplicateProperties', function() {
         });
 
         it ('leaves a non-duplicate accessor alone', function () {
-            var buffer = new Buffer([1, 2, 3, 1, 2, 3, 3, 2, 1]);
+            var buffer = Buffer.from([1, 2, 3, 1, 2, 3, 3, 2, 1]);
             var gltf = clone(testGltf);
             var gltfBuffer = gltf.buffers.buffer;
             gltfBuffer.extras._pipeline.source = buffer;
@@ -139,8 +139,8 @@ describe('MergeDuplicateProperties', function() {
 
     var mergeShaders = MergeDuplicateProperties.mergeShaders;
     describe('mergeShaders', function() {
-        var testShaderBufferOne = new Buffer('test shader one', 'utf8');
-        var testShaderBufferTwo = new Buffer('test shader two', 'utf8');
+        var testShaderBufferOne = Buffer.from('test shader one', 'utf8');
+        var testShaderBufferTwo = Buffer.from('test shader two', 'utf8');
         it('merges duplicate shaders', function() {
             var gltf = {
                 programs : {

--- a/specs/lib/bakeAmbientOcclusionSpec.js
+++ b/specs/lib/bakeAmbientOcclusionSpec.js
@@ -44,7 +44,8 @@ describe('AmbientOcclusion', function() {
     var indices = [0,1,2,0,2,3];
     var indicesBuffer = new Buffer(indices.length * 2);
     var indicesLength = indices.length;
-    for (var i = 0; i < indicesLength; i++) {
+    var i;
+    for (i = 0; i < indicesLength; i++) {
         indicesBuffer.writeUInt16LE(indices[i], i * 2);
     }
     var positions = [
@@ -309,7 +310,8 @@ describe('AmbientOcclusion', function() {
 
     it('generates all occluded (1.0) for samples inside a closed tetrahedron', function() {
         var normals = [];
-        for (var i = 0; i < 6; i++) {
+        var i;
+        for (i = 0; i < 6; i++) {
             var values = [0.0, 0.0, 0.0];
             values[i % 3] = (i % 2) ? 1.0 : -1.0;
             var newNormal = new Cartesian3(values[0], values[1], values[2]);

--- a/specs/lib/bakeAmbientOcclusionSpec.js
+++ b/specs/lib/bakeAmbientOcclusionSpec.js
@@ -42,7 +42,7 @@ describe('AmbientOcclusion', function() {
     var boxOverGroundGltf;
 
     var indices = [0,1,2,0,2,3];
-    var indicesBuffer = new Buffer(indices.length * 2);
+    var indicesBuffer = Buffer.allocUnsafe(indices.length * 2);
     var indicesLength = indices.length;
     var i;
     for (i = 0; i < indicesLength; i++) {
@@ -67,17 +67,17 @@ describe('AmbientOcclusion', function() {
         0.25,0.75
     ];
     var positionsLength = positions.length;
-    var positionsBuffer = new Buffer(positionsLength * 4);
+    var positionsBuffer = Buffer.allocUnsafe(positionsLength * 4);
     for (i = 0; i < positionsLength; i++) {
         positionsBuffer.writeFloatLE(positions[i], i * 4);
     }
     var normalsLength = normals.length;
-    var normalsBuffer = new Buffer(normalsLength * 4);
+    var normalsBuffer = Buffer.allocUnsafe(normalsLength * 4);
     for (i = 0; i < normalsLength; i++) {
         normalsBuffer.writeFloatLE(normals[i], i * 4);
     }
     var uvsLength = uvs.length;
-    var uvsBuffer = new Buffer(uvsLength * 4);
+    var uvsBuffer = Buffer.allocUnsafe(uvsLength * 4);
     for (i = 0; i < uvsLength; i++) {
         uvsBuffer.writeFloatLE(uvs[i], i * 4);
     }

--- a/specs/lib/changeAccessorComponentTypeSpec.js
+++ b/specs/lib/changeAccessorComponentTypeSpec.js
@@ -21,7 +21,7 @@ describe('changeAccessorComponentType', function() {
 
     it('overwrites the existing data if the target component type is smaller', function() {
         var data = new Uint16Array([0, 1, 2, 3, 4, 5]);
-        var dataBuffer = new Buffer(data.buffer);
+        var dataBuffer = Buffer.from(data.buffer);
         var gltf = {
             accessors : {
                 accessor : {
@@ -66,7 +66,7 @@ describe('changeAccessorComponentType', function() {
 
     it('overwrites the existing data if the target component type is the same size', function() {
         var data = new Float32Array([0, 1, 2, 3, 4, 5]);
-        var dataBuffer = new Buffer(data.buffer);
+        var dataBuffer = Buffer.from(data.buffer);
         var gltf = {
             accessors : {
                 accessor : {
@@ -111,7 +111,7 @@ describe('changeAccessorComponentType', function() {
 
     it('creates a new buffer if the target component type is larger', function() {
         var data = new Uint16Array([0, 1, 2, 3, 4, 5]);
-        var dataBuffer = new Buffer(data.buffer);
+        var dataBuffer = Buffer.from(data.buffer);
         var gltf = {
             accessors : {
                 accessor : {

--- a/specs/lib/combineNodesSpec.js
+++ b/specs/lib/combineNodesSpec.js
@@ -198,10 +198,10 @@ describe('combineNodes', function() {
         var positions = new Float32Array([1.0, 0.0, 0.0,  0.0, 1.0, 0.0,  0.0, 0.0, 1.0]);
         var normals = new Float32Array([1.0, 0.0, 0.0,  0.0, 1.0, 0.0,  0.0, 0.0, 1.0]);
         var indices = new Uint16Array([0, 1, 2, 2, 1, 0]);
-        var positionsBuffer = new Buffer(positions.buffer);
-        var normalsBuffer = new Buffer(normals.buffer);
+        var positionsBuffer = Buffer.from(positions.buffer);
+        var normalsBuffer = Buffer.from(normals.buffer);
         var attributesBuffer = Buffer.concat([positionsBuffer, normalsBuffer]);
-        var indicesBuffer = new Buffer(indices.buffer);
+        var indicesBuffer = Buffer.from(indices.buffer);
         var buffer = Buffer.concat([attributesBuffer, indicesBuffer]);
         var gltf = {
             accessors : {
@@ -318,11 +318,11 @@ describe('combineNodes', function() {
         var normals = new Float32Array([1.0, 0.0, 0.0,  0.0, 1.0, 0.0,  0.0, 0.0, 1.0]);
         var indices = new Uint16Array([0, 1]);
         var overlappedIndices = new Uint16Array([1, 2]);
-        var positionsBuffer = new Buffer(positions.buffer);
-        var normalsBuffer = new Buffer(normals.buffer);
+        var positionsBuffer = Buffer.from(positions.buffer);
+        var normalsBuffer = Buffer.from(normals.buffer);
         var attributesBuffer = Buffer.concat([positionsBuffer, normalsBuffer]);
-        var indicesBuffer = new Buffer(indices.buffer);
-        var overlappedIndicesBuffer = new Buffer(overlappedIndices.buffer);
+        var indicesBuffer = Buffer.from(indices.buffer);
+        var overlappedIndicesBuffer = Buffer.from(overlappedIndices.buffer);
         var allIndicesBuffer = Buffer.concat([indicesBuffer, overlappedIndicesBuffer]);
         var buffer = Buffer.concat([attributesBuffer, allIndicesBuffer]);
         var gltf = {

--- a/specs/lib/combinePrimitivesSpec.js
+++ b/specs/lib/combinePrimitivesSpec.js
@@ -8,12 +8,12 @@ var WebGLConstants = Cesium.WebGLConstants;
 
 describe('combinePrimitives', function() {
     var arrayOneA = new Float32Array([1, 2, 3]);
-    var bufferOneA = new Buffer(arrayOneA.buffer);
+    var bufferOneA = Buffer.from(arrayOneA.buffer);
     var arrayTwoA = new Float32Array([4, 5, 6]);
-    var bufferTwoA = new Buffer(arrayTwoA.buffer);
+    var bufferTwoA = Buffer.from(arrayTwoA.buffer);
     var arrayOneB = new Float32Array([1, 2, 3]);
     var arrayTwoB = new Float32Array([5, 6, 7, 8]);
-    var bufferTwoB = new Buffer(arrayTwoB.buffer);
+    var bufferTwoB = Buffer.from(arrayTwoB.buffer);
 
     it('combines two primitives without indices by concatenating them', function() {
         var buffer = Buffer.concat([bufferOneA, bufferTwoA]);
@@ -89,9 +89,9 @@ describe('combinePrimitives', function() {
 
     it('combines two primitives with indices by concatenating them', function() {
         var indicesOne = new Uint16Array([2, 0, 1]);
-        var bufferIndicesOne = new Buffer(indicesOne.buffer);
+        var bufferIndicesOne = Buffer.from(indicesOne.buffer);
         var indicesTwo = new Uint16Array([1, 2, 0]);
-        var bufferIndicesTwo = new Buffer(indicesTwo.buffer);
+        var bufferIndicesTwo = Buffer.from(indicesTwo.buffer);
         var buffer = Buffer.concat([bufferOneA, bufferTwoA, bufferIndicesOne, bufferIndicesTwo]);
         var gltf = {
             accessors : {
@@ -182,9 +182,9 @@ describe('combinePrimitives', function() {
 
     it('combines two primitives with shared attribute accessors by merging them', function() {
         var indicesOne = new Uint16Array([0, 2]);
-        var bufferIndicesOne = new Buffer(indicesOne.buffer);
+        var bufferIndicesOne = Buffer.from(indicesOne.buffer);
         var indicesTwo = new Uint16Array([2, 1]);
-        var bufferIndicesTwo = new Buffer(indicesTwo.buffer);
+        var bufferIndicesTwo = Buffer.from(indicesTwo.buffer);
         var buffer = Buffer.concat([bufferOneA, bufferIndicesOne, bufferIndicesTwo]);
         var gltf = {
             accessors : {
@@ -267,11 +267,11 @@ describe('combinePrimitives', function() {
 
     it('combines three primitives, merging two and then concatenating the result with the third', function() {
         var indicesOne = new Uint16Array([0, 2]);
-        var bufferIndicesOne = new Buffer(indicesOne.buffer);
+        var bufferIndicesOne = Buffer.from(indicesOne.buffer);
         var indicesTwo = new Uint16Array([2, 1]);
-        var bufferIndicesTwo = new Buffer(indicesTwo.buffer);
+        var bufferIndicesTwo = Buffer.from(indicesTwo.buffer);
         var indicesThree = new Uint16Array([0, 1, 2, 3, 2, 1]);
-        var bufferIndicesThree = new Buffer(indicesThree.buffer);
+        var bufferIndicesThree = Buffer.from(indicesThree.buffer);
         var buffer = Buffer.concat([bufferOneA, bufferTwoB, bufferIndicesOne, bufferIndicesTwo, bufferIndicesThree]);
         var gltf = {
             accessors : {
@@ -535,7 +535,7 @@ describe('combinePrimitives', function() {
         for (i = 0; i < valueCount; i++) {
             quarterOverflow[i] = i;
         }
-        var quarterOverflowBuffer = new Buffer(quarterOverflow.buffer);
+        var quarterOverflowBuffer = Buffer.from(quarterOverflow.buffer);
         var quarterOverflowAccessor = {
             bufferView : 'bufferView',
             byteOffset : 0,

--- a/specs/lib/combinePrimitivesSpec.js
+++ b/specs/lib/combinePrimitivesSpec.js
@@ -531,7 +531,8 @@ describe('combinePrimitives', function() {
         var valueCount = 16385;
         var smallerValueCount = 100;
         var quarterOverflow = new Uint16Array(valueCount);
-        for (var i = 0; i < valueCount; i++) {
+        var i;
+        for (i = 0; i < valueCount; i++) {
             quarterOverflow[i] = i;
         }
         var quarterOverflowBuffer = new Buffer(quarterOverflow.buffer);

--- a/specs/lib/compressIntegerAccessorsSpec.js
+++ b/specs/lib/compressIntegerAccessorsSpec.js
@@ -5,13 +5,13 @@ var WebGLConstants = Cesium.WebGLConstants;
 
 var compressIntegerAccessors = require('../../lib/compressIntegerAccessors');
 
-var cantCompressByte = new Buffer([-1, 0, 1]);
-var cantCompressUByte = new Buffer([0, 1, 2]);
-var cantCompressIndices = new Buffer(new Uint16Array([1, 2, 3]).buffer);
-var cantCompressBigShort = new Buffer(new Uint16Array([0, 1, 65535]).buffer);
-var floatToShort = new Buffer(new Float32Array([32767.0, -1.0, 0.0]).buffer);
-var floatToByte = new Buffer(new Float32Array([255.0, -1.0, 0.0]).buffer);
-var shortToByte = new Buffer(new Uint16Array([-2, 0, 2]).buffer);
+var cantCompressByte = Buffer.from([-1, 0, 1]);
+var cantCompressUByte = Buffer.from([0, 1, 2]);
+var cantCompressIndices = Buffer.from(new Uint16Array([1, 2, 3]).buffer);
+var cantCompressBigShort = Buffer.from(new Uint16Array([0, 1, 65535]).buffer);
+var floatToShort = Buffer.from(new Float32Array([32767.0, -1.0, 0.0]).buffer);
+var floatToByte = Buffer.from(new Float32Array([255.0, -1.0, 0.0]).buffer);
+var shortToByte = Buffer.from(new Uint16Array([-2, 0, 2]).buffer);
 var testGltf = {
     accessors : {
         cantCompressByte : {

--- a/specs/lib/compressTextureCoordinatesSpec.js
+++ b/specs/lib/compressTextureCoordinatesSpec.js
@@ -11,7 +11,7 @@ describe('compressTextureCoordinates', function() {
         var texCoords = new Float32Array([1.0, 0.0,
                                          0.0, 1.0,
                                          0.5, 0.5]);
-        var texCoordBuffer = new Buffer(texCoords.buffer.slice(0));
+        var texCoordBuffer = Buffer.from(texCoords.buffer.slice(0));
         var gltf = {
             accessors : {
                 texCoordAccessor : {
@@ -135,7 +135,7 @@ describe('compressTextureCoordinates', function() {
             0.0, 1.0,
             0.5, 0.5
         ]);
-        var texCoordBuffer = new Buffer(texCoords.buffer.slice(0));
+        var texCoordBuffer = Buffer.from(texCoords.buffer.slice(0));
         var gltf = {
             accessors : {
                 texCoordAccessor_1 : {

--- a/specs/lib/findAccessorMinMaxSpec.js
+++ b/specs/lib/findAccessorMinMaxSpec.js
@@ -38,7 +38,7 @@ describe('findAccessorMinMax', function() {
                 0.0, 0.0, 0.0,
                 0.5, -0.5, 0.5
             ]);
-        var source = new Buffer(bufferData.buffer);
+        var source = Buffer.from(bufferData.buffer);
         var gltfBuffer = gltf.buffers.buffer;
         gltfBuffer.extras._pipeline.source = source;
         gltfBuffer.byteLength = source.length;
@@ -67,7 +67,7 @@ describe('findAccessorMinMax', function() {
                 -1.0, -2.0, -3.0,
                 nan, nan, nan
             ]);
-        var source = new Buffer(bufferData.buffer);
+        var source = Buffer.from(bufferData.buffer);
         var gltfBuffer = gltf.buffers.buffer;
         gltfBuffer.extras._pipeline.source = source;
         gltfBuffer.byteLength = source.length;

--- a/specs/lib/isDataUriSpec.js
+++ b/specs/lib/isDataUriSpec.js
@@ -1,8 +1,7 @@
 'use strict';
+var isDataUri = require('../../lib/isDataUri');
 
 describe('isDataUri', function() {
-    var isDataUri = require('../../lib/isDataUri');
-
     it('is a data uri', function() {
         var dataUri = "data:text/plain;base64,cHJlY2lzaW9uIGhpZ2hwIGZsb2F0Owp2YXJ5aW5nIHZlYzMgdl9ub3JtYWw7CnZhcnlpbmcgdmVjMiB2X3RleGNvb3JkMDsKdW5pZm9ybSBzYW1wbGVyMkQgdV9kaWZmdXNlOwp1bmlmb3JtIHZlYzQgdV9zcGVjdWxhcjsKdW5pZm9ybSBmbG9hdCB1X3NoaW5pbmVzczsKdm9pZCBtYWluKHZvaWQpIHsKdmVjMyBub3JtYWwgPSBub3JtYWxpemUodl9ub3JtYWwpOwp2ZWM0IGNvbG9yID0gdmVjNCgwLiwgMC4sIDAuLCAwLik7CnZlYzQgZGlmZnVzZSA9IHZlYzQoMC4sIDAuLCAwLiwgMS4pOwp2ZWM0IHNwZWN1bGFyOwpkaWZmdXNlID0gdGV4dHVyZTJEKHVfZGlmZnVzZSwgdl90ZXhjb29yZDApOwpzcGVjdWxhciA9IHVfc3BlY3VsYXI7CmRpZmZ1c2UueHl6ICo9IG1heChkb3Qobm9ybWFsLHZlYzMoMC4sMC4sMS4pKSwgMC4pOwpjb2xvci54eXogKz0gZGlmZnVzZS54eXo7CmNvbG9yID0gdmVjNChjb2xvci5yZ2IgKiBkaWZmdXNlLmEsIGRpZmZ1c2UuYSk7CmdsX0ZyYWdDb2xvciA9IGNvbG9yOwp9Cg==";
         expect(isDataUri(dataUri)).toBe(true);

--- a/specs/lib/loadShaderUrisSpec.js
+++ b/specs/lib/loadShaderUrisSpec.js
@@ -18,7 +18,7 @@ describe('loadShaderUris', function() {
         fsExtra.readFile(fragmentShaderPath)
             .then(function(data){
                 fragmentShaderData = data.toString();
-                fragmentShaderUri = 'data:text/plain;base64,' + new Buffer(fragmentShaderData).toString('base64');
+                fragmentShaderUri = 'data:text/plain;base64,' + Buffer.from(fragmentShaderData).toString('base64');
                 done();
             })
             .catch(done.fail);

--- a/specs/lib/mergeBuffersSpec.js
+++ b/specs/lib/mergeBuffersSpec.js
@@ -4,9 +4,9 @@ var mergeBuffers = require('../../lib/mergeBuffers');
 
 describe('mergeBuffers', function() {
     it('merges buffers', function() {
-        var buffer0 = new Buffer([1, 2]);
-        var buffer1 = new Buffer([3, 4, 5]);
-        var bufferMerged = new Buffer([1, 2, 3, 4, 5]);
+        var buffer0 = Buffer.from([1, 2]);
+        var buffer1 = Buffer.from([3, 4, 5]);
+        var bufferMerged = Buffer.from([1, 2, 3, 4, 5]);
         var gltf = {
             "bufferViews": {
                 "bufferView_0": {

--- a/specs/lib/mergeDuplicateVerticesSpec.js
+++ b/specs/lib/mergeDuplicateVerticesSpec.js
@@ -4,9 +4,9 @@ var mergeDuplicateVertices = require('../../lib/mergeDuplicateVertices');
 
 describe('mergeDuplicateVertices', function() {
     it('merges duplicate vertices', function() {
-        var A = new Buffer(new Float32Array([0.0, 1.0, 2.0, 0.0, 1.0, 2.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 0.0, 1.0, 2.0]).buffer);
-        var B = new Buffer(new Uint16Array([6, 7, 8, 9, 6, 7, 6, 7, 6, 7]).buffer);
-        var C = new Buffer(new Uint16Array([0, 1, 2, 3, 4, 3, 2, 1, 0]).buffer);
+        var A = Buffer.from(new Float32Array([0.0, 1.0, 2.0, 0.0, 1.0, 2.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 0.0, 1.0, 2.0]).buffer);
+        var B = Buffer.from(new Uint16Array([6, 7, 8, 9, 6, 7, 6, 7, 6, 7]).buffer);
+        var C = Buffer.from(new Uint16Array([0, 1, 2, 3, 4, 3, 2, 1, 0]).buffer);
         var gltf = {
             accessors : {
                 accessorA : {
@@ -101,11 +101,11 @@ describe('mergeDuplicateVertices', function() {
     });
 
     it('merges duplicate vertices with repeated index accessors', function() {
-        var A = new Buffer(new Float32Array([0.0, 1.0, 2.0, 0.0, 1.0, 2.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 0.0, 1.0, 2.0]).buffer);
-        var A2 = new Buffer(new Float32Array([4.0, 5.0, 6.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 4.0, 5.0, 6.0, 4.0, 5.0, 6.0]).buffer);
-        var B = new Buffer(new Uint16Array([6, 7, 8, 9, 6, 7, 6, 7, 6, 7]).buffer);
-        var B2 = new Buffer(new Uint16Array([10, 11, 12, 13, 10, 11, 10, 11, 10, 11]).buffer);
-        var C = new Buffer(new Uint16Array([0, 1, 2, 3, 4, 3, 2, 1, 0]).buffer);
+        var A = Buffer.from(new Float32Array([0.0, 1.0, 2.0, 0.0, 1.0, 2.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 0.0, 1.0, 2.0]).buffer);
+        var A2 = Buffer.from(new Float32Array([4.0, 5.0, 6.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 4.0, 5.0, 6.0, 4.0, 5.0, 6.0]).buffer);
+        var B = Buffer.from(new Uint16Array([6, 7, 8, 9, 6, 7, 6, 7, 6, 7]).buffer);
+        var B2 = Buffer.from(new Uint16Array([10, 11, 12, 13, 10, 11, 10, 11, 10, 11]).buffer);
+        var C = Buffer.from(new Uint16Array([0, 1, 2, 3, 4, 3, 2, 1, 0]).buffer);
         var gltf = {
             accessors : {
                 accessorA : {

--- a/specs/lib/octEncodeNormalsSpec.js
+++ b/specs/lib/octEncodeNormalsSpec.js
@@ -11,7 +11,7 @@ describe('octEncodeNormals', function() {
        var normals = new Float32Array([1.0, 0.0, 0.0,
                                        0.0, 1.0, 0.0,
                                        0.0, 0.0, 1.0]);
-       var normalBuffer = new Buffer(normals.buffer.slice(0));
+       var normalBuffer = Buffer.from(normals.buffer.slice(0));
        var gltf = {
            accessors : {
                normalAccessor : {
@@ -128,7 +128,7 @@ describe('octEncodeNormals', function() {
         var normals = new Float32Array([1.0, 0.0, 0.0,
             0.0, 1.0, 0.0,
             0.0, 0.0, 1.0]);
-        var normalBuffer = new Buffer(normals.buffer.slice(0));
+        var normalBuffer = Buffer.from(normals.buffer.slice(0));
         var gltf = {
             accessors : {
                 normalAccessor_1 : {

--- a/specs/lib/parseBinaryGltfSpec.js
+++ b/specs/lib/parseBinaryGltfSpec.js
@@ -109,7 +109,7 @@ describe('parseBinaryGltf', function() {
     });
 
     it('throws an error', function() {
-        var magicError = new Buffer(testData.binary);
+        var magicError = Buffer.from(testData.binary);
         magicError.fill(0, 0, 4);
         expect(function() {
             try {
@@ -124,7 +124,7 @@ describe('parseBinaryGltf', function() {
     });
 
     it('throws a version error', function() {
-        var versionError = new Buffer(testData.binary);
+        var versionError = Buffer.from(testData.binary);
         versionError.fill(0, 4, 8);
         expect(function() {
             try {
@@ -139,7 +139,7 @@ describe('parseBinaryGltf', function() {
     });
 
     it('throws a format error', function() {
-        var formatError = new Buffer(testData.binary);
+        var formatError = Buffer.from(testData.binary);
         formatError.fill(1, 16, 20);
         expect(function() {
             try {

--- a/specs/lib/quantizeAttributesSpec.js
+++ b/specs/lib/quantizeAttributesSpec.js
@@ -6,7 +6,7 @@ var numberOfComponentsForType = require('../../lib/numberOfComponentsForType');
 var quantizeAttributes = require('../../lib/quantizeAttributes');
 
 describe('quantizeAttributes', function() {
-    var buffer = new Buffer(new Uint8Array(120));
+    var buffer = Buffer.from(new Uint8Array(120));
     var testGltf = {
         accessors : {
             // Interleaved accessors in bufferView_0
@@ -116,7 +116,7 @@ describe('quantizeAttributes', function() {
                 type : 'array_buffer',
                 extras : {
                     _pipeline : {
-                        source : new Buffer(new Float32Array([0.0026710000820457935]).buffer)
+                        source : Buffer.from(new Float32Array([0.0026710000820457935]).buffer)
                     }
                 }
             }

--- a/specs/lib/readAccessorSpec.js
+++ b/specs/lib/readAccessorSpec.js
@@ -56,8 +56,8 @@ describe('readAccessor', function() {
                 };
                 break;
         }
-
-        for (var i = 0; i < data.length; i++) {
+        var i;
+        for (i = 0; i < data.length; i++) {
             var values = attributeToArray(data[i]);
             for (var j = 0; j < min.length; j++) {
                 if (values[j] > max[j] || values[j] < min[j]) {
@@ -85,7 +85,8 @@ describe('readAccessor', function() {
         var accessorIDtoMinMax = {};
 
         var allAccessors = testBoxGltf.accessors;
-        for (var accessorID in allAccessors) {
+        var accessorID;
+        for (accessorID in allAccessors) {
             if (allAccessors.hasOwnProperty(accessorID)) {
                 var accessor = allAccessors[accessorID];
                 var accessorData = [];

--- a/specs/lib/removeUnusedVerticesSpec.js
+++ b/specs/lib/removeUnusedVerticesSpec.js
@@ -9,9 +9,9 @@ describe('removeUnusedVertices', function() {
     var indices = new Uint16Array([0, 1, 2]);
     var indicesOneUnused = new Uint16Array([0, 2]);
     var indicesTwoUnused = new Uint16Array([1]);
-    var attributeOne = new Buffer(new Float32Array([0, 1, 2, 3, 4, 5, 6, 7, 8]).buffer);
-    var attributeTwo = new Buffer(new Uint16Array([0, 1, 2, 3, 4, 5]).buffer);
-    var attributeThree = new Buffer(new Uint16Array([9, 10, 11, 12, 13, 14, 15, 16, 17]).buffer);
+    var attributeOne = Buffer.from(new Float32Array([0, 1, 2, 3, 4, 5, 6, 7, 8]).buffer);
+    var attributeTwo = Buffer.from(new Uint16Array([0, 1, 2, 3, 4, 5]).buffer);
+    var attributeThree = Buffer.from(new Uint16Array([9, 10, 11, 12, 13, 14, 15, 16, 17]).buffer);
     var attributesBuffer = Buffer.concat([attributeOne, attributeTwo, attributeThree]);
 
     var testGltf = {
@@ -96,7 +96,7 @@ describe('removeUnusedVertices', function() {
     it('does not remove any data if all attribute values are accessed', function() {
         var gltf = clone(testGltf);
         var gltfIndexBuffer = gltf.buffers.indexBuffer;
-        var indexBuffer = new Buffer(indices.buffer);
+        var indexBuffer = Buffer.from(indices.buffer);
         gltfIndexBuffer.extras._pipeline.source = indexBuffer;
         gltfIndexBuffer.byteLength = indexBuffer.length;
         gltf.bufferViews.indexBufferView.byteLength = indexBuffer.length;
@@ -111,7 +111,7 @@ describe('removeUnusedVertices', function() {
     it('removes one unused attribute', function() {
         var gltf = clone(testGltf);
         var gltfIndexBuffer = gltf.buffers.indexBuffer;
-        var indexBuffer = new Buffer(indicesOneUnused.slice(0).buffer);
+        var indexBuffer = Buffer.from(indicesOneUnused.slice(0).buffer);
         gltfIndexBuffer.extras._pipeline.source = indexBuffer;
         gltfIndexBuffer.byteLength = indexBuffer.length;
         gltf.bufferViews.indexBufferView.byteLength = indexBuffer.length;
@@ -144,7 +144,7 @@ describe('removeUnusedVertices', function() {
     it('removes two unused attributes', function() {
         var gltf = clone(testGltf);
         var gltfIndexBuffer = gltf.buffers.indexBuffer;
-        var indexBuffer = new Buffer(indicesTwoUnused.slice(0).buffer);
+        var indexBuffer = Buffer.from(indicesTwoUnused.slice(0).buffer);
         gltfIndexBuffer.extras._pipeline.source = indexBuffer;
         gltfIndexBuffer.byteLength = indexBuffer.length;
         gltf.bufferViews.indexBufferView.byteLength = indexBuffer.length;
@@ -184,14 +184,14 @@ describe('removeUnusedVertices', function() {
     it('handles when primitives use the same accessors with different indices', function() {
         var gltf = clone(testGltf);
         var gltfIndexBuffer = gltf.buffers.indexBuffer;
-        var indexBuffer = new Buffer(indicesTwoUnused.slice(0).buffer);
+        var indexBuffer = Buffer.from(indicesTwoUnused.slice(0).buffer);
         gltfIndexBuffer.extras._pipeline.source = indexBuffer;
         gltfIndexBuffer.byteLength = indexBuffer.length;
         var indexBufferView = gltf.bufferViews.indexBufferView;
         indexBufferView.byteLength = indexBuffer.length;
 
         var gltfIndexBuffer2 = clone(gltfIndexBuffer);
-        var indexBuffer2 = new Buffer(indicesOneUnused.slice(0).buffer);
+        var indexBuffer2 = Buffer.from(indicesOneUnused.slice(0).buffer);
         gltfIndexBuffer2.extras._pipeline.source = indexBuffer2;
         gltfIndexBuffer2.byteLength = indexBuffer2.length;
         gltf.buffers.indexBuffer2 = gltfIndexBuffer2;
@@ -222,14 +222,14 @@ describe('removeUnusedVertices', function() {
     it('handles when primitives use the same accessors along with different accessors with different indices', function() {
         var gltf = clone(testGltf);
         var gltfIndexBuffer = gltf.buffers.indexBuffer;
-        var indexBuffer = new Buffer(indicesTwoUnused.slice(0).buffer);
+        var indexBuffer = Buffer.from(indicesTwoUnused.slice(0).buffer);
         gltfIndexBuffer.extras._pipeline.source = indexBuffer;
         gltfIndexBuffer.byteLength = indexBuffer.length;
         var indexBufferView = gltf.bufferViews.indexBufferView;
         indexBufferView.byteLength = indexBuffer.length;
 
         var gltfIndexBuffer2 = clone(gltfIndexBuffer);
-        var indexBuffer2 = new Buffer(indicesOneUnused.slice(0).buffer);
+        var indexBuffer2 = Buffer.from(indicesOneUnused.slice(0).buffer);
         gltfIndexBuffer2.extras._pipeline.source = indexBuffer2;
         gltfIndexBuffer2.byteLength = indexBuffer2.length;
         gltf.buffers.indexBuffer2 = gltfIndexBuffer2;
@@ -261,13 +261,13 @@ describe('removeUnusedVertices', function() {
 
     it('handles when there is a cross-dependency between two groups of primitives', function() {
         var attributeData1 = new Float32Array([0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0]);
-        var attributeDataBuffer1 = new Buffer(attributeData1.buffer);
+        var attributeDataBuffer1 = Buffer.from(attributeData1.buffer);
         var attributeData2 = new Float32Array([15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0]);
-        var attributeDataBuffer2 = new Buffer(attributeData2.buffer);
+        var attributeDataBuffer2 = Buffer.from(attributeData2.buffer);
         var indexData1 = new Uint16Array([0, 1, 2, 4, 2, 1, 0, 1, 2]);
-        var indexDataBuffer1 = new Buffer(indexData1.buffer);
+        var indexDataBuffer1 = Buffer.from(indexData1.buffer);
         var indexData2 = new Uint16Array([0, 1, 3, 4, 3, 1, 0]);
-        var indexDataBuffer2 = new Buffer(indexData2.buffer);
+        var indexDataBuffer2 = Buffer.from(indexData2.buffer);
         var gltf = {
             accessors : {
                 attributeAccessor1 : {
@@ -399,7 +399,7 @@ describe('removeUnusedVertices', function() {
     it('removes parts of the buffer based on the attribute type if the stride is 0', function() {
         var i;
         var indices = [0,1,2,0,2,3];
-        var indicesBuffer = new Buffer(indices.length * 2);
+        var indicesBuffer = Buffer.allocUnsafe(indices.length * 2);
         for (i = 0; i < indices.length; i++) {
             indicesBuffer.writeUInt16LE(indices[i], i * 2);
         }
@@ -413,7 +413,7 @@ describe('removeUnusedVertices', function() {
             2,2,2,
             2,2,2
         ];
-        var positionsBuffer = new Buffer(positions.length * 4);
+        var positionsBuffer = Buffer.allocUnsafe(positions.length * 4);
         for (i = 0; i < positions.length; i++) {
             positionsBuffer.writeFloatLE(positions[i], i * 4);
         }
@@ -496,7 +496,7 @@ describe('removeUnusedVertices', function() {
     it('handles 8 bit indices', function(){
         var i;
         var indices = [0,1,2,0,2,3];
-        var indicesBuffer = new Buffer(indices.length);
+        var indicesBuffer = Buffer.allocUnsafe(indices.length);
         for (i = 0; i < indices.length; i++) {
             indicesBuffer.writeUInt8(indices[i], i);
         }
@@ -510,7 +510,7 @@ describe('removeUnusedVertices', function() {
             2,2,2,
             2,2,2
         ];
-        var positionsBuffer = new Buffer(positions.length * 4);
+        var positionsBuffer = Buffer.allocUnsafe(positions.length * 4);
         for (i = 0; i < positions.length; i++) {
             positionsBuffer.writeFloatLE(positions[i], i * 4);
         }

--- a/specs/lib/writeShadersSpec.js
+++ b/specs/lib/writeShadersSpec.js
@@ -32,7 +32,7 @@ describe('writeShaders', function() {
                         }
                     }
                 };
-                fragmentShaderUri = 'data:text/plain;base64,' + new Buffer(fragmentShaderData).toString('base64');
+                fragmentShaderUri = 'data:text/plain;base64,' + Buffer.from(fragmentShaderData).toString('base64');
             }), done).toResolve();
     });
 


### PR DESCRIPTION
For https://github.com/AnalyticalGraphicsInc/cesium/issues/5456.

Fix all the errors ESLint throws with the new 2.0 additions. Includes [global-require](http://eslint.org/docs/rules/global-require), [no-buffer-constructor](http://eslint.org/docs/rules/no-buffer-constructor), and [no-new-require](http://eslint.org/docs/rules/no-new-require) rules.

I disabled the `quotes` rule because of how much it is broken in this repo. I assume the double quotes are for JSON objects. If it's decided that we should use single quotes, it will be an easy change with `--fix`