### PR TITLE
Ensure gltf.asset.version is defined

### DIFF
--- a/lib/updateVersion.js
+++ b/lib/updateVersion.js
@@ -48,6 +48,7 @@ function updateVersion(gltf, options) {
         version: '1.0'
     });
 
+    gltf.asset.version = defaultValue(gltf.asset.version, '1.0');
     version = defaultValue(version, gltf.asset.version).toString();
 
     // Invalid version


### PR DESCRIPTION
Some gltf assets, such as some sample b3dms, have `gltf.asset` defined, but not `gltf.asset.version`, which was causing failures.