### PR TITLE
Update attribute component types, and remove sampler name properties

### DIFF
--- a/lib/mergeBuffers.js
+++ b/lib/mergeBuffers.js
@@ -27,7 +27,8 @@ function mergeBuffers(gltf) {
     ForEach.bufferView(gltf, function(bufferView) {
         if (defined(gltf.buffers[bufferView.buffer])) {
             var buffer = gltf.buffers[bufferView.buffer];
-            var sourceBufferViewData = buffer.extras._pipeline.source.slice(bufferView.byteOffset, bufferView.byteOffset + bufferView.byteLength);
+            var sourceBufferViewData = Buffer.from(buffer.extras._pipeline.source.slice(bufferView.byteOffset,
+                bufferView.byteOffset + bufferView.byteLength));
 
             var bufferViewPadding = getPadding(lengthSoFar);
             buffersToMerge.push(bufferViewPadding);

--- a/lib/updateAccessorComponentTypes.js
+++ b/lib/updateAccessorComponentTypes.js
@@ -1,0 +1,67 @@
+'use strict';
+var Cesium = require('cesium');
+var addToArray = require('./addToArray');
+var ForEach = require('./ForEach');
+var readAccessorPacked = require('./readAccessorPacked');
+
+var ComponentDatatype = Cesium.ComponentDatatype;
+var WebGLConstants = Cesium.WebGLConstants;
+
+module.exports = updateAccessorComponentTypes;
+
+/**
+ * Update accessors referenced by JOINTS_0 and WEIGHTS_0 attributes to use correct component types.
+ *
+ * @param {Object} gltf A javascript object containing a glTF asset.
+ * @returns {Object} The glTF asset with compressed meshes.
+ *
+ * @private
+ */
+function updateAccessorComponentTypes(gltf) {
+    var componentType;
+    ForEach.accessorWithSemantic(gltf, 'JOINTS_0', function(accessorId) {
+        var accessor = gltf.accessors[accessorId];
+        componentType = accessor.componentType;
+        if (componentType === WebGLConstants.BYTE) {
+            convertType(gltf, accessor, componentType, ComponentDatatype.UNSIGNED_BYTE);
+        } else if (componentType !== WebGLConstants.UNSIGNED_BYTE
+                && componentType !== WebGLConstants.UNSIGNED_SHORT) {
+            convertType(gltf, accessor, componentType, ComponentDatatype.UNSIGNED_SHORT);
+        }
+    });
+    ForEach.accessorWithSemantic(gltf, 'WEIGHTS_0', function(accessorId) {
+        var accessor = gltf.accessors[accessorId];
+        componentType = accessor.componentType;
+        if (componentType === WebGLConstants.BYTE) {
+            convertType(gltf, accessor, componentType, ComponentDatatype.UNSIGNED_BYTE);
+        } else if (componentType === WebGLConstants.SHORT) {
+            convertType(gltf, accessor, componentType, ComponentDatatype.UNSIGNED_SHORT);
+        }
+    });
+
+    return gltf;
+}
+
+function convertType(gltf, accessor, componentType, updatedComponentType) {
+    var data = ComponentDatatype.createTypedArray(componentType, readAccessorPacked(gltf, accessor));
+    var typedArray = ComponentDatatype.createTypedArray(updatedComponentType, data);
+    var newBuffer = Buffer.from(typedArray.buffer);
+    var newBufferLength = newBuffer.length;
+    var buffer = {
+        byteLength: newBufferLength,
+        extras: {
+            _pipeline: {
+                source: newBuffer
+            }
+        }
+    };
+
+    delete gltf.bufferViews[accessor.bufferView];
+
+    var bufferId = addToArray(gltf.buffers, buffer);
+    accessor.componentType = updatedComponentType;
+    accessor.bufferView = addToArray(gltf.bufferViews, {
+        buffer: bufferId,
+        byteLength: newBufferLength
+    });
+}

--- a/lib/updateAccessorComponentTypes.js
+++ b/lib/updateAccessorComponentTypes.js
@@ -23,29 +23,28 @@ function updateAccessorComponentTypes(gltf) {
         var accessor = gltf.accessors[accessorId];
         componentType = accessor.componentType;
         if (componentType === WebGLConstants.BYTE) {
-            convertType(gltf, accessor, componentType, ComponentDatatype.UNSIGNED_BYTE);
+            convertType(gltf, accessor, ComponentDatatype.UNSIGNED_BYTE);
         } else if (componentType !== WebGLConstants.UNSIGNED_BYTE
                 && componentType !== WebGLConstants.UNSIGNED_SHORT) {
-            convertType(gltf, accessor, componentType, ComponentDatatype.UNSIGNED_SHORT);
+            convertType(gltf, accessor, ComponentDatatype.UNSIGNED_SHORT);
         }
     });
     ForEach.accessorWithSemantic(gltf, 'WEIGHTS_0', function(accessorId) {
         var accessor = gltf.accessors[accessorId];
         componentType = accessor.componentType;
         if (componentType === WebGLConstants.BYTE) {
-            convertType(gltf, accessor, componentType, ComponentDatatype.UNSIGNED_BYTE);
+            convertType(gltf, accessor, ComponentDatatype.UNSIGNED_BYTE);
         } else if (componentType === WebGLConstants.SHORT) {
-            convertType(gltf, accessor, componentType, ComponentDatatype.UNSIGNED_SHORT);
+            convertType(gltf, accessor, ComponentDatatype.UNSIGNED_SHORT);
         }
     });
 
     return gltf;
 }
 
-function convertType(gltf, accessor, componentType, updatedComponentType) {
-    var data = ComponentDatatype.createTypedArray(componentType, readAccessorPacked(gltf, accessor));
-    var typedArray = ComponentDatatype.createTypedArray(updatedComponentType, data);
-    var newBuffer = Buffer.from(typedArray.buffer);
+function convertType(gltf, accessor, updatedComponentType) {
+    var typedArray = ComponentDatatype.createTypedArray(updatedComponentType, readAccessorPacked(gltf, accessor));
+    var newBuffer = new Uint8Array(typedArray.buffer);
     var newBufferLength = newBuffer.length;
     var buffer = {
         byteLength: newBufferLength,
@@ -55,8 +54,6 @@ function convertType(gltf, accessor, componentType, updatedComponentType) {
             }
         }
     };
-
-    delete gltf.bufferViews[accessor.bufferView];
 
     var bufferId = addToArray(gltf.buffers, buffer);
     accessor.componentType = updatedComponentType;

--- a/lib/updateVersion.js
+++ b/lib/updateVersion.js
@@ -277,14 +277,14 @@ function removeAnimationSamplersIndirection(gltf) {
     }
 }
 
-function objectToArray(object, mapping, topLevelId) {
+function objectToArray(object, mapping) {
     var array = [];
     for (var id in object) {
         if (object.hasOwnProperty(id)) {
             var value = object[id];
             mapping[id] = array.length;
             array.push(value);
-            if (!defined(value.name) && (topLevelId !== 'samplers')) { // sampler objects do not specify a name property
+            if (!defined(value.name)) {
                 value.name = id;
             }
         }
@@ -331,7 +331,7 @@ function objectsToArrays(gltf) {
         if (gltf.hasOwnProperty(topLevelId) && defined(globalMapping[topLevelId])) {
             var objectMapping = {};
             var object = gltf[topLevelId];
-            gltf[topLevelId] = objectToArray(object, objectMapping, topLevelId);
+            gltf[topLevelId] = objectToArray(object, objectMapping);
             globalMapping[topLevelId] = objectMapping;
         }
     }
@@ -481,7 +481,7 @@ function objectsToArrays(gltf) {
     });
     ForEach.animation(gltf, function(animation) {
         var samplerMapping = {};
-        animation.samplers = objectToArray(animation.samplers, samplerMapping, 'samplers');
+        animation.samplers = objectToArray(animation.samplers, samplerMapping);
         ForEach.animationSampler(animation, function(sampler) {
             sampler.input = globalMapping.accessors[sampler.input];
             sampler.output = globalMapping.accessors[sampler.output];
@@ -555,6 +555,14 @@ function objectsToArrays(gltf) {
         if (defined(texture.source)) {
             texture.source = globalMapping.images[texture.source];
         }
+    });
+}
+
+function removeAnimationSamplerNames(gltf) {
+    ForEach.animation(gltf, function(animation) {
+        ForEach.animationSampler(animation, function(sampler) {
+            delete sampler.name;
+        });
     });
 }
 
@@ -825,6 +833,8 @@ function glTF10to20(gltf) {
     removeAnimationSamplersIndirection(gltf);
     // Top-level objects are now arrays referenced by index instead of id
     objectsToArrays(gltf);
+    // Animation.sampler objects cannot have names
+    removeAnimationSamplerNames(gltf);
     // asset.profile no longer exists
     stripAsset(gltf);
     // Move known extensions from extensionsUsed to extensionsRequired

--- a/lib/updateVersion.js
+++ b/lib/updateVersion.js
@@ -9,6 +9,7 @@ var numberOfComponentsForType = require('./numberOfComponentsForType');
 var moveTechniqueRenderStates = require('./moveTechniqueRenderStates');
 var moveTechniquesToExtension = require('./moveTechniquesToExtension');
 var removeUnusedElements = require('./removeUnusedElements');
+var updateAccessorComponentTypes = require('./updateAccessorComponentTypes');
 
 var Cartesian3 = Cesium.Cartesian3;
 var clone = Cesium.clone;
@@ -276,14 +277,14 @@ function removeAnimationSamplersIndirection(gltf) {
     }
 }
 
-function objectToArray(object, mapping) {
+function objectToArray(object, mapping, topLevelId) {
     var array = [];
     for (var id in object) {
         if (object.hasOwnProperty(id)) {
             var value = object[id];
             mapping[id] = array.length;
             array.push(value);
-            if (!defined(value.name)) {
+            if (!defined(value.name) && (topLevelId !== 'samplers')) { // sampler objects do not specify a name property
                 value.name = id;
             }
         }
@@ -330,7 +331,7 @@ function objectsToArrays(gltf) {
         if (gltf.hasOwnProperty(topLevelId) && defined(globalMapping[topLevelId])) {
             var objectMapping = {};
             var object = gltf[topLevelId];
-            gltf[topLevelId] = objectToArray(object, objectMapping);
+            gltf[topLevelId] = objectToArray(object, objectMapping, topLevelId);
             globalMapping[topLevelId] = objectMapping;
         }
     }
@@ -480,7 +481,7 @@ function objectsToArrays(gltf) {
     });
     ForEach.animation(gltf, function(animation) {
         var samplerMapping = {};
-        animation.samplers = objectToArray(animation.samplers, samplerMapping);
+        animation.samplers = objectToArray(animation.samplers, samplerMapping, 'samplers');
         ForEach.animationSampler(animation, function(sampler) {
             sampler.input = globalMapping.accessors[sampler.input];
             sampler.output = globalMapping.accessors[sampler.output];
@@ -815,6 +816,17 @@ function requirePositionAccessorMinMax(gltf) {
     });
 }
 
+function requireAnimationSamplerAccessorMinMax(gltf) {
+    ForEach.accessorWithSemantic(gltf, 'POSITION', function(accessorId) {
+        var accessor = gltf.accessors[accessorId];
+        if (!defined(accessor.min) || !defined(accessor.max)) {
+            var minMax = findAccessorMinMax(gltf, accessor);
+            accessor.min = minMax.min;
+            accessor.max = minMax.max;
+        }
+    });
+}
+
 function glTF10to20(gltf) {
     gltf.asset = defaultValue(gltf.asset, {});
     gltf.asset.version = '2.0';
@@ -842,6 +854,8 @@ function glTF10to20(gltf) {
     requireAttributeSetIndex(gltf);
     // Add underscores to application-specific parameters
     underscoreApplicationSpecificSemantics(gltf);
+    // Accessors referenced by JOINTS_0 and WEIGHTS_0 attributes must have correct component types
+    updateAccessorComponentTypes(gltf);
     // Clamp camera parameters
     clampCameraParameters(gltf);
     // Move legacy technique render states to material properties and add KHR_blend extension blending functions

--- a/lib/updateVersion.js
+++ b/lib/updateVersion.js
@@ -816,17 +816,6 @@ function requirePositionAccessorMinMax(gltf) {
     });
 }
 
-function requireAnimationSamplerAccessorMinMax(gltf) {
-    ForEach.accessorWithSemantic(gltf, 'POSITION', function(accessorId) {
-        var accessor = gltf.accessors[accessorId];
-        if (!defined(accessor.min) || !defined(accessor.max)) {
-            var minMax = findAccessorMinMax(gltf, accessor);
-            accessor.min = minMax.min;
-            accessor.max = minMax.max;
-        }
-    });
-}
-
 function glTF10to20(gltf) {
     gltf.asset = defaultValue(gltf.asset, {});
     gltf.asset.version = '2.0';

--- a/specs/lib/updateAccessorComponentTypeSpec.js
+++ b/specs/lib/updateAccessorComponentTypeSpec.js
@@ -1,0 +1,177 @@
+'use strict';
+var Cesium = require('cesium');
+var updateAccessorComponentTypes = require('../../lib/updateAccessorComponentTypes');
+
+var WebGLConstants = Cesium.WebGLConstants;
+
+var source = Buffer.from((new Float32Array([-2.0, 1.0, 0.0, 1.0, 2.0, 3.0])).buffer);
+
+describe('updateAccessorComponentTypes', function() {
+    it('converts joints accessor types', function() {
+        var gltf = {
+            meshes: [
+                {
+                    primitives: [
+                        {
+                            attributes: {
+                                JOINTS_0: 0
+                            }
+                        }, {
+                            attributes: {
+                                JOINTS_0: 1
+                            }
+                        }, {
+                            attributes: {
+                                JOINTS_0: 2
+                            }
+                        }
+                    ]
+                }
+            ],
+            accessors: [
+                {
+                    bufferView: 0,
+                    componentType: WebGLConstants.BYTE,
+                    count: 24,
+                    type: 'VEC4'
+                }, {
+                    bufferView: 1,
+                    componentType: WebGLConstants.FLOAT,
+                    count: 24,
+                    type: 'VEC4'
+                }, {
+                    bufferView: 2,
+                    componentType: WebGLConstants.UNSIGNED_SHORT,
+                    count: 24,
+                    type: 'VEC4'
+                }
+            ],
+            bufferViews: [
+                {
+                    buffer: 0,
+                    byteLength: 12
+                }, {
+                    buffer: 0,
+                    byteOffset: 12,
+                    byteLength: 12
+                }, {
+                    buffer: 0,
+                    byteLength: 12
+                }
+            ],
+            buffers: [
+                {
+                    byteLength: source.byteLength,
+                    extras: {
+                        _pipeline: {
+                            source: source
+                        }
+                    }
+                }
+            ]
+        };
+
+        updateAccessorComponentTypes(gltf);
+
+        expect(gltf.accessors.length).toBe(3);
+        expect(gltf.bufferViews.length).toBe(5);
+        expect(gltf.buffers.length).toBe(3);
+
+        expect(gltf.accessors[0].componentType).toBe(WebGLConstants.UNSIGNED_BYTE);
+        expect(gltf.accessors[0].bufferView).toBe(3);
+        expect(gltf.bufferViews[3].buffer).toBe(1);
+        expect(gltf.bufferViews[3].byteLength).toBe(96);
+
+        expect(gltf.accessors[1].componentType).toBe(WebGLConstants.UNSIGNED_SHORT);
+        expect(gltf.accessors[1].bufferView).toBe(4);
+        expect(gltf.bufferViews[4].buffer).toBe(2);
+        expect(gltf.bufferViews[4].byteLength).toBe(192);
+
+        expect(gltf.accessors[2].componentType).toBe(WebGLConstants.UNSIGNED_SHORT);
+        expect(gltf.accessors[2].bufferView).toBe(2);
+    });
+
+    it('converts weights accessor types', function() {
+        var gltf = {
+            meshes: [
+                {
+                    primitives: [
+                        {
+                            attributes: {
+                                WEIGHTS_0: 0
+                            }
+                        }, {
+                            attributes: {
+                                WEIGHTS_0: 1
+                            }
+                        }, {
+                            attributes: {
+                                WEIGHTS_0: 2
+                            }
+                        }
+                    ]
+                }
+            ],
+            accessors: [
+                {
+                    bufferView: 0,
+                    componentType: WebGLConstants.FLOAT,
+                    count: 24,
+                    type: 'VEC4'
+                }, {
+                    bufferView: 1,
+                    componentType: WebGLConstants.BYTE,
+                    count: 24,
+                    type: 'VEC4'
+                }, {
+                    bufferView: 2,
+                    componentType: WebGLConstants.SHORT,
+                    count: 24,
+                    type: 'VEC4'
+                }
+            ],
+            bufferViews: [
+                {
+                    buffer: 0,
+                    byteLength: 12
+                }, {
+                    buffer: 0,
+                    byteOffset: 12,
+                    byteLength: 12
+                }, {
+                    buffer: 0,
+                    byteLength: 12
+                }
+            ],
+            buffers: [
+                {
+                    byteLength: source.byteLength,
+                    extras: {
+                        _pipeline: {
+                            source: source
+                        }
+                    }
+                }
+            ]
+        };
+
+        updateAccessorComponentTypes(gltf);
+
+        expect(gltf.accessors.length).toBe(3);
+        expect(gltf.bufferViews.length).toBe(5);
+        expect(gltf.buffers.length).toBe(3);
+
+        expect(gltf.accessors[0].componentType).toBe(WebGLConstants.FLOAT);
+        expect(gltf.accessors[0].bufferView).toBe(0);
+
+        expect(gltf.accessors[1].componentType).toBe(WebGLConstants.UNSIGNED_BYTE);
+        expect(gltf.accessors[1].bufferView).toBe(3);
+        expect(gltf.bufferViews[3].buffer).toBe(1);
+        expect(gltf.bufferViews[3].byteLength).toBe(96);
+
+        expect(gltf.accessors[2].componentType).toBe(WebGLConstants.UNSIGNED_SHORT);
+        expect(gltf.accessors[2].bufferView).toBe(4);
+        expect(gltf.bufferViews[4].buffer).toBe(2);
+        expect(gltf.bufferViews[4].byteLength).toBe(192);
+    });
+});

--- a/specs/lib/updateAccessorComponentTypeSpec.js
+++ b/specs/lib/updateAccessorComponentTypeSpec.js
@@ -1,12 +1,23 @@
 'use strict';
 var Cesium = require('cesium');
+var readResources = require('../../lib/readResources');
 var updateAccessorComponentTypes = require('../../lib/updateAccessorComponentTypes');
 
 var WebGLConstants = Cesium.WebGLConstants;
 
-var source = Buffer.from((new Float32Array([-2.0, 1.0, 0.0, 1.0, 2.0, 3.0])).buffer);
+var buffer;
 
 describe('updateAccessorComponentTypes', function() {
+    beforeAll(function() {
+        var source = Buffer.from((new Float32Array([-2.0, 1.0, 0.0, 1.0, 2.0, 3.0])).buffer);
+        var byteLength = source.length;
+        var dataUri = 'data:application/octet-stream;base64,' + source.toString('base64');
+        buffer = {
+            uri: dataUri,
+            byteLength: byteLength
+        };
+    });
+
     it('converts joints accessor types', function() {
         var gltf = {
             meshes: [
@@ -59,36 +70,29 @@ describe('updateAccessorComponentTypes', function() {
                     byteLength: 12
                 }
             ],
-            buffers: [
-                {
-                    byteLength: source.byteLength,
-                    extras: {
-                        _pipeline: {
-                            source: source
-                        }
-                    }
-                }
-            ]
+            buffers: [buffer]
         };
 
-        updateAccessorComponentTypes(gltf);
+        return readResources(gltf).then(function(gltf) {
+            updateAccessorComponentTypes(gltf);
 
-        expect(gltf.accessors.length).toBe(3);
-        expect(gltf.bufferViews.length).toBe(5);
-        expect(gltf.buffers.length).toBe(3);
+            expect(gltf.accessors.length).toBe(3);
+            expect(gltf.bufferViews.length).toBe(5);
+            expect(gltf.buffers.length).toBe(3);
 
-        expect(gltf.accessors[0].componentType).toBe(WebGLConstants.UNSIGNED_BYTE);
-        expect(gltf.accessors[0].bufferView).toBe(3);
-        expect(gltf.bufferViews[3].buffer).toBe(1);
-        expect(gltf.bufferViews[3].byteLength).toBe(96);
+            expect(gltf.accessors[0].componentType).toBe(WebGLConstants.UNSIGNED_BYTE);
+            expect(gltf.accessors[0].bufferView).toBe(3);
+            expect(gltf.bufferViews[3].buffer).toBe(1);
+            expect(gltf.bufferViews[3].byteLength).toBe(96);
 
-        expect(gltf.accessors[1].componentType).toBe(WebGLConstants.UNSIGNED_SHORT);
-        expect(gltf.accessors[1].bufferView).toBe(4);
-        expect(gltf.bufferViews[4].buffer).toBe(2);
-        expect(gltf.bufferViews[4].byteLength).toBe(192);
+            expect(gltf.accessors[1].componentType).toBe(WebGLConstants.UNSIGNED_SHORT);
+            expect(gltf.accessors[1].bufferView).toBe(4);
+            expect(gltf.bufferViews[4].buffer).toBe(2);
+            expect(gltf.bufferViews[4].byteLength).toBe(192);
 
-        expect(gltf.accessors[2].componentType).toBe(WebGLConstants.UNSIGNED_SHORT);
-        expect(gltf.accessors[2].bufferView).toBe(2);
+            expect(gltf.accessors[2].componentType).toBe(WebGLConstants.UNSIGNED_SHORT);
+            expect(gltf.accessors[2].bufferView).toBe(2);
+        });
     });
 
     it('converts weights accessor types', function() {
@@ -143,35 +147,28 @@ describe('updateAccessorComponentTypes', function() {
                     byteLength: 12
                 }
             ],
-            buffers: [
-                {
-                    byteLength: source.byteLength,
-                    extras: {
-                        _pipeline: {
-                            source: source
-                        }
-                    }
-                }
-            ]
+            buffers: [buffer]
         };
 
-        updateAccessorComponentTypes(gltf);
+        return readResources(gltf).then(function(gltf) {
+            updateAccessorComponentTypes(gltf);
 
-        expect(gltf.accessors.length).toBe(3);
-        expect(gltf.bufferViews.length).toBe(5);
-        expect(gltf.buffers.length).toBe(3);
+            expect(gltf.accessors.length).toBe(3);
+            expect(gltf.bufferViews.length).toBe(5);
+            expect(gltf.buffers.length).toBe(3);
 
-        expect(gltf.accessors[0].componentType).toBe(WebGLConstants.FLOAT);
-        expect(gltf.accessors[0].bufferView).toBe(0);
+            expect(gltf.accessors[0].componentType).toBe(WebGLConstants.FLOAT);
+            expect(gltf.accessors[0].bufferView).toBe(0);
 
-        expect(gltf.accessors[1].componentType).toBe(WebGLConstants.UNSIGNED_BYTE);
-        expect(gltf.accessors[1].bufferView).toBe(3);
-        expect(gltf.bufferViews[3].buffer).toBe(1);
-        expect(gltf.bufferViews[3].byteLength).toBe(96);
+            expect(gltf.accessors[1].componentType).toBe(WebGLConstants.UNSIGNED_BYTE);
+            expect(gltf.accessors[1].bufferView).toBe(3);
+            expect(gltf.bufferViews[3].buffer).toBe(1);
+            expect(gltf.bufferViews[3].byteLength).toBe(96);
 
-        expect(gltf.accessors[2].componentType).toBe(WebGLConstants.UNSIGNED_SHORT);
-        expect(gltf.accessors[2].bufferView).toBe(4);
-        expect(gltf.bufferViews[4].buffer).toBe(2);
-        expect(gltf.bufferViews[4].byteLength).toBe(192);
+            expect(gltf.accessors[2].componentType).toBe(WebGLConstants.UNSIGNED_SHORT);
+            expect(gltf.accessors[2].bufferView).toBe(4);
+            expect(gltf.bufferViews[4].buffer).toBe(2);
+            expect(gltf.bufferViews[4].byteLength).toBe(192);
+        });
     });
 });

--- a/specs/lib/updateVersionSpec.js
+++ b/specs/lib/updateVersionSpec.js
@@ -583,6 +583,7 @@ describe('updateVersion', function() {
                 // animation.parameters removed
                 var animation = gltf.animations[0];
                 var sampler = animation.samplers[0];
+                expect(sampler.name).toBeUndefined();
                 expect(sampler.input).toEqual(2);
                 expect(sampler.output).toEqual(3);
                 expect(animation.parameters).toBeUndefined();
@@ -640,6 +641,9 @@ describe('updateVersion', function() {
                 expect(primitive.attributes.APPLICATIONSPECIFIC).toBeUndefined();
                 expect(primitive.attributes._APPLICATIONSPECIFIC).toEqual(0);
                 expect(primitive.attributes._TEMPERATURE).toEqual(10);
+
+                // JOINTS_0 has converted component type
+                expect(gltf.accessors[8].componentType).toBe(WebGLConstants.UNSIGNED_SHORT);
 
                 // Clamp camera parameters
                 var camera = gltf.cameras[0];


### PR DESCRIPTION
* Remove sampler `name` property to be consistant with glTF validator.
* Update accessors referenced by JOINTS_0 and WEIGHTS_0 attributes to use correct component types.
> The number of joints that influence one vertex is limited to 4, so referenced accessors must have VEC4 type and following component formats:
>
> JOINTS_0: UNSIGNED_BYTE or UNSIGNED_SHORT
> WEIGHTS_0: FLOAT, or normalized UNSIGNED_BYTE, or normalized UNSIGNED_SHORT