### PR TITLE
Extension related fixes

### DIFF
--- a/lib/moveTechniquesToExtension.js
+++ b/lib/moveTechniquesToExtension.js
@@ -29,6 +29,10 @@ function moveTechniquesToExtension(gltf) {
             techniques: []
         };
 
+        // Some 1.1 models have a glExtensionsUsed property that can be transferred to program.glExtensions
+        var glExtensions = gltf.glExtensionsUsed;
+        delete gltf.glExtensionsUsed;
+
         ForEach.technique(gltf, function (techniqueLegacy, techniqueIndex) {
             var technique = {
                 name: techniqueLegacy.name,
@@ -63,7 +67,8 @@ function moveTechniquesToExtension(gltf) {
             var program = {
                 name: programLegacy.name,
                 fragmentShader: undefined,
-                vertexShader: undefined
+                vertexShader: undefined,
+                glExtensions: glExtensions
             };
 
             var fs = gltf.shaders[programLegacy.fragmentShader];

--- a/lib/removeExtension.js
+++ b/lib/removeExtension.js
@@ -20,16 +20,20 @@ function removeExtension(gltf, extension) {
     removeExtensionsUsed(gltf, extension); // Also removes from extensionsRequired
 
     if (extension === 'CESIUM_RTC') {
-        ForEach.technique(gltf, function(technique) {
-            ForEach.techniqueUniform(technique, function(uniform) {
-                if (uniform.semantic === 'CESIUM_RTC_MODELVIEW') {
-                    uniform.semantic = 'MODELVIEW';
-                }
-            });
-        });
+        removeCesiumRTC(gltf);
     }
 
     return removeExtensionAndTraverse(gltf, extension);
+}
+
+function removeCesiumRTC(gltf) {
+    ForEach.technique(gltf, function(technique) {
+        ForEach.techniqueUniform(technique, function(uniform) {
+            if (uniform.semantic === 'CESIUM_RTC_MODELVIEW') {
+                uniform.semantic = 'MODELVIEW';
+            }
+        });
+    });
 }
 
 function removeExtensionAndTraverse(object, extension) {

--- a/lib/removeExtension.js
+++ b/lib/removeExtension.js
@@ -1,5 +1,6 @@
 'use strict';
 var Cesium = require('cesium');
+var ForEach = require('./ForEach');
 var removeExtensionsUsed = require('./removeExtensionsUsed');
 
 var defined = Cesium.defined;
@@ -17,6 +18,17 @@ module.exports = removeExtension;
  */
 function removeExtension(gltf, extension) {
     removeExtensionsUsed(gltf, extension); // Also removes from extensionsRequired
+
+    if (extension === 'CESIUM_RTC') {
+        ForEach.technique(gltf, function(technique) {
+            ForEach.techniqueUniform(technique, function(uniform) {
+                if (uniform.semantic === 'CESIUM_RTC_MODELVIEW') {
+                    uniform.semantic = 'MODELVIEW';
+                }
+            });
+        });
+    }
+
     return removeExtensionAndTraverse(gltf, extension);
 }
 

--- a/specs/lib/removeExtensionSpec.js
+++ b/specs/lib/removeExtensionSpec.js
@@ -1,5 +1,8 @@
 'use strict';
+var Cesium = require('cesium');
 var removeExtension = require('../../lib/removeExtension');
+
+var WebGLConstants = Cesium.WebGLConstants;
 
 describe('removeExtension', function() {
     it('removes extension', function() {
@@ -86,4 +89,42 @@ describe('removeExtension', function() {
         removeExtension(gltf, 'extension1');
         expect(emptyGltf).toEqual({});
     });
+
+    it('removes CESIUM_RTC extension', function() {
+        var gltf = {
+            extensionsRequired: [
+                'CESIUM_RTC',
+                'KHR_techniques_webgl'
+            ],
+            extensionsUsed: [
+                'CESIUM_RTC',
+                'KHR_techniques_webgl'
+            ],
+            extensions: {
+                CESIUM_RTC: {
+                    center: [1.0, 2.0, 3.0]
+                },
+                KHR_techniques_webgl: {
+                    techniques: [
+                        {
+                            uniforms: {
+                                u_modelViewMatrix: {
+                                    type: WebGLConstants.FLOAT_MAT4,
+                                    semantic: 'CESIUM_RTC_MODELVIEW'
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        };
+        var extension = removeExtension(gltf, 'CESIUM_RTC');
+        expect(extension).toEqual({
+            center: [1.0, 2.0, 3.0]
+        });
+        expect(gltf.extensionsRequired).toEqual(['KHR_techniques_webgl']);
+        expect(gltf.extensionsUsed).toEqual(['KHR_techniques_webgl']);
+        expect(gltf.extensions.KHR_techniques_webgl.techniques[0].uniforms.u_modelViewMatrix.semantic).toBe('MODELVIEW');
+    });
+
 });

--- a/specs/lib/updateVersionSpec.js
+++ b/specs/lib/updateVersionSpec.js
@@ -575,7 +575,8 @@ describe('updateVersion', function() {
                     target: WebGLConstants.TEXTURE_2D,
                     type: WebGLConstants.UNSIGNED_BYTE
                 }
-            ]
+            ],
+            glExtensionsUsed: ['OES_element_index_uint']
         };
 
         expect(readResources(gltf)
@@ -719,6 +720,10 @@ describe('updateVersion', function() {
                 expect(positionAccessor.byteStride).toBeUndefined();
                 expect(normalAccessor.byteStride).toBeUndefined();
                 expect(texcoordAccessor.byteStride).toBeUndefined();
+
+                // glExtensionsUsed removed
+                expect(gltf.glExtensionsUsed).toBeUndefined();
+                expect(gltf.extensions.KHR_techniques_webgl.programs[0].glExtensions).toEqual(['OES_element_index_uint']);
             }), done).toResolve();
     });
 });


### PR DESCRIPTION
Two random issues I noticed when upgrading some 3D Tileset to glTF 2.0
* Some glTFs have a `glExtensionsUsed` property which was added somewhere between 1.0 and 2.0. If defined, it is moved to the `KHR_techniques_webgl` programs objects.
* Added some custom code from removing the `CESIUM_RTC` extension.

@ggetz can you review?