### PR TITLE
Avoid adding duplicate shader for KHR_techniques_webgl

### DIFF
--- a/lib/addExtensionsRequired.js
+++ b/lib/addExtensionsRequired.js
@@ -1,6 +1,7 @@
 'use strict';
 var Cesium = require('cesium');
 var addExtensionsUsed = require('./addExtensionsUsed');
+var addToArray = require('./addToArray');
 
 var defined = Cesium.defined;
 
@@ -21,8 +22,6 @@ function addExtensionsRequired(gltf, extension) {
         extensionsRequired = [];
         gltf.extensionsRequired = extensionsRequired;
     }
-    if (extensionsRequired.indexOf(extension) === -1) {
-        extensionsRequired.push(extension);
-    }
+    addToArray(extensionsRequired, extension, true);
     addExtensionsUsed(gltf, extension);
 }

--- a/lib/addExtensionsUsed.js
+++ b/lib/addExtensionsUsed.js
@@ -1,5 +1,6 @@
 'use strict';
 var Cesium = require('cesium');
+var addToArray = require('./addToArray');
 
 var defined = Cesium.defined;
 
@@ -20,7 +21,5 @@ function addExtensionsUsed(gltf, extension) {
         extensionsUsed = [];
         gltf.extensionsUsed = extensionsUsed;
     }
-    if (extensionsUsed.indexOf(extension) === -1) {
-        extensionsUsed.push(extension);
-    }
+    addToArray(extensionsUsed, extension, true);
 }

--- a/lib/addToArray.js
+++ b/lib/addToArray.js
@@ -1,4 +1,8 @@
 'use strict';
+var Cesium = require('cesium');
+
+var defaultValue = Cesium.defaultValue;
+
 module.exports = addToArray;
 
 /**
@@ -6,10 +10,19 @@ module.exports = addToArray;
  *
  * @param {Array} array The array to add to.
  * @param {Object} element The element to add.
+ * @param {Boolean} [checkDuplicates=false] When <code>true</code>, if a duplicate element is found its index is returned and <code>element</code> is not added to the array.
  *
  * @private
  */
-function addToArray(array, element) {
+function addToArray(array, element, checkDuplicates) {
+    checkDuplicates = defaultValue(checkDuplicates, false);
+    if (checkDuplicates) {
+        var index = array.indexOf(element);
+        if (index > -1) {
+            return index;
+        }
+    }
+
     array.push(element);
     return array.length - 1;
 }

--- a/lib/moveTechniquesToExtension.js
+++ b/lib/moveTechniquesToExtension.js
@@ -67,20 +67,10 @@ function moveTechniquesToExtension(gltf) {
             };
 
             var fs = gltf.shaders[programLegacy.fragmentShader];
-            var fsIndex = extension.shaders.indexOf(fs);
-            if (fsIndex > -1) {
-                program.fragmentShader = fsIndex;
-            } else {
-                program.fragmentShader = addToArray(extension.shaders, fs);
-            }
+            program.fragmentShader = addToArray(extension.shaders, fs, true);
 
             var vs = gltf.shaders[programLegacy.vertexShader];
-            var vsIndex = extension.shaders.indexOf(vs);
-            if (vsIndex > -1) {
-                program.vertexShader = vsIndex;
-            } else {
-                program.vertexShader = addToArray(extension.shaders, vs);
-            }
+            program.vertexShader = addToArray(extension.shaders, vs, true);
 
             technique.program = addToArray(extension.programs, program);
 

--- a/lib/moveTechniquesToExtension.js
+++ b/lib/moveTechniquesToExtension.js
@@ -67,10 +67,20 @@ function moveTechniquesToExtension(gltf) {
             };
 
             var fs = gltf.shaders[programLegacy.fragmentShader];
-            program.fragmentShader = addToArray(extension.shaders, fs);
+            var fsIndex = extension.shaders.indexOf(fs);
+            if (fsIndex > -1) {
+                program.fragmentShader = fsIndex;
+            } else {
+                program.fragmentShader = addToArray(extension.shaders, fs);
+            }
 
             var vs = gltf.shaders[programLegacy.vertexShader];
-            program.vertexShader = addToArray(extension.shaders, vs);
+            var vsIndex = extension.shaders.indexOf(vs);
+            if (vsIndex > -1) {
+                program.vertexShader = vsIndex;
+            } else {
+                program.vertexShader = addToArray(extension.shaders, vs);
+            }
 
             technique.program = addToArray(extension.programs, program);
 

--- a/specs/lib/addToArraySpec.js
+++ b/specs/lib/addToArraySpec.js
@@ -16,4 +16,22 @@ describe('addToArray', function() {
         expect(addToArray(gltf.buffers, buffer1)).toBe(1);
         expect(gltf.buffers).toEqual([buffer0, buffer1]);
     });
+
+    it('returns index of duplicate element when checkDuplicates is true', function() {
+        var gltf = {
+            buffers: []
+        };
+        var buffer0 = {
+            byteLength: 100
+        };
+        var buffer1 = {
+            byteLength: 200
+        };
+        expect(addToArray(gltf.buffers, buffer0, true)).toBe(0);
+        expect(addToArray(gltf.buffers, buffer1, true)).toBe(1);
+        expect(addToArray(gltf.buffers, buffer0, true)).toBe(0);
+        expect(gltf.buffers.length).toBe(2);
+        expect(addToArray(gltf.buffers, buffer0)).toBe(2);
+        expect(gltf.buffers.length).toBe(3);
+    });
 });

--- a/specs/lib/moveTechniquesToExtensionSpec.js
+++ b/specs/lib/moveTechniquesToExtensionSpec.js
@@ -15,6 +15,15 @@ describe('moveTechniquesToExtension', function() {
                     ],
                     fragmentShader: 'BoxTextured0FS',
                     vertexShader: 'BoxTextured0VS'
+                },
+                program_1: {
+                    attributes: [
+                        'a_normal',
+                        'a_position',
+                        'a_texcoord0'
+                    ],
+                    fragmentShader: 'BoxTextured1FS',
+                    vertexShader: 'BoxTextured0VS'
                 }
             },
             shaders: {
@@ -25,6 +34,10 @@ describe('moveTechniquesToExtension', function() {
                 BoxTextured0VS: {
                     type: WebGLConstants.VERTEX_SHADER,
                     uri: 'BoxTextured0VS.glsl'
+                },
+                BoxTextured1FS: {
+                    type: WebGLConstants.FRAGMENT_SHADER,
+                    uri: 'BoxTextured1FS.glsl'
                 }
             },
             techniques: {
@@ -84,6 +97,9 @@ describe('moveTechniquesToExtension', function() {
                         u_shininess: 'shininess',
                         u_specular: 'specular'
                     }
+                },
+                technique1 : {
+                    program: 'program_1'
                 }
             },
             materials: [
@@ -108,7 +124,7 @@ describe('moveTechniquesToExtension', function() {
         expect(gltfWithTechniquesWebgl.extensions).toBeDefined();
         var techniques = gltfWithTechniquesWebgl.extensions.KHR_techniques_webgl;
         expect(techniques).toBeDefined();
-        expect(techniques.techniques.length).toBe(1);
+        expect(techniques.techniques.length).toBe(2);
 
         var technique = techniques.techniques[0];
         var attributes = technique.attributes;
@@ -124,11 +140,11 @@ describe('moveTechniquesToExtension', function() {
         expect(technique.parameters).toBeUndefined();
         expect(technique.states).toBeUndefined();
 
-        expect(techniques.programs.length).toBe(1);
+        expect(techniques.programs.length).toBe(2);
         var program = techniques.programs[technique.program];
         expect(program).toBeDefined();
 
-        expect(techniques.shaders.length).toBe(2);
+        expect(techniques.shaders.length).toBe(3);
         expect(techniques.shaders[program.fragmentShader].type).toBe(WebGLConstants.FRAGMENT_SHADER);
         expect(techniques.shaders[program.vertexShader].type).toBe(WebGLConstants.VERTEX_SHADER);
 
@@ -145,5 +161,10 @@ describe('moveTechniquesToExtension', function() {
 
         expect(material.technique).toBeUndefined();
         expect(material.values).toBeUndefined();
+
+        var technique2 = techniques.techniques[1];
+        var program2 = techniques.programs[technique2.program];
+        expect(program2.vertexShader).toBe(program.vertexShader);
+        expect(program2.fragmentShader).not.toBe(program.fragmentShader);
     });
 });


### PR DESCRIPTION
I ran into an issue where two programs used the same vertex shader, and that shader object would get added twice to `extras.KHR_techniques_webgl.shaders`. This caused problems when writing resources later on.

@ggetz could you review?