### PR TITLE
Require min/max only for accessors containing position attributes

### DIFF
--- a/lib/updateVersion.js
+++ b/lib/updateVersion.js
@@ -803,7 +803,8 @@ function moveByteStrideToBufferView(gltf) {
 }
 
 function requireAccessorMinMax(gltf) {
-    ForEach.accessor(gltf, function(accessor) {
+    ForEach.accessorWithSemantic(gltf, 'POSITION', function(accessorId) {
+        var accessor = gltf.accessors[accessorId];
         if (!defined(accessor.min) || !defined(accessor.max)) {
             var minMax = findAccessorMinMax(gltf, accessor);
             accessor.min = minMax.min;
@@ -829,7 +830,7 @@ function glTF10to20(gltf) {
     requireByteLength(gltf);
     // byteStride moved from accessor to bufferView
     moveByteStrideToBufferView(gltf);
-    // accessor.min and accessor.max must be defined
+    // accessor.min and accessor.max must be defined for accessors containing POSITION attributes
     requireAccessorMinMax(gltf);
     // buffer.type is unnecessary and should be removed
     removeBufferType(gltf);

--- a/lib/updateVersion.js
+++ b/lib/updateVersion.js
@@ -802,7 +802,7 @@ function moveByteStrideToBufferView(gltf) {
     removeUnusedElements(gltf);
 }
 
-function requireAccessorMinMax(gltf) {
+function requirePositionAccessorMinMax(gltf) {
     ForEach.accessorWithSemantic(gltf, 'POSITION', function(accessorId) {
         var accessor = gltf.accessors[accessorId];
         if (!defined(accessor.min) || !defined(accessor.max)) {
@@ -831,7 +831,7 @@ function glTF10to20(gltf) {
     // byteStride moved from accessor to bufferView
     moveByteStrideToBufferView(gltf);
     // accessor.min and accessor.max must be defined for accessors containing POSITION attributes
-    requireAccessorMinMax(gltf);
+    requirePositionAccessorMinMax(gltf);
     // buffer.type is unnecessary and should be removed
     removeBufferType(gltf);
     // Remove format, internalFormat, target, and type

--- a/specs/lib/updateVersionSpec.js
+++ b/specs/lib/updateVersionSpec.js
@@ -626,8 +626,9 @@ describe('updateVersion', function() {
                 var bufferView = gltf.bufferViews[0];
                 expect(bufferView.byteLength).toEqual(source.length);
 
-                // Min and max are added to all accessors
-                ForEach.accessor(gltf, function(accessor) {
+                // Min and max are added to all POSITION accessors
+                ForEach.accessorWithSemantic(gltf, 'POSITION', function(accessorId) {
+                    var accessor = gltf.accessors[accessorId];
                     expect(accessor.min.length).toEqual(numberOfComponentsForType(accessor.type));
                     expect(accessor.max.length).toEqual(numberOfComponentsForType(accessor.type));
                 });


### PR DESCRIPTION
Fixes #325

According to the spec: 

> POSITION accessor must have min and max properties defined.

And it is optional for other accessors.

Since `requireAccessorMinMax` is by far the slowest part of the 1.0 - 2.0 upgrade I think it makes sense to only compute the min/max when needed. This will help speed up engines using gltf-pipeline to upgrade models on the fly. In fact I had previously removed `requireAccessorMinMax` from the `cesium-2.0` branch because it was too slow.

Thankfully min/max are already present on most glTF 1.0 position accessors so `findAccessorMinMax` should not be called too often.