### PR TITLE
Use uniqueProgram/uniqueTechniques to retrive unique programs/techniques

### DIFF
--- a/lib/MergeDuplicateProperties.js
+++ b/lib/MergeDuplicateProperties.js
@@ -246,7 +246,7 @@ MergeDuplicateProperties.mergePrograms = function(gltf) {
             var unique = true;
             for (var i = 0; i < uniqueProgramIdsLength; i++) {
                 var uniqueProgramId = uniqueProgramIds[i];
-                var uniqueProgram = programs[uniqueProgramId];
+                var uniqueProgram = uniquePrograms[uniqueProgramId];
                 if (deepEqual(program, uniqueProgram)) {
                     programIdMapping[programId] = uniqueProgramId;
                     unique = false;
@@ -296,7 +296,7 @@ MergeDuplicateProperties.mergeTechniques = function(gltf) {
             var unique = true;
             for (var i = 0; i < uniqueTechniqueIdsLength; i++) {
                 var uniqueTechniqueId = uniqueTechniqueIds[i];
-                var uniqueTechnique = techniques[uniqueTechniqueId];
+                var uniqueTechnique = uniqueTechniques[uniqueTechniqueId];
                 if (deepEqual(technique, uniqueTechnique)) {
                     techniqueIdMapping[techniqueId] = uniqueTechniqueId;
                     unique = false;

--- a/specs/lib/MergeDuplicatePropertiesSpec.js
+++ b/specs/lib/MergeDuplicatePropertiesSpec.js
@@ -202,7 +202,8 @@ describe('MergeDuplicateProperties', function() {
                 programs: {
                     programOne: {
                         fragmentShader: 'FSOne',
-                        vertexShader: 'VSOne'
+                        vertexShader: 'VSOne',
+                        extras : {}
                     },
                     programTwo: {
                         fragmentShader: 'FSOne',
@@ -210,15 +211,18 @@ describe('MergeDuplicateProperties', function() {
                     },
                     programThree: {
                         fragmentShader: 'FSOne',
-                        vertexShader: 'VSTwo'
+                        vertexShader: 'VSTwo',
+                        extras : {}
                     }
                 },
                 techniques: {
                     techniqueOne: {
-                        program: 'programOne'
+                        program: 'programOne',
+                        extras: {}
                     },
                     techniqueTwo: {
-                        program: 'programTwo'
+                        program: 'programTwo',
+                        extras: {}
                     },
                     techniqueThree: {
                         program: 'programThree'
@@ -243,7 +247,8 @@ describe('MergeDuplicateProperties', function() {
                         arrayOf : ['values'],
                         nested : {
                             key : 'value'
-                        }
+                        },
+                        extras : {}
                     },
                     techniqueTwo : {
                         key : 'value',
@@ -257,15 +262,18 @@ describe('MergeDuplicateProperties', function() {
                         arrayOf : ['values'],
                         nested : {
                             key : 'value'
-                        }
+                        },
+                        extras : {}
                     }
                 },
                 materials : {
                     materialOne : {
-                        technique : 'techniqueOne'
+                        technique : 'techniqueOne',
+                        extras : {}
                     },
                     materialTwo : {
-                        technique : 'techniqueTwo'
+                        technique : 'techniqueTwo',
+                        extras : {}
                     },
                     materialThree : {
                         technique : 'techniqueThree'
@@ -312,14 +320,16 @@ describe('MergeDuplicateProperties', function() {
                         arrayOf : ['values'],
                         nested : {
                             key : 'value'
-                        }
+                        },
+                        extras : {}
                     },
                     materialTwo : {
                         key : 'value',
                         arrayOf : ['different', 'values'],
                         nested : {
                             key : 'value'
-                        }
+                        },
+                        extras : {}
                     },
                     materialThree : {
                         key : 'value',


### PR DESCRIPTION
* This is already being done for materials
* If this is not done, then the comparison is happening between objects
where one has name/extras and the other doesn't. This the comparison
will fail.
* I pseudo-randomly added `extras` property to program/technique/material objects in `MergeDuplicateProperties` spec such that the properties should merge regardless of the `extras` property.