### PR TITLE
Remove empty nodes when upgrading version

### DIFF
--- a/lib/updateVersion.js
+++ b/lib/updateVersion.js
@@ -11,11 +11,13 @@ var moveTechniquesToExtension = require('./moveTechniquesToExtension');
 var removeUnusedElements = require('./removeUnusedElements');
 
 var Cartesian3 = Cesium.Cartesian3;
+var Cartesian4 = Cesium.Cartesian4;
 var clone = Cesium.clone;
 var ComponentDatatype = Cesium.ComponentDatatype;
 var defaultValue = Cesium.defaultValue;
 var defined = Cesium.defined;
 var isArray = Cesium.isArray;
+var Matrix4 = Cesium.Matrix4;
 var Quaternion = Cesium.Quaternion;
 var WebGLConstants = Cesium.WebGLConstants;
 
@@ -815,6 +817,58 @@ function requirePositionAccessorMinMax(gltf) {
     });
 }
 
+function isNodeEmpty(node) {
+    return (!defined(node.children) || node.children.length === 0) &&
+        (!defined(node.meshes) || node.meshes.length === 0) &&
+        !defined(node.camera) && !defined(node.skin) && !defined(node.skeletons) && !defined(node.jointName) &&
+        (!defined(node.translation) || Cartesian3.fromArray(node.translation).equals(Cartesian3.ZERO)) &&
+        (!defined(node.scale) || Cartesian3.fromArray(node.scale).equals(new Cartesian3(1.0, 1.0, 1.0))) &&
+        (!defined(node.rotation) || Cartesian4.fromArray(node.rotation).equals(new Cartesian4(0.0, 0.0, 0.0, 1.0))) &&
+        (!defined(node.matrix) || Matrix4.fromColumnMajorArray(node.matrix).equals(Matrix4.IDENTITY));
+}
+
+function deleteNode(gltf, nodeId) {
+    // Remove from list of nodes in scene
+    ForEach.scene(gltf, function(scene) {
+        var sceneNodes = scene.nodes;
+        if (defined(sceneNodes)) {
+            var sceneNodesLength = sceneNodes.length;
+            for (var i = sceneNodesLength; i >= 0; --i) {
+                if (sceneNodes[i] === nodeId) {
+                    sceneNodes.splice(i, 1);
+                    return;
+                }
+            }
+        }
+    });
+
+    // Remove parent node reference to this node, and delete the parent if also empty
+    ForEach.node(gltf, function(parentNode, parentNodeId) {
+        if (defined(parentNode.children)) {
+            var index = parentNode.children.indexOf(nodeId);
+            if (index > -1) {
+                parentNode.children.splice(index, 1);
+
+                if (isNodeEmpty(parentNode)) {
+                    deleteNode(gltf, parentNodeId);
+                }
+            }
+        }
+    });
+
+    delete gltf.nodes[nodeId];
+}
+
+function removeEmptyNodes(gltf) {
+    ForEach.node(gltf, function(node, nodeId) {
+        if (isNodeEmpty(node)) {
+            deleteNode(gltf, nodeId);
+        }
+    });
+
+    return gltf;
+}
+
 function glTF10to20(gltf) {
     gltf.asset = defaultValue(gltf.asset, {});
     gltf.asset.version = '2.0';
@@ -822,6 +876,8 @@ function glTF10to20(gltf) {
     updateInstanceTechniques(gltf);
     // animation.samplers now refers directly to accessors and animation.parameters should be removed
     removeAnimationSamplersIndirection(gltf);
+    // Remove empty nodes and re-assign referencing indices
+    removeEmptyNodes(gltf);
     // Top-level objects are now arrays referenced by index instead of id
     objectsToArrays(gltf);
     // asset.profile no longer exists

--- a/lib/updateVersion.js
+++ b/lib/updateVersion.js
@@ -842,7 +842,7 @@ function deleteNode(gltf, nodeId) {
         }
     });
 
-    // Remove parent node reference to this node, and delete the parent if also empty
+    // Remove parent node's reference to this node, and delete the parent if also empty
     ForEach.node(gltf, function(parentNode, parentNodeId) {
         if (defined(parentNode.children)) {
             var index = parentNode.children.indexOf(nodeId);

--- a/specs/lib/updateVersionSpec.js
+++ b/specs/lib/updateVersionSpec.js
@@ -509,7 +509,28 @@ describe('updateVersion', function() {
                     ]
                 },
                 nodeWithoutChildren: {
-                    children: []
+                    children: [],
+                    camera: 0
+                },
+                nonEmptyNodeParent: {
+                    children: [
+                        'emptyNode'
+                    ],
+                    scale: [1, 2, 3]
+                },
+                emptyNodeParent: {
+                    children: [
+                        'emptyNode'
+                    ]
+                },
+                emptyNode: {
+                    children: [],
+                    matrix: [
+                        1, 0, 0, 0,
+                        0, 1, 0, 0,
+                        0, 0, 1, 0,
+                        0, 0, 0, 1
+                    ]
                 }
             },
             programs: {
@@ -528,7 +549,8 @@ describe('updateVersion', function() {
             scenes: {
                 defaultScene: {
                     nodes: [
-                        'rootTransform'
+                        'rootTransform',
+                        'emptyNodeParent'
                     ]
                 }
             },
@@ -590,6 +612,12 @@ describe('updateVersion', function() {
                 // Empty arrays removed
                 expect(gltf.samplers).toBeUndefined();
                 expect(getNodeByName(gltf, 'nodeWithoutChildren').children).toBeUndefined();
+
+                // Empty nodes removed
+                expect(getNodeByName(gltf, 'nonEmptyNodeParent')).toBeDefined();
+                expect(getNodeByName(gltf, 'emptyNodeParent')).toBeUndefined();
+                expect(getNodeByName(gltf, 'emptyNode')).toBeUndefined();
+                expect(gltf.scenes[0].nodes.length).toBe(1);
 
                 // Expect material values to be moved to material KHR_techniques_webgl extension
                 var material = gltf.materials[0];


### PR DESCRIPTION
Remove empty nodes when updating version, checks parents for deletion recursively, and removes deleted nodes from the scene list. I do not believe we have to check anywhere else to update after deleting, as if the empty nodes were referenced, it wouldn't be a valid glTF in the first place.

Can test this with `CesiumMilkTruck` 1.0 model.