### PR TITLE
If primitive contains targets set sequential encoding

### DIFF
--- a/lib/compressDracoMeshes.js
+++ b/lib/compressDracoMeshes.js
@@ -262,6 +262,11 @@ function compressDracoMeshes(gltf, options) {
                 encoder.SetAttributeQuantization(encoderModule.GENERIC, skinQuantization);
             }
 
+            if (defined(primitive.targets)) {
+                // Set sequential encoding to preserve order of vertices.
+                encoder.SetEncodingMethod(encoderModule.MESH_SEQUENTIAL_ENCODING);
+            }
+
             var encodedLength = encoder.EncodeMeshToDracoBuffer(newMesh, encodedDracoDataArray);
             if (encodedLength <= 0) {
                 throw new DeveloperError('Error: Encoding failed.');


### PR DESCRIPTION
Check if the primitive contians any morph targets. If it does, set sequential encoding to preserve the order of vertices.

This fixes https://github.com/AnalyticalGraphicsInc/gltf-pipeline/issues/365