### PR TITLE
Skip merge accessors before combine nodes/meshes

### DIFF
--- a/lib/MergeDuplicateProperties.js
+++ b/lib/MergeDuplicateProperties.js
@@ -30,7 +30,7 @@ function MergeDuplicateProperties() {}
  */
 MergeDuplicateProperties.mergeAll = function(gltf, skipMergeAccessors) {
     skipMergeAccessors = defaultValue(skipMergeAccessors, true);
-    if(!skipMergeAccessors) {
+    if (!skipMergeAccessors) {
         MergeDuplicateProperties.mergeAccessors(gltf);
     }
     MergeDuplicateProperties.mergeShaders(gltf);

--- a/lib/MergeDuplicateProperties.js
+++ b/lib/MergeDuplicateProperties.js
@@ -8,6 +8,7 @@ var getAccessorByteStride = require('./getAccessorByteStride');
 var numberOfComponentsForType = require('./numberOfComponentsForType');
 
 var defined = Cesium.defined;
+var defaultValue = Cesium.defaultValue;
 
 module.exports = MergeDuplicateProperties;
 
@@ -24,10 +25,14 @@ function MergeDuplicateProperties() {}
  * Merges all duplicate elements in the glTF asset in top-down order so merged references resolve down the hierarchy.
  *
  * @param {Object} gltf A javascript object containing a glTF asset.
+ * @param {Boolean} skipMergeAccessors Option to skip running mergeAccessors.
  * @returns {Object} The glTF asset with merged duplicate elements.
  */
-MergeDuplicateProperties.mergeAll = function(gltf) {
-    MergeDuplicateProperties.mergeAccessors(gltf);
+MergeDuplicateProperties.mergeAll = function(gltf, skipMergeAccessors) {
+    skipMergeAccessors = defaultValue(skipMergeAccessors, true);
+    if(!skipMergeAccessors) {
+        MergeDuplicateProperties.mergeAccessors(gltf);
+    }
     MergeDuplicateProperties.mergeShaders(gltf);
     MergeDuplicateProperties.mergePrograms(gltf);
     MergeDuplicateProperties.mergeTechniques(gltf);

--- a/lib/Pipeline.js
+++ b/lib/Pipeline.js
@@ -120,7 +120,7 @@ Pipeline.processJSONWithExtras  = function(gltfWithExtras, options) {
         if (mergeVertices) {
             mergeDuplicateVertices(gltfWithExtras);
         }
-        MergeDuplicateProperties.mergeAll(gltfWithExtras);
+        MergeDuplicateProperties.mergeAll(gltfWithExtras, true);
         RemoveUnusedProperties.removeAll(gltfWithExtras);
         removeDuplicatePrimitives(gltfWithExtras);
         combinePrimitives(gltfWithExtras);


### PR DESCRIPTION
Running merge accessors before nodes/meshes when multiple accessors can
be independent but have the same data causes one of the accessors to be
deleted and both meshes to use the same accessor. When this happens,
combineNodes can no longer merge the meshes.

Skipping merge accessors allows the nodes to be merged first and the
accessors can be merged during the second call to
mergeDuplicateProperties.