### PR TITLE
Add build-cesium task, and use dependency tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,16 +142,6 @@ npm run build-cesium
 
 This will output a portion of the gltf-pipeline code into the `dist/cesium` folder, reformatted into AMD style for use with RequireJS and Cesium in the browser.
 
-### Building for other integration
-
-Some functionality of gltf-pipeline is used by other projects along with Cesium as a third party library. The necessary files can be generated using:
-
-```
-npm run build-cesium-combine
-```
-
-This will output a portion of the gltf-pipeline code into the `dist/cesium-combined` folder, reformatted into self-contained file. Currently, only files that have no other local dependencies are allowed.
-
 ### Running Test Coverage
 
 Coverage uses [nyc](https://github.com/istanbuljs/nyc).  Run:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Content pipeline tools for optimizing [glTF](https://www.khronos.org/gltf) asset
 Supports common operations including:
 * Converting glTF to glb (and reverse)
 * Saving buffers/textures as embedded or separate files
-* Converting glTF 1.0 models to glTF 2.0 (using the [KHR_techniques_webgl](https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_techniques_webgl) extension)
+* Converting glTF 1.0 models to glTF 2.0 (using the [KHR_techniques_webgl](https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_techniques_webgl) and [EXT_blend](https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/EXT_blend) extensions)
 
 `gltf-pipeline` can be used as a command-line tool or Node.js module.
 
@@ -131,6 +131,26 @@ To run ESLint automatically when a file is saved, run the following and leave it
 ```
 npm run eslint-watch
 ```
+
+### Building for Cesium integration
+
+Some functionality of gltf-pipeline is used by Cesium as a third party library. The necessary files can be generated using:
+
+```
+npm run build-cesium
+```
+
+This will output a portion of the gltf-pipeline code into the `dist/cesium` folder, reformatted into AMD style for use with RequireJS and Cesium in the browser.
+
+### Building for other integration
+
+Some functionality of gltf-pipeline is used by other projects along with Cesium as a third party library. The necessary files can be generated using:
+
+```
+npm run build-cesium-combine
+```
+
+This will output a portion of the gltf-pipeline code into the `dist/cesium-combined` folder, reformatted into self-contained file. Currently, only files that have no other local dependencies are allowed.
 
 ### Running Test Coverage
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,6 +2,7 @@
 
 var Cesium = require('cesium');
 var child_process = require('child_process');
+var dependencyTree = require('dependency-tree');
 var fsExtra = require('fs-extra');
 var gulp = require('gulp');
 var Jasmine = require('jasmine');
@@ -96,6 +97,153 @@ gulp.task('cloc', function() {
                 console.log(stdout);
                 resolve();
             });
+        });
+    });
+});
+
+function amdify(source, subDependencyMapping) {
+    var fullMatch;
+    var variableName;
+    var requireVariable;
+    var requirePath;
+
+    source = source.replace(/\r\n/g, '\n');
+    var outputSource = source;
+
+    // find module exports
+    var returnValue;
+    var findModuleExportsRegex = /module.exports\s*=\s*(.*?);\n/;
+    var findModuleExports = findModuleExportsRegex.exec(source);
+    if (defined(findModuleExports && findModuleExports.length > 0)) {
+        fullMatch = findModuleExports[0];
+        returnValue = findModuleExports[1];
+        // remove module.exports from output source
+        outputSource = outputSource.replace(fullMatch, '');
+    }
+
+    // create require mapping for dependencies
+    var findRequireRegex = /var\s+(.+?)\s*=\s*require\('(.+?)'\);\n/g;
+    var findRequire = findRequireRegex.exec(source);
+    var requireMapping = {};
+    while (defined(findRequire) && findRequire.length > 0) {
+        fullMatch = findRequire[0];
+        variableName = findRequire[1];
+        requirePath = findRequire[2];
+        requireMapping[variableName] = requirePath;
+        // remove requires from output source
+        outputSource = outputSource.replace(fullMatch, '');
+        findRequire = findRequireRegex.exec(source);
+    }
+    // find places where sub-dependencies are pulled from a require
+    var subdependencyMapping = {};
+    var removeRequireMapping = [];
+    for (requireVariable in requireMapping) {
+        if (requireMapping.hasOwnProperty(requireVariable)) {
+            requirePath = requireMapping[requireVariable];
+            var findSubdependencyString = 'var\\s+(.+?)\\s*?=\\s*?' + requireVariable + '\\.(.+?);\n';
+            var findSubdependencyRegex = new RegExp(findSubdependencyString, 'g');
+            var findSubdependency = findSubdependencyRegex.exec(source);
+            while (defined(findSubdependency) && findSubdependency.length > 0) {
+                var mapping = subDependencyMapping[requirePath];
+                if (!defined(mapping)) {
+                    throw new Error('Build Failed: Module sub-dependency found for ' + requirePath + ' with no defined mapping behavior.');
+                }
+                removeRequireMapping.push(requireVariable);
+                fullMatch = findSubdependency[0];
+                variableName = findSubdependency[1];
+                var subdependencyPath = findSubdependency[2];
+                subdependencyMapping[variableName] = mapping.prefix + subdependencyPath;
+                // remove sub-dependency declarations from output source
+                outputSource = outputSource.replace(fullMatch, '');
+                findSubdependency = findSubdependencyRegex.exec(source);
+            }
+        }
+    }
+    // Top-level modules can be removed if mapped
+    while (removeRequireMapping.length > 0) {
+        var removeVariableName = removeRequireMapping.pop();
+        delete requireMapping[removeVariableName];
+    }
+    // join sub-dependencies with requireMapping
+    for (var subdependencyVariable in subdependencyMapping) {
+        if (subdependencyMapping.hasOwnProperty(subdependencyVariable)) {
+            requireMapping[subdependencyVariable] = subdependencyMapping[subdependencyVariable];
+        }
+    }
+    // amdify source
+    // indent
+    outputSource = outputSource.replace(/\n/g, '\n    ');
+    // wrap define header
+    var variables = [];
+    var paths = [];
+    for (var variable in requireMapping) {
+        if (requireMapping.hasOwnProperty(variable)) {
+            variables.push(variable);
+            paths.push(requireMapping[variable]);
+        }
+    }
+    var defineHeader = 'define([], function() {\n    ';
+    if (paths.length > 0) {
+        var definePathsHeader = '\'' + paths.join('\',\n        \'') + '\'';
+        var defineVariablesHeader = variables.join(',\n        ');
+        defineHeader =
+            'define([\n' +
+            '        ' + definePathsHeader + '\n' +
+            '    ], function(\n' +
+            '        ' + defineVariablesHeader + ') {\n    ';
+    }
+    var defineFooter = '\n});\n';
+    if (defined(returnValue)) {
+        defineFooter = '\n    return ' + returnValue + ';' + defineFooter;
+    }
+    outputSource = defineHeader + outputSource + defineFooter;
+    // remove repeat newlines
+    outputSource = outputSource.replace(/\n\s*\n/g, '\n\n');
+    return outputSource;
+}
+
+gulp.task('build-cesium', function () {
+    var basePath = 'lib';
+    var outputDir = 'dist/cesium';
+    var files = [
+        'addDefaults.js',
+        'addPipelineExtras.js',
+        'ForEach.js',
+        'parseGlb.js',
+        'updateVersion.js'
+    ];
+
+    var subDependencyMapping = {
+        cesium : {
+            prefix : '../../Core/'
+        }
+    };
+
+    var filesToAmdify = {};
+    Promise.map(files, function (fileName) {
+        var filePath = path.join(basePath, fileName);
+
+        // Get list of dependant files
+        filesToAmdify[filePath] = true;
+        return dependencyTree.toList({
+            filename : filePath,
+            directory : basePath,
+            filter: function(path) {
+                return path.indexOf('node_modules') === -1;
+            }
+        }).forEach(function (dependency) {
+            filesToAmdify[path.relative(__dirname, dependency)] = true;
+        });
+    }).then(function () {
+        return Promise.map(Object.keys(filesToAmdify), function(filePath) {
+            var fileName = path.relative(basePath, filePath);
+            return fsExtra.readFile(filePath)
+                .then(function (buffer) {
+                    var source = buffer.toString();
+                    source = amdify(source, subDependencyMapping);
+                    var outputPath = path.join(outputDir, fileName);
+                    return fsExtra.outputFile(outputPath, source);
+                });
         });
     });
 });

--- a/lib/ForEach.js
+++ b/lib/ForEach.js
@@ -1,6 +1,6 @@
 'use strict';
 var Cesium = require('cesium');
-var hasExtension = require('./hasExtension.js');
+var hasExtension = require('./hasExtension');
 
 var defined = Cesium.defined;
 var isArray = Cesium.isArray;

--- a/lib/findAccessorMinMax.js
+++ b/lib/findAccessorMinMax.js
@@ -6,7 +6,7 @@ var ComponentDatatype = Cesium.ComponentDatatype;
 var defined = Cesium.defined;
 
 var getAccessorByteStride = require('./getAccessorByteStride');
-var getComponentReader = require('./getComponentReader.js');
+var getComponentReader = require('./getComponentReader');
 var numberOfComponentsForType = require('./numberOfComponentsForType');
 
 module.exports = findAccessorMinMax;

--- a/lib/readAccessorPacked.js
+++ b/lib/readAccessorPacked.js
@@ -1,7 +1,7 @@
 'use strict';
 var Cesium = require('cesium');
 var getAccessorByteStride = require('./getAccessorByteStride');
-var getComponentReader = require('./getComponentReader.js');
+var getComponentReader = require('./getComponentReader');
 var numberOfComponentsForType = require('./numberOfComponentsForType');
 
 var arrayFill = Cesium.arrayFill;

--- a/lib/removeUnusedElements.js
+++ b/lib/removeUnusedElements.js
@@ -1,7 +1,7 @@
 'use strict';
 var Cesium = require('cesium');
 var ForEach = require('./ForEach');
-var hasExtension = require('./hasExtension.js');
+var hasExtension = require('./hasExtension');
 
 var defined = Cesium.defined;
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "devDependencies": {
     "cloc": "^2.3.3",
     "coveralls": "^3.0.0",
+    "dependency-tree": "^6.1.0",
     "eslint": "^4.19.1",
     "eslint-config-cesium": "^4.0.0",
     "gulp": "^3.9.1",
@@ -57,7 +58,8 @@
     "test-watch": "gulp test-watch",
     "coverage": "gulp coverage",
     "coveralls": "cat ./coverage/lcov.info | ./node_modules/.bin/coveralls",
-    "cloc": "gulp cloc"
+    "cloc": "gulp cloc",
+    "build-cesium": "gulp build-cesium"
   },
   "bin": {
     "gltf-pipeline": "./bin/gltf-pipeline.js"


### PR DESCRIPTION
Add back `build-cesium` task, and add add module for determining the dependency tree of files specified.

Part of https://github.com/AnalyticalGraphicsInc/gltf-pipeline/issues/330