### PR TITLE
Catch Jimp.read errors and ignore it

### DIFF
--- a/lib/loadGltfUris.js
+++ b/lib/loadGltfUris.js
@@ -188,6 +188,7 @@ function generateJimpImage(object) {
             pipelineExtras.imageChanged = false;
             pipelineExtras.transparent = isTransparent(image);
         })
-        .catch(function(e) {
+        .catch(function() {
+            // Empty function to catch and ignore errors
         });
 }

--- a/lib/loadGltfUris.js
+++ b/lib/loadGltfUris.js
@@ -187,5 +187,7 @@ function generateJimpImage(object) {
             pipelineExtras.jimpImage = image;
             pipelineExtras.imageChanged = false;
             pipelineExtras.transparent = isTransparent(image);
+        })
+        .catch(function(e) {
         });
 }


### PR DESCRIPTION
Doesn't affect how the pipeline works if the images is not loaded. But
saves the processing from crashing due to unhandled errors from jimp.