### PR TITLE
Add minimum lighting limit

### DIFF
--- a/lib/processModelMaterialsCommon.js
+++ b/lib/processModelMaterialsCommon.js
@@ -533,7 +533,8 @@ function generateTechnique(gltf, khrMaterialsCommon, lightParameters, options) {
         } else {
             fragmentLightingBlock += '  vec3 l = vec3(0.0, 0.0, 1.0);\n';
         }
-        fragmentLightingBlock += '  diffuseLight += vec3(1.0, 1.0, 1.0) * max(dot(normal,l), 0.);\n';
+        var minimumLighting = optimizeForCesium ? 0.2 : 0.0;
+        fragmentLightingBlock += '  diffuseLight += vec3(1.0, 1.0, 1.0) * max(dot(normal,l), ' + minimumLighting + ');\n';
 
         if (hasSpecular) {
             if (lightingModel === 'BLINN') {


### PR DESCRIPTION
Fixes https://github.com/AnalyticalGraphicsInc/cesium/issues/5787

Prevents models using the `KHR_materials_common` extension from getting too dark, but only in Cesium.