### PR TITLE
Support vertex colors for materialsCommon and pbrMetallicRoughness

### DIFF
--- a/lib/processModelMaterialsCommon.js
+++ b/lib/processModelMaterialsCommon.js
@@ -942,7 +942,7 @@ function splitIncompatibleMaterials(gltf) {
                         },
                         hasVertexColors : hasVertexColors
                     };
-                } else if ((primitive.skinning.skinned !== isSkinned) || (primitive.skinning.type !== type) || (primitive.hasVertexColors !== hasVertexColors)) {
+                } else if ((primitiveInfo.skinning.skinned !== isSkinned) || (primitiveInfo.skinning.type !== type) || (primitiveInfo.hasVertexColors !== hasVertexColors)) {
                     // This primitive uses the same material as another one that either:
                     // * Isn't skinned
                     // * Uses a different type to store joints and weights

--- a/lib/processModelMaterialsCommon.js
+++ b/lib/processModelMaterialsCommon.js
@@ -218,6 +218,20 @@ function generateLightParameters(gltf) {
     return result;
 }
 
+function modelHasVertexColors(gltf) {
+    var hasVertexColors = false;
+    ForEach.mesh(gltf, function(mesh) {
+        ForEach.meshPrimitive(mesh, function(primitive) {
+            ForEach.meshPrimitiveAttribute(primitive, function(attribute, semantic) {
+                if (semantic.indexOf('COLOR') === 0) {
+                    hasVertexColors = true;
+                }
+            });
+        });
+    });
+    return hasVertexColors;
+}
+
 function generateTechnique(gltf, khrMaterialsCommon, lightParameters, options) {
     var optimizeForCesium = defaultValue(options.optimizeForCesium, false);
     var hasCesiumRTCExtension = defined(gltf.extensions) && defined(gltf.extensions.CESIUM_RTC);
@@ -434,6 +448,19 @@ function generateTechnique(gltf, khrMaterialsCommon, lightParameters, options) {
         vertexShader += 'attribute ' + attributeType + ' a_weight;\n';
     }
 
+    var hasVertexColors = modelHasVertexColors(gltf);
+    if (hasVertexColors) {
+        techniqueAttributes.a_vertexColor = 'vertexColor';
+        techniqueParameters.vertexColor = {
+            semantic: 'COLOR_0',
+            type: WebGLConstants.FLOAT_VEC4
+        };
+        vertexShader += 'attribute vec4 a_vertexColor;\n';
+        vertexShader += 'varying vec4 v_vertexColor;\n';
+        vertexShaderMain += '  v_vertexColor = a_vertexColor;\n';
+        fragmentShader += 'varying vec4 v_vertexColor;\n';
+    }
+
     if (addBatchIdToGeneratedShaders) {
         techniqueAttributes.a_batchId = 'batchId';
         techniqueParameters.batchId = {
@@ -600,6 +627,10 @@ function generateTechnique(gltf, khrMaterialsCommon, lightParameters, options) {
         }
     }
 
+    if (hasVertexColors) {
+        colorCreationBlock += '  color *= v_vertexColor.rgb;\n';
+    }
+
     if (defined(techniqueParameters.emission)) {
         if (techniqueParameters.emission.type === WebGLConstants.SAMPLER_2D) {
             fragmentShader += '  vec3 emission = texture2D(u_emission, ' + v_texcoord + ').rgb;\n';
@@ -670,10 +701,10 @@ function generateTechnique(gltf, khrMaterialsCommon, lightParameters, options) {
     // Add shaders
     var vertexShaderId = addToArray(shaders, {
         type: WebGLConstants.VERTEX_SHADER,
-            extras: {
-                _pipeline: {
-                    source: vertexShader,
-                    extension: '.glsl'
+        extras: {
+            _pipeline: {
+                source: vertexShader,
+                extension: '.glsl'
             }
         }
     });
@@ -898,42 +929,42 @@ function splitIncompatibleSkins(gltf) {
     var accessors = gltf.accessors;
     var materials = gltf.materials;
     ForEach.mesh(gltf, function(mesh) {
-       ForEach.meshPrimitive(mesh, function(primitive) {
-           var materialId = primitive.material;
-           var material = materials[materialId];
+        ForEach.meshPrimitive(mesh, function(primitive) {
+            var materialId = primitive.material;
+            var material = materials[materialId];
 
-           if (defined(material.extensions) && defined(material.extensions.KHR_materials_common)) {
-               var khrMaterialsCommon = material.extensions.KHR_materials_common;
-               var jointAccessorId = primitive.attributes.JOINT;
-               var componentType;
-               var type;
-               if (defined(jointAccessorId)) {
-                   var jointAccessor = accessors[jointAccessorId];
-                   componentType = jointAccessor.componentType;
-                   type = jointAccessor.type;
-               }
-               var isSkinned = defined(jointAccessorId);
+            if (defined(material.extensions) && defined(material.extensions.KHR_materials_common)) {
+                var khrMaterialsCommon = material.extensions.KHR_materials_common;
+                var jointAccessorId = primitive.attributes.JOINT;
+                var componentType;
+                var type;
+                if (defined(jointAccessorId)) {
+                    var jointAccessor = accessors[jointAccessorId];
+                    componentType = jointAccessor.componentType;
+                    type = jointAccessor.type;
+                }
+                var isSkinned = defined(jointAccessorId);
 
-               var skinningInfo = khrMaterialsCommon.extras._pipeline.skinning;
-               if (!defined(skinningInfo)) {
-                   khrMaterialsCommon.extras._pipeline.skinning = {
-                       skinned: isSkinned,
-                       componentType: componentType,
-                       type: type
-                   };
-               } else if ((skinningInfo.skinned !== isSkinned) || (skinningInfo.type !== type)) {
-                   // This primitive uses the same material as another one that either isn't skinned or uses a different type to store joints and weights
-                   var clonedMaterial = clone(material, true);
-                   clonedMaterial.extensions.KHR_materials_common.extras._pipeline.skinning = {
-                       skinned: isSkinned,
-                       componentType: componentType,
-                       type: type
-                   };
-                   // Split this off as a separate material
-                   materialId = addToArray(materials, clonedMaterial);
-                   primitive.material = materialId;
-               }
-           }
-       });
+                var skinningInfo = khrMaterialsCommon.extras._pipeline.skinning;
+                if (!defined(skinningInfo)) {
+                    khrMaterialsCommon.extras._pipeline.skinning = {
+                        skinned: isSkinned,
+                        componentType: componentType,
+                        type: type
+                    };
+                } else if ((skinningInfo.skinned !== isSkinned) || (skinningInfo.type !== type)) {
+                    // This primitive uses the same material as another one that either isn't skinned or uses a different type to store joints and weights
+                    var clonedMaterial = clone(material, true);
+                    clonedMaterial.extensions.KHR_materials_common.extras._pipeline.skinning = {
+                        skinned: isSkinned,
+                        componentType: componentType,
+                        type: type
+                    };
+                    // Split this off as a separate material
+                    materialId = addToArray(materials, clonedMaterial);
+                    primitive.material = materialId;
+                }
+            }
+        });
     });
 }

--- a/lib/processModelMaterialsCommon.js
+++ b/lib/processModelMaterialsCommon.js
@@ -55,8 +55,8 @@ function processModelMaterialsCommon(gltf, options) {
 
         var lightParameters = generateLightParameters(gltf);
 
-        // Pre-processing to assign skinning info and address incompatibilities
-        splitIncompatibleSkins(gltf);
+        // Pre-processing to address incompatibilities between primitives using the same materials. Handles skinning and vertex color incompatibilities.
+        splitIncompatibleMaterials(gltf);
 
         var techniques = {};
         ForEach.material(gltf, function(material) {
@@ -218,20 +218,6 @@ function generateLightParameters(gltf) {
     return result;
 }
 
-function modelHasVertexColors(gltf) {
-    var hasVertexColors = false;
-    ForEach.mesh(gltf, function(mesh) {
-        ForEach.meshPrimitive(mesh, function(primitive) {
-            ForEach.meshPrimitiveAttribute(primitive, function(attribute, semantic) {
-                if (semantic.indexOf('COLOR') === 0) {
-                    hasVertexColors = true;
-                }
-            });
-        });
-    });
-    return hasVertexColors;
-}
-
 function generateTechnique(gltf, khrMaterialsCommon, lightParameters, options) {
     var optimizeForCesium = defaultValue(options.optimizeForCesium, false);
     var hasCesiumRTCExtension = defined(gltf.extensions) && defined(gltf.extensions.CESIUM_RTC);
@@ -255,10 +241,9 @@ function generateTechnique(gltf, khrMaterialsCommon, lightParameters, options) {
     var jointCount = defaultValue(khrMaterialsCommon.jointCount, 0);
 
     var hasSkinning = jointCount > 0;
-    var skinningInfo = {};
-    if (hasSkinning) {
-        skinningInfo = khrMaterialsCommon.extras._pipeline.skinning;
-    }
+    var primitiveInfo = khrMaterialsCommon.extras._pipeline.primitive;
+    var skinningInfo = primitiveInfo.skinning;
+    var hasVertexColors = primitiveInfo.hasVertexColors;
 
     var vertexShader = 'precision highp float;\n';
     var fragmentShader = 'precision highp float;\n';
@@ -448,7 +433,6 @@ function generateTechnique(gltf, khrMaterialsCommon, lightParameters, options) {
         vertexShader += 'attribute ' + attributeType + ' a_weight;\n';
     }
 
-    var hasVertexColors = modelHasVertexColors(gltf);
     if (hasVertexColors) {
         techniqueAttributes.a_vertexColor = 'vertexColor';
         techniqueParameters.vertexColor = {
@@ -795,10 +779,12 @@ function getTechniqueKey(khrMaterialsCommon) {
     techniqueKey += transparent.toString() + ';';
     var jointCount = defaultValue(khrMaterialsCommon.jointCount, 0);
     techniqueKey += jointCount.toString() + ';';
+    var primitiveInfo = khrMaterialsCommon.extras._pipeline.primitive;
+    var skinningInfo = primitiveInfo.skinning;
     if (jointCount > 0) {
-        var skinningInfo = khrMaterialsCommon.extras._pipeline.skinning;
         techniqueKey += skinningInfo.type + ';';
     }
+    techniqueKey += primitiveInfo.hasVertexColors;
 
     return techniqueKey;
 }
@@ -925,7 +911,7 @@ function ensureSemanticExistence(gltf) {
     });
 }
 
-function splitIncompatibleSkins(gltf) {
+function splitIncompatibleMaterials(gltf) {
     var accessors = gltf.accessors;
     var materials = gltf.materials;
     ForEach.mesh(gltf, function(mesh) {
@@ -944,21 +930,31 @@ function splitIncompatibleSkins(gltf) {
                     type = jointAccessor.type;
                 }
                 var isSkinned = defined(jointAccessorId);
+                var hasVertexColors = defined(primitive.attributes.COLOR_0);
 
-                var skinningInfo = khrMaterialsCommon.extras._pipeline.skinning;
-                if (!defined(skinningInfo)) {
-                    khrMaterialsCommon.extras._pipeline.skinning = {
-                        skinned: isSkinned,
-                        componentType: componentType,
-                        type: type
+                var primitiveInfo = khrMaterialsCommon.extras._pipeline.primitive;
+                if (!defined(primitiveInfo)) {
+                    khrMaterialsCommon.extras._pipeline.primitive = {
+                        skinning : {
+                            skinned: isSkinned,
+                            componentType: componentType,
+                            type: type
+                        },
+                        hasVertexColors : hasVertexColors
                     };
-                } else if ((skinningInfo.skinned !== isSkinned) || (skinningInfo.type !== type)) {
-                    // This primitive uses the same material as another one that either isn't skinned or uses a different type to store joints and weights
+                } else if ((primitive.skinning.skinned !== isSkinned) || (primitive.skinning.type !== type) || (primitive.hasVertexColors !== hasVertexColors)) {
+                    // This primitive uses the same material as another one that either:
+                    // * Isn't skinned
+                    // * Uses a different type to store joints and weights
+                    // * Doesn't have vertex colors
                     var clonedMaterial = clone(material, true);
-                    clonedMaterial.extensions.KHR_materials_common.extras._pipeline.skinning = {
-                        skinned: isSkinned,
-                        componentType: componentType,
-                        type: type
+                    clonedMaterial.extensions.KHR_materials_common.extras._pipeline.primitive = {
+                        skinning : {
+                            skinned: isSkinned,
+                            componentType: componentType,
+                            type: type
+                        },
+                        hasVertexColors : hasVertexColors
                     };
                     // Split this off as a separate material
                     materialId = addToArray(materials, clonedMaterial);

--- a/lib/processPbrMetallicRoughness.js
+++ b/lib/processPbrMetallicRoughness.js
@@ -38,8 +38,8 @@ function processPbrMetallicRoughness(gltf, options) {
             gltf.techniques = [];
         }
 
-        // Pre-processing to assign skinning info and address incompatibilities
-        splitIncompatibleSkins(gltf);
+        // Pre-processing to address incompatibilities between primitives using the same materials. Handles skinning and vertex color incompatibilities.
+        splitIncompatibleMaterials(gltf);
 
         ForEach.material(gltf, function(material) {
             var pbrMetallicRoughness = material.pbrMetallicRoughness;
@@ -58,20 +58,6 @@ function processPbrMetallicRoughness(gltf, options) {
     }
 
     return gltf;
-}
-
-function modelHasVertexColors(gltf) {
-    var hasVertexColors = false;
-    ForEach.mesh(gltf, function(mesh) {
-        ForEach.meshPrimitive(mesh, function(primitive) {
-            ForEach.meshPrimitiveAttribute(primitive, function(attribute, semantic) {
-                if (semantic.indexOf('COLOR') === 0) {
-                    hasVertexColors = true;
-                }
-            });
-        });
-    });
-    return hasVertexColors;
 }
 
 function generateTechnique(gltf, material, options) {
@@ -99,8 +85,10 @@ function generateTechnique(gltf, material, options) {
     }
     var joints = (defined(skin)) ? skin.joints : [];
     var jointCount = joints.length;
-    var skinningInfo = material.extras._pipeline.skinning;
-    var hasSkinning = defined(skinningInfo.type);
+    var primitiveInfo = material.extras._pipeline.primitive;
+    var skinningInfo = primitiveInfo.skinning;
+    var hasSkinning = skinningInfo.skinned;
+    var hasVertexColors = primitiveInfo.hasVertexColors;
 
     var hasNormals = true;
     var hasTangents = false;
@@ -355,7 +343,6 @@ function generateTechnique(gltf, material, options) {
         vertexShader += 'attribute ' + attributeType + ' a_weight;\n';
     }
 
-    var hasVertexColors = modelHasVertexColors(gltf);
     if (hasVertexColors) {
         techniqueAttributes.a_vertexColor = 'vertexColor';
         techniqueParameters.vertexColor = {
@@ -781,7 +768,7 @@ function ensureSemanticExistence(gltf) {
     });
 }
 
-function splitIncompatibleSkins(gltf) {
+function splitIncompatibleMaterials(gltf) {
     var accessors = gltf.accessors;
     var materials = gltf.materials;
     ForEach.mesh(gltf, function(mesh) {
@@ -798,21 +785,31 @@ function splitIncompatibleSkins(gltf) {
                 type = jointAccessor.type;
             }
             var isSkinned = defined(jointAccessorId);
+            var hasVertexColors = defined(primitive.attributes.COLOR_0);
 
-            var skinningInfo = material.extras._pipeline.skinning;
-            if (!defined(skinningInfo)) {
-                material.extras._pipeline.skinning = {
-                    skinned : isSkinned,
-                    componentType : componentType,
-                    type : type
+            var primitiveInfo = material.extras._pipeline.primitive;
+            if (!defined(primitiveInfo)) {
+                material.extras._pipeline.primitive = {
+                    skinning : {
+                        skinned : isSkinned,
+                        componentType : componentType,
+                        type : type
+                    },
+                    hasVertexColors : hasVertexColors
                 };
-            } else if ((skinningInfo.skinned !== isSkinned) || (skinningInfo.type !== type)) {
-                // This primitive uses the same material as another one that either isn't skinned or uses a different type to store joints and weights
+            } else if ((primitive.skinning.skinned !== isSkinned) || (primitive.skinning.type !== type) || (primitive.hasVertexColors !== hasVertexColors)) {
+                // This primitive uses the same material as another one that either:
+                // * Isn't skinned
+                // * Uses a different type to store joints and weights
+                // * Doesn't have vertex colors
                 var clonedMaterial = clone(material, true);
-                clonedMaterial.material.extras._pipeline.skinning = {
-                    skinned : isSkinned,
-                    componentType : componentType,
-                    type : type
+                clonedMaterial.extras._pipeline.skinning = {
+                    skinning : {
+                        skinned : isSkinned,
+                        componentType : componentType,
+                        type : type
+                    },
+                    hasVertexColors : hasVertexColors
                 };
                 // Split this off as a separate material
                 materialId = addToArray(materials, clonedMaterial);

--- a/lib/processPbrMetallicRoughness.js
+++ b/lib/processPbrMetallicRoughness.js
@@ -60,6 +60,20 @@ function processPbrMetallicRoughness(gltf, options) {
     return gltf;
 }
 
+function modelHasVertexColors(gltf) {
+    var hasVertexColors = false;
+    ForEach.mesh(gltf, function(mesh) {
+        ForEach.meshPrimitive(mesh, function(primitive) {
+            ForEach.meshPrimitiveAttribute(primitive, function(attribute, semantic) {
+                if (semantic.indexOf('COLOR') === 0) {
+                    hasVertexColors = true;
+                }
+            });
+        });
+    });
+    return hasVertexColors;
+}
+
 function generateTechnique(gltf, material, options) {
     var optimizeForCesium = defaultValue(options.optimizeForCesium, false);
     var hasCesiumRTCExtension = defined(gltf.extensions) && defined(gltf.extensions.CESIUM_RTC);
@@ -341,6 +355,19 @@ function generateTechnique(gltf, material, options) {
         vertexShader += 'attribute ' + attributeType + ' a_weight;\n';
     }
 
+    var hasVertexColors = modelHasVertexColors(gltf);
+    if (hasVertexColors) {
+        techniqueAttributes.a_vertexColor = 'vertexColor';
+        techniqueParameters.vertexColor = {
+            semantic: 'COLOR_0',
+            type: WebGLConstants.FLOAT_VEC4
+        };
+        vertexShader += 'attribute vec4 a_vertexColor;\n';
+        vertexShader += 'varying vec4 v_vertexColor;\n';
+        vertexShaderMain += '  v_vertexColor = a_vertexColor;\n';
+        fragmentShader += 'varying vec4 v_vertexColor;\n';
+    }
+
     if (addBatchIdToGeneratedShaders) {
         techniqueAttributes.a_batchId = 'batchId';
         techniqueParameters.batchId = {
@@ -449,6 +476,11 @@ function generateTechnique(gltf, material, options) {
             fragmentShader += '    vec4 baseColorWithAlpha = vec4(1.0);\n';
         }
     }
+
+    if (hasVertexColors) {
+        fragmentShader += '    baseColorWithAlpha *= v_vertexColor;\n';
+    }
+
     fragmentShader += '    vec3 baseColor = baseColorWithAlpha.rgb;\n';
     // Add metallic-roughness to fragment shader
     if (defined(parameterValues.metallicRoughnessTexture)) {

--- a/lib/processPbrMetallicRoughness.js
+++ b/lib/processPbrMetallicRoughness.js
@@ -797,7 +797,7 @@ function splitIncompatibleMaterials(gltf) {
                     },
                     hasVertexColors : hasVertexColors
                 };
-            } else if ((primitive.skinning.skinned !== isSkinned) || (primitive.skinning.type !== type) || (primitive.hasVertexColors !== hasVertexColors)) {
+            } else if ((primitiveInfo.skinning.skinned !== isSkinned) || (primitiveInfo.skinning.type !== type) || (primitiveInfo.hasVertexColors !== hasVertexColors)) {
                 // This primitive uses the same material as another one that either:
                 // * Isn't skinned
                 // * Uses a different type to store joints and weights

--- a/specs/lib/processModelMaterialsCommonSpec.js
+++ b/specs/lib/processModelMaterialsCommonSpec.js
@@ -10,6 +10,15 @@ var WebGLConstants = Cesium.WebGLConstants;
 describe('processModelMaterialsCommon', function() {
     it('generates techniques and nodes for KHR_materials_common lights', function() {
         var gltf = {
+            meshes: [
+                {
+                    primitives: [
+                        {
+                            material: 0
+                        }
+                    ]
+                }
+            ],
             materials: [
                 {
                     extensions : {
@@ -120,6 +129,15 @@ describe('processModelMaterialsCommon', function() {
 
     it('works with optimizeForCesium', function() {
         var gltf = {
+            meshes: [
+                {
+                    primitives: [
+                        {
+                            material: 0
+                        }
+                    ]
+                }
+            ],
             extensionsUsed: ['KHR_materials_common'],
             materials: [
                 {
@@ -296,5 +314,50 @@ describe('processModelMaterialsCommon', function() {
         var techniqueMat3 = techniques[materials[materialMat3Id].technique];
         expect(techniqueVec4.parameters.joint.type).toEqual(WebGLConstants.FLOAT_VEC4);
         expect(techniqueMat3.parameters.joint.type).toEqual(WebGLConstants.FLOAT_MAT3);
+    });
+
+    it('material referenced by a primitive with vertex colors and a primitive without vertex colors is split', function() {
+        var gltf = {
+            accessors: [
+                {
+                    componentType: WebGLConstants.FLOAT,
+                    type: 'VEC4'
+                }
+            ],
+            extensionsUsed: [
+                'KHR_materials_common'
+            ],
+            materials: [
+                {
+                    extensions: {
+                        KHR_materials_common: {
+                            technique: 'BLINN'
+                        }
+                    }
+                }
+            ],
+            meshes: [
+                {
+                    primitives: [{
+                        attributes: {
+                            COLOR_0: 0
+                        },
+                        material: 0
+                    }]
+                }, {
+                    primitives: [{
+                        material: 0
+                    }]
+                }
+            ]
+        };
+        addDefaults(gltf);
+        addPipelineExtras(gltf);
+        processModelMaterialsCommon(gltf);
+
+        var meshes = gltf.meshes;
+        var materialWithVertexColors = meshes[0].primitives[0].material;
+        var materialWithoutVertexColors = meshes[1].primitives[0].material;
+        expect(materialWithVertexColors).not.toEqual(materialWithoutVertexColors);
     });
 });


### PR DESCRIPTION
Adds support for shading with vertex colors when generating shaders with `processModelMaterialsCommon` or `processPbrMetallicRoughness`.

TODO:

* [x] Tests