### PR TITLE
Require animation sampler accessor min and max

### DIFF
--- a/lib/updateVersion.js
+++ b/lib/updateVersion.js
@@ -815,6 +815,17 @@ function requirePositionAccessorMinMax(gltf) {
     });
 }
 
+function requireAnimationAccessorMinMax(gltf) {
+    ForEach.animationSampler(gltf, function(sampler) {
+        var accessor = gltf.accessors[sampler.input];
+        if (!defined(accessor.min) || !defined(accessor.max)) {
+            var minMax = findAccessorMinMax(gltf, accessor);
+            accessor.min = minMax.min;
+            accessor.max = minMax.max;
+        }
+    });
+}
+
 function glTF10to20(gltf) {
     gltf.asset = defaultValue(gltf.asset, {});
     gltf.asset.version = '2.0';
@@ -834,6 +845,8 @@ function glTF10to20(gltf) {
     moveByteStrideToBufferView(gltf);
     // accessor.min and accessor.max must be defined for accessors containing POSITION attributes
     requirePositionAccessorMinMax(gltf);
+    // An animation sampler's input accessor must have min and max properties defined
+    requireAnimationAccessorMinMax(gltf);
     // buffer.type is unnecessary and should be removed
     removeBufferType(gltf);
     // Remove format, internalFormat, target, and type

--- a/lib/updateVersion.js
+++ b/lib/updateVersion.js
@@ -816,13 +816,15 @@ function requirePositionAccessorMinMax(gltf) {
 }
 
 function requireAnimationAccessorMinMax(gltf) {
-    ForEach.animationSampler(gltf, function(sampler) {
-        var accessor = gltf.accessors[sampler.input];
-        if (!defined(accessor.min) || !defined(accessor.max)) {
-            var minMax = findAccessorMinMax(gltf, accessor);
-            accessor.min = minMax.min;
-            accessor.max = minMax.max;
-        }
+    ForEach.animation(gltf, function(animation) {
+        ForEach.animationSampler(animation, function(sampler) {
+            var accessor = gltf.accessors[sampler.input];
+            if (!defined(accessor.min) || !defined(accessor.max)) {
+                var minMax = findAccessorMinMax(gltf, accessor);
+                accessor.min = minMax.min;
+                accessor.max = minMax.max;
+            }
+        });
     });
 }
 

--- a/specs/lib/updateVersionSpec.js
+++ b/specs/lib/updateVersionSpec.js
@@ -661,10 +661,12 @@ describe('updateVersion', function() {
                 });
 
                 // Min and max are added to all animation sampler input accessors
-                ForEach.animationSampler(gltf, function(sampler) {
-                    var accessor = gltf.accessors[sampler.input];
-                    expect(accessor.min.length).toEqual(numberOfComponentsForType(accessor.type));
-                    expect(accessor.max.length).toEqual(numberOfComponentsForType(accessor.type));
+                ForEach.animation(gltf, function(animation) {
+                    ForEach.animationSampler(animation, function(sampler) {
+                        var accessor = gltf.accessors[sampler.input];
+                        expect(accessor.min.length).toEqual(numberOfComponentsForType(accessor.type));
+                        expect(accessor.max.length).toEqual(numberOfComponentsForType(accessor.type));
+                    });
                 });
 
                 // byteStride moved from accessor to bufferView

--- a/specs/lib/updateVersionSpec.js
+++ b/specs/lib/updateVersionSpec.js
@@ -660,6 +660,13 @@ describe('updateVersion', function() {
                     expect(accessor.max.length).toEqual(numberOfComponentsForType(accessor.type));
                 });
 
+                // Min and max are added to all animation sampler input accessors
+                ForEach.animationSampler(gltf, function(sampler) {
+                    var accessor = gltf.accessors[sampler.input];
+                    expect(accessor.min.length).toEqual(numberOfComponentsForType(accessor.type));
+                    expect(accessor.max.length).toEqual(numberOfComponentsForType(accessor.type));
+                });
+
                 // byteStride moved from accessor to bufferView
                 var positionAccessor = gltf.accessors[primitive.attributes.POSITION];
                 var normalAccessor = gltf.accessors[primitive.attributes.NORMAL];


### PR DESCRIPTION
To comply with
> Animation Sampler's input accessor must have min and max properties defined.