### PR TITLE
Fix animations for 0.8 models

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 Change Log
 ==========
 
+### 1.0.3 - ???
+* Fixed a bug where animations in glTF 0.8 assets where not being converted from axis angle to quaternion.
+
 ### 1.0.2 - 2017-09-27
 * Fixed specular computation for certain models using the `KHR_materials_common` extension. [#309](https://github.com/AnalyticalGraphicsInc/gltf-pipeline/pull/309)
 * Added a `optimizeDrawCalls` flag to merge nodes and meshes more aggressively to minimize draw calls. [#308](https://github.com/AnalyticalGraphicsInc/gltf-pipeline/pull/308)

--- a/lib/updateVersion.js
+++ b/lib/updateVersion.js
@@ -1,7 +1,9 @@
 'use strict';
 var Cesium = require('cesium');
+var numberOfComponentsForType = require('./numberOfComponentsForType');
 
 var Cartesian3 = Cesium.Cartesian3;
+var ComponentDatatype = Cesium.ComponentDatatype;
 var Quaternion = Cesium.Quaternion;
 var WebGLConstants = Cesium.WebGLConstants;
 var defaultValue = Cesium.defaultValue;
@@ -102,6 +104,55 @@ function updateNodes(gltf) {
     }
 }
 
+function updateAnimations(gltf) {
+    var animations = gltf.animations;
+    var accessors = gltf.accessors;
+    var bufferViews = gltf.bufferViews;
+    var buffers = gltf.buffers;
+    var updatedAccessors = {};
+    var axis = new Cartesian3();
+    var quat = new Quaternion();
+    for (var animationId in animations) {
+        if (animations.hasOwnProperty(animationId)) {
+            var animation = animations[animationId];
+            var channels = animation.channels;
+            var parameters = animation.parameters;
+            var samplers = animation.samplers;
+            if (defined(channels)) {
+                var channelsLength = channels.length;
+                for (var i = 0; i < channelsLength; ++i) {
+                    var channel = channels[i];
+                    if (channel.target.path === 'rotation') {
+                        var accessorId = parameters[samplers[channel.sampler].output];
+                        if (defined(updatedAccessors[accessorId])) {
+                            continue;
+                        }
+                        updatedAccessors[accessorId] = true;
+                        var accessor = accessors[accessorId];
+                        var bufferView = bufferViews[accessor.bufferView];
+                        var buffer = buffers[bufferView.buffer];
+                        var source = buffer.extras._pipeline.source;
+                        var byteOffset = source.byteOffset + bufferView.byteOffset + accessor.byteOffset;
+                        var componentType = accessor.componentType;
+                        var count = accessor.count;
+                        var componentsLength = numberOfComponentsForType(accessor.type);
+                        var length = accessor.count * componentsLength;
+                        var typedArray = ComponentDatatype.createArrayBufferView(componentType, source.buffer, byteOffset, length);
+
+                        for (var j = 0; j < count; j++) {
+                            var offset = j * componentsLength;
+                            Cartesian3.unpack(typedArray, offset, axis);
+                            var angle = typedArray[offset + 3];
+                            Quaternion.fromAxisAngle(axis, angle, quat);
+                            Quaternion.pack(quat, typedArray, offset);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
 function removeTechniquePasses(gltf) {
     var techniques = gltf.techniques;
     for (var techniqueId in techniques) {
@@ -146,6 +197,8 @@ function glTF08to10(gltf) {
     // node rotation should be quaternion, not axis-angle
     // node.instanceSkin is deprecated
     updateNodes(gltf);
+    // animations that target rotations should be quaternion, not axis-angle
+    updateAnimations(gltf);
     // technique.pass and techniques.passes are deprecated
     removeTechniquePasses(gltf);
     // gltf.lights -> khrMaterialsCommon.lights

--- a/specs/lib/updateVersionSpec.js
+++ b/specs/lib/updateVersionSpec.js
@@ -3,6 +3,8 @@ var Cesium = require('cesium');
 
 var updateVersion = require('../../lib/updateVersion');
 
+var Cartesian3 = Cesium.Cartesian3;
+var Quaternion = Cesium.Quaternion;
 var WebGLConstants = Cesium.WebGLConstants;
 
 describe('updateVersion', function() {
@@ -24,6 +26,19 @@ describe('updateVersion', function() {
     });
 
     it('updates glTF from 0.8 to 1.0', function() {
+        var times = [0.0, 1.0];
+        var axisA = new Cartesian3(0.0, 0.0, 1.0);
+        var axisB = new Cartesian3(0.0, 1.0, 0.0);
+        var angleA = 0.0;
+        var angleB = 0.5;
+        var quatA = Quaternion.fromAxisAngle(axisA, angleA);
+        var quatB = Quaternion.fromAxisAngle(axisB, angleB);
+
+        var originalBuffer = new Float32Array([times[0], times[1], axisA.x, axisA.y, axisA.z, angleA, axisB.x, axisB.y, axisB.z, angleB]);
+        var expectedBuffer = new Float32Array([times[0], times[1], quatA.x, quatA.y, quatA.z, quatA.w, quatB.x, quatB.y, quatB.z, quatB.w]);
+
+        var buffer = new Uint8Array(originalBuffer.buffer);
+
         var gltf = {
             version: '0.8',
             asset: {
@@ -34,6 +49,95 @@ describe('updateVersion', function() {
             ],
             lights : {
                 'someLight' : true
+            },
+            buffers: {
+                buffer: {
+                    byteLength: buffer.byteLength,
+                    type: 'arraybuffer',
+                    extras: {
+                        _pipeline: {
+                            source: buffer
+                        }
+                    }
+                }
+            },
+            bufferViews: {
+                bufferViewTime: {
+                    buffer: 'buffer',
+                    byteLength: 8,
+                    byteOffset: 0
+                },
+                bufferViewRotation: {
+                    buffer: 'buffer',
+                    byteLength: 32,
+                    byteOffset: 8
+                }
+            },
+            accessors: {
+                accessorTime: {
+                    bufferView: "bufferViewTime",
+                    byteOffset: 0,
+                    byteStride: 0,
+                    componentType: WebGLConstants.FLOAT,
+                    count: 2,
+                    type: 'SCALAR'
+                },
+                accessorRotation: {
+                    bufferView: "bufferViewRotation",
+                    byteOffset: 0,
+                    byteStride: 0,
+                    componentType: WebGLConstants.FLOAT,
+                    count: 2,
+                    type: 'VEC4'
+                }
+            },
+            animations: {
+                animationNode: {
+                    channels: [
+                        {
+                            sampler: 'sampler',
+                            target: {
+                                id: 'node',
+                                path: 'rotation'
+                            }
+                        }
+                    ],
+                    count: 2,
+                    parameters: {
+                        time: 'accessorTime',
+                        rotation: 'accessorRotation'
+                    },
+                    samplers: {
+                        sampler: {
+                            input: 'time',
+                            interpolation: 'LINEAR',
+                            output: 'rotation'
+                        }
+                    }
+                },
+                animationNodeOther: {
+                    channels: [
+                        {
+                            sampler: 'sampler',
+                            target: {
+                                id: 'nodeOther',
+                                path: 'rotation'
+                            }
+                        }
+                    ],
+                    count: 2,
+                    parameters: {
+                        time: 'accessorTime',
+                        rotation: 'accessorRotation'
+                    },
+                    samplers: {
+                        sampler: {
+                            input: 'time',
+                            interpolation: 'LINEAR',
+                            output: 'rotation'
+                        }
+                    }
+                }
             },
             materials: {
                 material: {
@@ -62,6 +166,9 @@ describe('updateVersion', function() {
                         skin: 'skin',
                         meshes: ['mesh']
                     }
+                },
+                nodeOther: {
+                    rotation: [0.0, 0.0, 1.0, 0.0]
                 }
             },
             techniques: {
@@ -118,5 +225,7 @@ describe('updateVersion', function() {
             uniform: 'TEST_UNIFORM'
         });
         expect(technique.states).toEqual(['TEST_STATE']);
+
+        expect(originalBuffer).toEqual(expectedBuffer);
     });
 });


### PR DESCRIPTION
The animations were not being converted from axis-angle to quaternion.

Afterwards I will update this in the `2.0` and `2.0-cesium` branch, and then update Cesium.

@likangning93 can you review?