### PR TITLE
glTF BLEND mode didn't respect double-sided flag.

### DIFF
--- a/lib/processPbrMetallicRoughness.js
+++ b/lib/processPbrMetallicRoughness.js
@@ -610,7 +610,11 @@ function generateTechnique(gltf, material, options) {
     var techniqueStates;
     if (defined(alphaMode) && alphaMode !== 'OPAQUE') {
         techniqueStates = {
-            enable: [
+            enable: parameterValues.doubleSided ? [
+                WebGLConstants.DEPTH_TEST,
+                WebGLConstants.BLEND
+            ]: [
+                WebGLConstants.CULL_FACE,
                 WebGLConstants.DEPTH_TEST,
                 WebGLConstants.BLEND
             ],


### PR DESCRIPTION
This is a copy of https://github.com/AnalyticalGraphicsInc/cesium/pull/6371.