### PR TITLE
Remove default scene for gltf 2.0

### DIFF
--- a/lib/addDefaults.js
+++ b/lib/addDefaults.js
@@ -380,14 +380,8 @@ function addDefaultByteOffsets(gltf) {
 }
 
 function selectDefaultScene(gltf) {
-    var scenes = gltf.scenes;
-
-    if (!defined(gltf.scene)) {
-        var scenesLength = scenes.length;
-        for (var sceneId = 0; sceneId < scenesLength; sceneId++) {
-            gltf.scene = sceneId;
-            break;
-        }
+    if (defined(gltf.scenes) && !defined(gltf.scene)) {
+        gltf.scene = 0;
     }
 }
 


### PR DESCRIPTION
glTF 2.0 doesn't have scenes

Or if this is part of the 1.0 to 2.0 conversion, this function should be

```js
    if (defined(gltf.scenes) && !defined(gltf.scene)) {
        gltf.scene = gltf.scenes[0];
    }
```
instead.