### PR TITLE
Added removeExtension helper

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,5 +5,6 @@ module.exports = {
     glbToGltf: require('./lib/glbToGltf'),
     gltfToGlb: require('./lib/gltfToGlb'),
     processGlb: require('./lib/processGlb'),
-    processGltf: require('./lib/processGltf')
+    processGltf: require('./lib/processGltf'),
+    removeExtension: require('./lib/removeExtension')
 };

--- a/lib/removeExtension.js
+++ b/lib/removeExtension.js
@@ -1,0 +1,32 @@
+'use strict';
+var Cesium = require('cesium');
+var removeExtensionsUsed = require('./removeExtensionsUsed');
+
+var defined = Cesium.defined;
+
+module.exports = removeExtension;
+
+/**
+ * Removes an extension from gltf.extensions, gltf.extensionsUsed, and gltf.extensionsRequired if it is present.
+ * <p>
+ * Does not remove the extension from other objects in the glTF.
+ * </p>
+ *
+ * @param {Object} gltf A javascript object containing a glTF asset.
+ * @param {String} extension The extension to remove.
+ *
+ * @returns {*} The extension data removed from gltf.extensions.
+ */
+function removeExtension(gltf, extension) {
+    removeExtensionsUsed(gltf, extension); // Also removes from extensionsRequired
+
+    var extensions = gltf.extensions;
+    if (defined(extensions)) {
+        var extensionData = extensions[extension];
+        delete extensions[extension];
+        if (Object.keys(extensions).length === 0) {
+            delete gltf.extensions;
+        }
+        return extensionData;
+    }
+}

--- a/specs/lib/removeExtensionsSpec.js
+++ b/specs/lib/removeExtensionsSpec.js
@@ -1,0 +1,50 @@
+'use strict';
+var removeExtension = require('../../lib/removeExtension');
+
+describe('removeExtension', function() {
+    it('removes extension', function() {
+        var gltf = {
+            extensionsRequired: [
+                'extension1',
+                'extension2',
+                'extension3'
+            ],
+            extensionsUsed: [
+                'extension1',
+                'extension2',
+                'extension3'
+            ],
+            extensions: {
+                extension1: {
+                    value: 9
+                },
+                extension2: [0, 1, 2]
+            }
+        };
+        var extension1 = removeExtension(gltf, 'extension1');
+        expect(gltf.extensionsRequired).toEqual(['extension2', 'extension3']);
+        expect(gltf.extensionsUsed).toEqual(['extension2', 'extension3']);
+        expect(gltf.extensions).toEqual({
+            extension2: [0, 1, 2]
+        });
+        expect(extension1).toEqual({
+            value: 9
+        });
+
+        var extension2 = removeExtension(gltf, 'extension2');
+        expect(gltf.extensionsRequired).toEqual(['extension3']);
+        expect(gltf.extensionsUsed).toEqual(['extension3']);
+        expect(gltf.extensions).toBeUndefined();
+        expect(extension2).toEqual([0, 1,2]);
+
+        var extension3 = removeExtension(gltf, 'extension3');
+        expect(gltf.extensionsRequired).toBeUndefined();
+        expect(gltf.extensionsUsed).toBeUndefined();
+        expect(gltf.extensions).toBeUndefined();
+        expect(extension3).toBeUndefined();
+
+        var emptyGltf = {};
+        removeExtension(gltf, 'extension1');
+        expect(emptyGltf).toEqual({});
+    });
+});


### PR DESCRIPTION
Added a helper function `removeExtension` that removes an extension from the glTF. Added to `index.js` as well since there are a few other projects that could use this helper.