### PR TITLE
Clean up npm dependencies

### DIFF
--- a/lib/MergeDuplicateProperties.js
+++ b/lib/MergeDuplicateProperties.js
@@ -1,7 +1,6 @@
 'use strict';
 var Cesium = require('cesium');
 var clone = require('clone');
-var bufferEqual = require('buffer-equal');
 var deepEqual = require('deep-equal');
 
 var byteLengthForComponentType = require('./byteLengthForComponentType');
@@ -224,7 +223,7 @@ function shaderEquals(shaderOne, shaderTwo) {
     if (shaderOne.type !== shaderTwo.type) {
         return false;
     }
-    return bufferEqual(shaderOne.extras._pipeline.source, shaderTwo.extras._pipeline.source);
+    return shaderOne.extras._pipeline.source.equals(shaderTwo.extras._pipeline.source);
 }
 
 /**

--- a/lib/parseBinaryGltf.js
+++ b/lib/parseBinaryGltf.js
@@ -210,33 +210,24 @@ function getUsedBufferViews(gltf) {
     return usedBufferViews;
 }
 
-function bufferEqual(first, second) {
-    for (var i = 0; i < first.length && i < second.length; i++) {
-        if (first[i] !== second[i]) {
-            return false;
-        }
-    }
-    return true;
-}
-
 //Get binary image file format from first two bytes
 function getBinaryImageFormat(header) {
-    if (bufferEqual(header, new Uint8Array([66, 77]))) { //.bmp: 42 4D
+    if (header.equals(Buffer.from([0x42, 0x4D]))) { //.bmp
         return '.bmp';
     }
-    else if (bufferEqual(header, new Uint8Array([71, 73]))) { //.gif: 47 49
+    else if (header.equals(Buffer.from(([0x47, 0x49])))) { //.gif
         return '.gif';
     }
-    else if (bufferEqual(header, new Uint8Array([255, 216]))) { //.jpg: ff d8
+    else if (header.equals(Buffer.from(([0xff, 0xd8])))) { //.jpg
         return '.jpg';
     }
-    else if (bufferEqual(header, new Uint8Array([137, 80]))) { //.png: 89 50
+    else if (header.equals(Buffer.from(([0x89, 0x50])))) { //.png
         return '.png';
     }
-    else if (bufferEqual(header, new Uint8Array([171, 75]))) { //.ktx ab 4b
+    else if (header.equals(Buffer.from(([0xab, 0x4b])))) { //.ktx
         return '.ktx';
     }
-    else if (bufferEqual(header, new Uint8Array([72, 120]))) { //.crn 48 78
+    else if (header.equals(Buffer.from(([0x48, 0x78])))) { //.crn
         return '.crn';
     }
     throw new DeveloperError('Binary image does not have valid header');

--- a/package.json
+++ b/package.json
@@ -26,15 +26,13 @@
     "node": ">=4.0.0"
   },
   "dependencies": {
-    "async": "^2.1.4",
     "bluebird": "^3.4.6",
-    "buffer-equal": "^1.0.0",
     "cesium": "^1.30.0",
     "clone": "^2.1.0",
-    "data-uri-to-buffer": "^0.0.4",
+    "data-uri-to-buffer": "^1.0.0",
     "deep-equal": "^1.0.1",
     "fs-extra": "^3.0.1",
-    "image-size": "^0.5.0",
+    "image-size": "^0.6.0",
     "jimp": "^0.2.27",
     "jsonpath": "^0.2.9",
     "mime": "^1.3.4",

--- a/specs/lib/convertDagToTreeSpec.js
+++ b/specs/lib/convertDagToTreeSpec.js
@@ -1,6 +1,6 @@
 'use strict';
 var fs = require('fs');
-var async = require('async');
+var Promise = require('bluebird');
 var convertDagToTree = require('../../lib/convertDagToTree');
 var addPipelineExtras = require('../../lib/addPipelineExtras');
 var removePipelineExtras = require('../../lib/removePipelineExtras');
@@ -19,24 +19,12 @@ describe('convertDagToTree', function() {
         twoRoots: twoRootsPath
     };
 
-    beforeAll(function(done) {
-        async.each(Object.keys(testDags), function(name, callback) {
-            fs.readFile(testDags[name], function(err, data) {
-                if (err) {
-                    callback(err);
-                }
-                else {
-                    testDags[name] = addPipelineExtras(JSON.parse(data));
-                    callback();
-                }
-            });
-        }, function(err) {
-            if (err) {
-                throw err;
-            }
-
-            done();
+    beforeAll(function (done) {
+        var names = Object.keys(testDags);
+        var promise = Promise.each(names, function (name) {
+            testDags[name] = addPipelineExtras(JSON.parse(fs.readFileSync(testDags[name])));
         });
+        expect(promise, done).toResolve();
     });
 
     it('does not duplicate any nodes', function() {

--- a/specs/lib/encodeImagesSpec.js
+++ b/specs/lib/encodeImagesSpec.js
@@ -2,7 +2,6 @@
 var Jimp = require('jimp');
 var Promise = require('bluebird');
 var clone = require('clone');
-var bufferEqual = require('buffer-equal');
 var dataUriToBuffer = require('data-uri-to-buffer');
 
 var addPipelineExtras = require('../../lib/addPipelineExtras');
@@ -43,8 +42,8 @@ describe('encodeImages', function() {
 
                 encodeImages(gltfClone)
                     .then(function() {
-                        expect(bufferEqual(pipelineExtras0001.source, imageBuffer)).toBe(true);
-                        expect(bufferEqual(pipelineExtras0002.source, imageBuffer)).toBe(true);
+                        expect(pipelineExtras0001.source.equals(imageBuffer)).toBe(true);
+                        expect(pipelineExtras0002.source.equals(imageBuffer)).toBe(true);
                         done();
                     });
             });
@@ -73,8 +72,8 @@ describe('encodeImages', function() {
                         expect(jimpImage002.bitmap.width).toEqual(8);
                         expect(jimpImage002.bitmap.height).toEqual(8);
 
-                        expect(bufferEqual(pipelineExtras0001.source, imageBuffer)).not.toBe(true);
-                        expect(bufferEqual(pipelineExtras0002.source, imageBuffer)).not.toBe(true);
+                        expect(pipelineExtras0001.source.equals(imageBuffer)).not.toBe(true);
+                        expect(pipelineExtras0002.source.equals(imageBuffer)).not.toBe(true);
 
                         // expect the buffers to still be readable by jimp (valid image buffer)
                         var promises = [];

--- a/specs/lib/getBinaryGltfSpec.js
+++ b/specs/lib/getBinaryGltfSpec.js
@@ -1,5 +1,4 @@
 'use strict';
-var bufferEqual = require('buffer-equal');
 var clone = require('clone');
 var fsExtra = require('fs-extra');
 var Promise = require('bluebird');
@@ -86,7 +85,7 @@ describe('getBinaryGltf', function() {
         var body = glbData.body;
 
         var binaryBody = Buffer.concat([testData.buffer, testData.fragmentShader, testData.vertexShader, testData.image]);
-        expect(bufferEqual(binaryBody, body)).toBe(true);
+        expect(binaryBody.equals(body)).toBe(true);
     });
 
     it('writes the correct binary body with separate images', function () {
@@ -95,7 +94,7 @@ describe('getBinaryGltf', function() {
         var body = glbData.body;
 
         var binaryBody = Buffer.concat([testData.buffer, testData.fragmentShader, testData.vertexShader]);
-        expect(bufferEqual(binaryBody, body)).toBe(true);
+        expect(binaryBody.equals(body)).toBe(true);
     });
 
     it('writes the correct binary body with separate resources except images', function () {
@@ -104,7 +103,7 @@ describe('getBinaryGltf', function() {
         var body = glbData.body;
 
         var binaryBody = Buffer.concat([testData.buffer, testData.image]);
-        expect(bufferEqual(binaryBody, body)).toBe(true);
+        expect(binaryBody.equals(body)).toBe(true);
     });
 
     it('writes the correct binary body with separate resources', function () {
@@ -113,6 +112,6 @@ describe('getBinaryGltf', function() {
         var body = glbData.body;
 
         var binaryBody = testData.buffer;
-        expect(bufferEqual(binaryBody, body)).toBe(true);
+        expect(binaryBody.equals(body)).toBe(true);
     });
 });

--- a/specs/lib/loadBufferUrisSpec.js
+++ b/specs/lib/loadBufferUrisSpec.js
@@ -1,6 +1,5 @@
 'use strict';
 var fsExtra = require('fs-extra');
-var bufferEqual = require('buffer-equal');
 
 var addPipelineExtras = require('../../lib/addPipelineExtras');
 var loadGltfUris = require('../../lib/loadGltfUris');
@@ -37,7 +36,7 @@ describe('loadBufferUris', function() {
         loadGltfUris(gltf, options)
             .then(function() {
                 expect(gltf.buffers.CesiumTexturedBoxTest.extras._pipeline.source).toBeDefined();
-                expect(bufferEqual(gltf.buffers.CesiumTexturedBoxTest.extras._pipeline.source, bufferData)).toBe(true);
+                expect(gltf.buffers.CesiumTexturedBoxTest.extras._pipeline.source.equals(bufferData)).toBe(true);
                 expect(gltf.buffers.CesiumTexturedBoxTest.extras._pipeline.extension).toEqual('.bin');
                 done();
             });
@@ -56,7 +55,7 @@ describe('loadBufferUris', function() {
         loadGltfUris(gltf, options)
             .then(function() {
                 expect(gltf.buffers.CesiumTexturedBoxTest.extras._pipeline.source).toBeDefined();
-                expect(bufferEqual(gltf.buffers.CesiumTexturedBoxTest.extras._pipeline.source, bufferData)).toBe(true);
+                expect(gltf.buffers.CesiumTexturedBoxTest.extras._pipeline.source.equals(bufferData)).toBe(true);
                 expect(gltf.buffers.CesiumTexturedBoxTest.extras._pipeline.extension).toEqual('.bin');
                 done();
             });
@@ -78,7 +77,7 @@ describe('loadBufferUris', function() {
         loadGltfUris(gltf, options)
             .then(function() {
                 expect(gltf.buffers.embeddedBox.extras._pipeline.source).toBeDefined();
-                expect(bufferEqual(gltf.buffers.embeddedBox.extras._pipeline.source, bufferData)).toBe(true);
+                expect(gltf.buffers.embeddedBox.extras._pipeline.source.equals(bufferData)).toBe(true);
                 expect(gltf.buffers.externalBox.extras._pipeline.source).toBeDefined();
                 expect(gltf.buffers.externalBox.extras._pipeline.extension).toEqual('.bin');
                 done();

--- a/specs/lib/loadImageUrisSpec.js
+++ b/specs/lib/loadImageUrisSpec.js
@@ -1,6 +1,5 @@
 'use strict';
 var fsExtra = require('fs-extra');
-var bufferEqual = require('buffer-equal');
 
 var addPipelineExtras = require('../../lib/addPipelineExtras');
 var loadGltfUris = require('../../lib/loadGltfUris');
@@ -40,7 +39,7 @@ describe('loadImageUris', function() {
         loadGltfUris(gltf, options)
             .then(function() {
                 expect(gltf.images.Image0001.extras._pipeline.source).toBeDefined();
-                expect(bufferEqual(gltf.images.Image0001.extras._pipeline.source, imageData)).toBe(true);
+                expect(gltf.images.Image0001.extras._pipeline.source.equals(imageData)).toBe(true);
                 expect(gltf.images.Image0001.extras._pipeline.extension).toEqual('.png');
                 done();
             });
@@ -59,7 +58,7 @@ describe('loadImageUris', function() {
         loadGltfUris(gltf, options)
             .then(function() {
                 expect(gltf.images.Image0001.extras._pipeline.source).toBeDefined();
-                expect(bufferEqual(gltf.images.Image0001.extras._pipeline.source, imageData)).toBe(true);
+                expect(gltf.images.Image0001.extras._pipeline.source.equals(imageData)).toBe(true);
                 expect(gltf.images.Image0001.extras._pipeline.extension).toEqual('.png');
                 done();
             });
@@ -81,10 +80,10 @@ describe('loadImageUris', function() {
         loadGltfUris(gltf, options)
             .then(function() {
                 expect(gltf.images.embeddedImage0001.extras._pipeline.source).toBeDefined();
-                expect(bufferEqual(gltf.images.embeddedImage0001.extras._pipeline.source, imageData)).toBe(true);
+                expect(gltf.images.embeddedImage0001.extras._pipeline.source.equals(imageData)).toBe(true);
                 expect(gltf.images.embeddedImage0001.extras._pipeline.extension).toEqual('.png');
                 expect(gltf.images.externalImage0001.extras._pipeline.source).toBeDefined();
-                expect(bufferEqual(gltf.images.externalImage0001.extras._pipeline.source, imageData)).toBe(true);
+                expect(gltf.images.externalImage0001.extras._pipeline.source.equals(imageData)).toBe(true);
                 expect(gltf.images.externalImage0001.extras._pipeline.extension).toEqual('.png');
                 done();
             });

--- a/specs/lib/parseBinaryGltfSpec.js
+++ b/specs/lib/parseBinaryGltfSpec.js
@@ -1,7 +1,6 @@
 'use strict';
 var fs = require('fs');
-var async = require('async');
-var bufferEqual = require('buffer-equal');
+var Promise = require('bluebird');
 var parseBinaryGltf = require('../../lib/parseBinaryGltf');
 var removePipelineExtras = require('../../lib/removePipelineExtras');
 var binaryGltfPath = './specs/data/boxTexturedUnoptimized/CesiumTexturedBoxTest.glb';
@@ -21,25 +20,12 @@ describe('parseBinaryGltf', function() {
         overlap: overlapGltfPath
     };
 
-    beforeAll(function(done) {
+    beforeAll(function (done) {
         var names = Object.keys(testData);
-        async.each(names, function(name, callback) {
-            fs.readFile(testData[name], function(err, data) {
-                if (err) {
-                    callback(err);
-                }
-                else {
-                    testData[name] = data;
-                    callback();
-                }
-            });
-        }, function(err) {
-            if (err) {
-                throw err;
-            }
-
-            done();
+        var promise = Promise.each(names, function (name) {
+            testData[name] = fs.readFileSync(testData[name]);
         });
+        expect(promise, done).toResolve();
     });
 
     it('loads a glTF scene', function() {
@@ -83,22 +69,22 @@ describe('parseBinaryGltf', function() {
         expect(gltf.buffers.bufferView_29_buffer).toBeDefined();
         expect(gltf.buffers.bufferView_30_buffer).toBeDefined();
 
-        expect(bufferEqual(gltf.buffers.bufferView_29_buffer.extras._pipeline.source, noOverlapGltf.buffers.bufferView_29_buffer.extras._pipeline.source)).toBe(true);
-        expect(bufferEqual(gltf.buffers.bufferView_30_buffer.extras._pipeline.source, noOverlapGltf.buffers.bufferView_30_buffer.extras._pipeline.source)).toBe(true);
+        expect(gltf.buffers.bufferView_29_buffer.extras._pipeline.source.equals(noOverlapGltf.buffers.bufferView_29_buffer.extras._pipeline.source)).toBe(true);
+        expect(gltf.buffers.bufferView_30_buffer.extras._pipeline.source.equals(noOverlapGltf.buffers.bufferView_30_buffer.extras._pipeline.source)).toBe(true);
     });
 
     it('loads an embedded buffer', function() {
         var gltf = parseBinaryGltf(testData.binary);
 
         expect(gltf.buffers.bufferView_30_buffer.extras._pipeline.source).toBeDefined();
-        expect(bufferEqual(gltf.buffers.bufferView_30_buffer.extras._pipeline.source, testData.buffer)).toBe(true);
+        expect(gltf.buffers.bufferView_30_buffer.extras._pipeline.source.equals(testData.buffer)).toBe(true);
     });
 
     it('loads an embedded image', function() {
         var gltf = parseBinaryGltf(testData.binary);
 
         expect(gltf.images.Image0001.extras._pipeline.source).toBeDefined();
-        expect(bufferEqual(gltf.images.Image0001.extras._pipeline.source, testData.image)).toBe(true);
+        expect(gltf.images.Image0001.extras._pipeline.source.equals(testData.image)).toBe(true);
     });
 
     it('loads an embedded shader', function() {

--- a/specs/lib/writeBuffersSpec.js
+++ b/specs/lib/writeBuffersSpec.js
@@ -1,5 +1,4 @@
 'use strict';
-var bufferEqual = require('buffer-equal');
 var clone = require('clone');
 var fsExtra = require('fs-extra');
 
@@ -50,7 +49,7 @@ describe('writeBuffers', function() {
                 return fsExtra.readFile(outputBufferPath);
             })
             .then(function(outputData) {
-                expect(bufferEqual(outputData, bufferData)).toBe(true);
+                expect(outputData.equals(bufferData)).toBe(true);
             }), done).toResolve();
     });
 

--- a/specs/lib/writeImagesSpec.js
+++ b/specs/lib/writeImagesSpec.js
@@ -1,5 +1,4 @@
 'use strict';
-var bufferEqual = require('buffer-equal');
 var clone = require('clone');
 var fsExtra = require('fs-extra');
 
@@ -50,7 +49,7 @@ describe('writeImages', function() {
                 return fsExtra.readFile(outputImagePath);
             })
             .then(function (outputData) {
-                expect(bufferEqual(outputData, imageData)).toBe(true);
+                expect(outputData.equals(imageData)).toBe(true);
             }), done).toResolve();
     });
 

--- a/specs/lib/writeShadersSpec.js
+++ b/specs/lib/writeShadersSpec.js
@@ -2,7 +2,6 @@
 var clone = require('clone');
 var fsExtra = require('fs-extra');
 
-var bufferEqual = require('buffer-equal');
 var writeGltf = require('../../lib/writeGltf');
 
 var fragmentShaderPath = './specs/data/boxTexturedUnoptimized/CesiumTexturedBoxTest0FS.glsl';
@@ -52,7 +51,7 @@ describe('writeShaders', function() {
                 return fsExtra.readFile(outputFragmentShaderPath);
             })
             .then(function(outputData) {
-                expect(bufferEqual(outputData, fragmentShaderData)).toBe(true);
+                expect(outputData.equals(fragmentShaderData)).toBe(true);
             }), done).toResolve();
     });
 


### PR DESCRIPTION
This change is noisy, but simple, straightforward, and almost all specs.

1. Remove `buffer-equal`, `buf.Equals(other)` has been in Node since 0.11.
2. Remove `async`, it was only used in the tests and unneeded.
3. Update `data-uri-to-buffer` to `^1.0.0` (no changes required).
4. Update `image-size` to `^0.6.0` (no changes required).

