### PR TITLE
Selectively merge buffers

### DIFF
--- a/lib/compressDracoMeshes.js
+++ b/lib/compressDracoMeshes.js
@@ -220,6 +220,10 @@ function compressDracoMeshes(gltf, options) {
             addExtensionsRequired(gltf, 'KHR_draco_mesh_compression');
         }
         removeUnusedElements(gltf);
+
+        if (uncompressedFallback) {
+            assignMergedBufferNames(gltf);
+        }
     }
 
     return gltf;
@@ -266,6 +270,36 @@ function copyCompressedExtensionToPrimitive(primitive, compressedPrimitive) {
         bufferView: dracoExtension.bufferView,
         attributes: dracoExtension.attributes
     };
+}
+
+function assignBufferViewName(gltf, bufferViewId, name) {
+    var bufferView = gltf.bufferViews[bufferViewId];
+    var buffer = gltf.buffers[bufferView.buffer];
+    buffer.extras._pipeline.mergedBufferName = name;
+}
+
+function assignAccessorName(gltf, accessorId, name) {
+    var bufferViewId = gltf.accessors[accessorId].bufferView;
+    if (defined(bufferViewId)) {
+        assignBufferViewName(gltf, bufferViewId, name);
+    }
+}
+
+function assignMergedBufferNames(gltf) {
+    ForEach.accessorContainingVertexAttributeData(gltf, function(accessorId) {
+        assignAccessorName(gltf, accessorId, 'uncompressed');
+    });
+    ForEach.accessorContainingIndexData(gltf, function(accessorId) {
+        assignAccessorName(gltf, accessorId, 'uncompressed');
+    });
+    ForEach.mesh(gltf, function(mesh) {
+        ForEach.meshPrimitive(mesh, function(primitive) {
+            if (defined(primitive.extensions) &&
+                defined(primitive.extensions.KHR_draco_mesh_compression)) {
+                assignBufferViewName(gltf, primitive.extensions.KHR_draco_mesh_compression.bufferView, 'draco');
+            }
+        });
+    });
 }
 
 function getAddAttributeFunctionName(componentType) {

--- a/lib/gltfToGlb.js
+++ b/lib/gltfToGlb.js
@@ -4,6 +4,7 @@ var getJsonBufferPadded = require('./getJsonBufferPadded');
 var processGltf = require('./processGltf');
 
 var defaultValue = Cesium.defaultValue;
+var defined = Cesium.defined;
 
 module.exports = gltfToGlb;
 
@@ -33,7 +34,12 @@ function getGlb(gltf, binaryBuffer) {
     var jsonBuffer = getJsonBufferPadded(gltf);
 
     // Allocate buffer (Global header) + (JSON chunk header) + (JSON chunk) + (Binary chunk header) + (Binary chunk)
-    var glbLength = 12 + 8 + jsonBuffer.length + 8 + binaryBuffer.length;
+    var glbLength = 12 + 8 + jsonBuffer.length;
+
+    if (defined(binaryBuffer)) {
+        glbLength += 8 + binaryBuffer.length;
+    }
+
     var glb = Buffer.alloc(glbLength);
 
     // Write binary glTF header (magic, version, length)
@@ -55,13 +61,16 @@ function getGlb(gltf, binaryBuffer) {
     jsonBuffer.copy(glb, byteOffset);
     byteOffset += jsonBuffer.length;
 
-    // Write Binary Chunk header (length, type)
-    glb.writeUInt32LE(binaryBuffer.length, byteOffset);
-    byteOffset += 4;
-    glb.writeUInt32LE(0x004E4942, byteOffset); // BIN
-    byteOffset += 4;
+    if (defined(binaryBuffer)) {
+        // Write Binary Chunk header (length, type)
+        glb.writeUInt32LE(binaryBuffer.length, byteOffset);
+        byteOffset += 4;
+        glb.writeUInt32LE(0x004E4942, byteOffset); // BIN
+        byteOffset += 4;
 
-    // Write Binary Chunk
-    binaryBuffer.copy(glb, byteOffset);
+        // Write Binary Chunk
+        binaryBuffer.copy(glb, byteOffset);
+    }
+
     return glb;
 }

--- a/lib/mergeBuffers.js
+++ b/lib/mergeBuffers.js
@@ -1,8 +1,6 @@
 'use strict';
 var Cesium = require('cesium');
 var ForEach = require('./ForEach');
-var addToArray = require('./addToArray');
-var hasExtension = require('./hasExtension.js');
 
 var defaultValue = Cesium.defaultValue;
 var defined = Cesium.defined;
@@ -10,86 +8,79 @@ var defined = Cesium.defined;
 module.exports = mergeBuffers;
 
 /**
- * Merge all buffers.
+ * Merge all buffers. Buffers with the same extras._pipeline.mergedBufferName will be merged together.
  *
  * @param {Object} gltf A javascript object containing a glTF asset.
- * @param {String} defaultName The default name of the buffer data files.
- * @param {Boolean} uncompressedFallback If set split up the buffers into uncompressed meshes, compressed meshes, and non-meshes. If not set merge all buffers into one buffer.
+ * @param {String} [defaultName] The default name of the buffer data files.
  * @returns {Object} The glTF asset with its buffers merged.
  *
  * @private
  */
-function mergeBuffers(gltf, defaultName, uncompressedFallback) {
+function mergeBuffers(gltf, defaultName) {
     var baseBufferName = defaultName;
     ForEach.buffer(gltf, function(buffer) {
         baseBufferName = defaultValue(buffer.name, baseBufferName);
     });
 
-    var bufferList = getBufferList(gltf, baseBufferName, uncompressedFallback);
+    var placeholderName = 'other-buffers';
 
-    // Add array of Buffers to merge.
-    for (var i = 0; i < bufferList.length; ++i) {
-        bufferList[i].buffersToMerge = [];
-        bufferList[i].lengthSoFar = 0;
-        bufferList[i].bufferId = i;
-    }
+    var buffersToMerge = {};
 
-    var bufferViewId = -1;
     ForEach.bufferView(gltf, function(bufferView) {
-        ++bufferViewId;
-
-        if (defined(gltf.buffers[bufferView.buffer])) {
-            // Get new buffer
-            var newBuffer = bufferList[0];
-
-            // Check if the bufferView should be associated with a different buffer.
-            for (var j = 1; j < bufferList.length; ++j) {
-                if (defined(bufferList[j].bufferViews)) {
-                    if (bufferList[j].bufferViews[bufferViewId]) {
-                        newBuffer = bufferList[j];
-                        break;
-                    }
-                }
-            }
-
-            // Check if we need to add padding beofre we add data to the buffer.
-            var bufferViewPadding = getPadding(newBuffer.lengthSoFar);
-            addToArray(newBuffer.buffersToMerge, bufferViewPadding);
-            newBuffer.lengthSoFar += bufferViewPadding.length;
-
-            var buffer = gltf.buffers[bufferView.buffer];
-            var sourceBufferViewData = Buffer.from(buffer.extras._pipeline.source.slice(bufferView.byteOffset,
-                bufferView.byteOffset + bufferView.byteLength));
-
-            // Copy the data from the source buffer to new buffer.
-            bufferView.byteOffset = newBuffer.lengthSoFar;
-            bufferView.buffer = newBuffer.bufferId;
-
-            addToArray(newBuffer.buffersToMerge, sourceBufferViewData);
-            newBuffer.lengthSoFar += sourceBufferViewData.length;
+        var buffer = gltf.buffers[bufferView.buffer];
+        var mergedName = buffer.extras._pipeline.mergedBufferName;
+        if (defined(baseBufferName) && defined(mergedName)) {
+            mergedName = baseBufferName + '-' + mergedName;
+        } else {
+            mergedName = defaultValue(defaultValue(mergedName, baseBufferName), placeholderName);
         }
+        if (!defined(buffersToMerge[mergedName])) {
+            buffersToMerge[mergedName] = {
+                buffers: [],
+                length: 0,
+                index: Object.keys(buffersToMerge).length
+            };
+        }
+        var buffers = buffersToMerge[mergedName].buffers;
+        var length = buffersToMerge[mergedName].length;
+        var index = buffersToMerge[mergedName].index;
+
+        var sourceBufferViewData = Buffer.from(buffer.extras._pipeline.source.slice(bufferView.byteOffset, bufferView.byteOffset + bufferView.byteLength));
+        var bufferViewPadding = getPadding(length);
+        buffers.push(bufferViewPadding);
+        length += bufferViewPadding.length;
+
+        bufferView.byteOffset = length;
+        bufferView.buffer = index;
+
+        buffers.push(sourceBufferViewData);
+        length += sourceBufferViewData.length;
+
+        buffersToMerge[mergedName].length = length;
     });
 
-    // Clear the current buffers.
-    gltf.buffers = [];
+    var buffersLength = Object.keys(buffersToMerge).length;
+    gltf.buffers = new Array(buffersLength);
 
-    for (var k = 0; k < bufferList.length; ++k) {
-        var newBuffer = bufferList[k];
-
-        var bufferPadding = getPadding(newBuffer.lengthSoFar);
-        addToArray(newBuffer.buffersToMerge, bufferPadding);
-        var mergedSource = Buffer.concat(newBuffer.buffersToMerge);
-
-        var bufferElement = {
-            name: newBuffer.name,
-            byteLength: mergedSource.length,
-            extras: {
-                _pipeline: {
-                    source: mergedSource
+    for (var mergedName in buffersToMerge) {
+        if (buffersToMerge.hasOwnProperty(mergedName)) {
+            var buffers = buffersToMerge[mergedName].buffers;
+            var length = buffersToMerge[mergedName].length;
+            var index = buffersToMerge[mergedName].index;
+            var bufferPadding = getPadding(length);
+            buffers.push(bufferPadding);
+            var mergedSource = Buffer.concat(buffers);
+            var name = mergedName === placeholderName ? undefined : mergedName;
+            gltf.buffers[index] = {
+                name: name,
+                byteLength: mergedSource.length,
+                extras: {
+                    _pipeline: {
+                        source: mergedSource
+                    }
                 }
-            }
-        };
-        addToArray(gltf.buffers, bufferElement);
+            };
+        }
     }
 
     return gltf;
@@ -102,99 +93,4 @@ function getPadding(length) {
         return Buffer.alloc(bytesToPad);
     }
     return Buffer.alloc(0);
-}
-
-function getBufferList(gltf, baseBufferName, uncompressedFallback) {
-    var bufferList = [];
-    if (uncompressedFallback) {
-        bufferList = getBufferListWithFallback(gltf, baseBufferName);
-    } else {
-        // Only one buffer is needed.
-        var newBufferElement = {
-            name: baseBufferName
-        };
-        bufferList = [];
-        addToArray(bufferList, newBufferElement);
-    }
-    return bufferList;
-}
-
-function getBufferListWithFallback(gltf, baseBufferName) {
-    var uncompressedMeshBufferViewIds = {};
-    var compressedMeshBufferViewIds = {};
-    var nonMeshBufferViewIds = {};
-    var meshBufferViewIds = {};
-
-    // Figure out which bufferViews are associated with compressed and
-    // uncompressed data.
-    ForEach.mesh(gltf, function(mesh) {
-        ForEach.meshPrimitive(mesh, function(primitive) {
-            ForEach.meshPrimitiveAttribute(primitive, function(accessorId) {
-                var accessor = gltf.accessors[accessorId];
-                if (defined(accessor.bufferView)) {
-                    uncompressedMeshBufferViewIds[accessor.bufferView] = true;
-                    meshBufferViewIds.uncompressed = uncompressedMeshBufferViewIds;
-                }
-            });
-            ForEach.meshPrimitiveTarget(primitive, function(target) {
-                ForEach.meshPrimitiveTargetAttribute(target, function(accessorId) {
-                    var accessor = gltf.accessors[accessorId];
-                    if (defined(accessor.bufferView)) {
-                        uncompressedMeshBufferViewIds[accessor.bufferView] = true;
-                        meshBufferViewIds.uncompressed = uncompressedMeshBufferViewIds;
-                    }
-                });
-            });
-            var indices = primitive.indices;
-            if (defined(indices)) {
-                var accessor = gltf.accessors[indices];
-                if (defined(accessor.bufferView)) {
-                    uncompressedMeshBufferViewIds[accessor.bufferView] = true;
-                    meshBufferViewIds.uncompressed = uncompressedMeshBufferViewIds;
-                }
-            }
-            if (hasExtension(gltf, 'KHR_draco_mesh_compression')) {
-                if (defined(primitive.extensions) &&
-                    defined(primitive.extensions.KHR_draco_mesh_compression)) {
-                    compressedMeshBufferViewIds[primitive.extensions.KHR_draco_mesh_compression.bufferView] = true;
-                    meshBufferViewIds.compressed = compressedMeshBufferViewIds;
-                }
-            }
-        });
-    });
-
-    var bufferViewId = -1;
-    ForEach.bufferView(gltf, function(bufferView) { // eslint-disable-line no-unused-vars
-        ++bufferViewId;
-
-        if (!uncompressedMeshBufferViewIds[bufferViewId] && !compressedMeshBufferViewIds[bufferViewId]) {
-            // The Buffer View is for non-mesh data.
-            nonMeshBufferViewIds[bufferViewId] = true;
-            meshBufferViewIds.nonMesh = nonMeshBufferViewIds;
-        }
-    });
-
-    var newBufferList = [];
-    if (defined(meshBufferViewIds.uncompressed)) {
-        var newBufferUncompressed = {
-            name: baseBufferName + '-uncompressed',
-            bufferViews: meshBufferViewIds.uncompressed
-        };
-        addToArray(newBufferList, newBufferUncompressed);
-    }
-    if (defined(meshBufferViewIds.compressed)) {
-        var newBufferCompressed = {
-            name: baseBufferName + '-draco',
-            bufferViews: meshBufferViewIds.compressed
-        };
-        addToArray(newBufferList, newBufferCompressed);
-    }
-    if (defined(meshBufferViewIds.nonMesh)) {
-        var newBufferNonMesh = {
-            name: baseBufferName,
-            bufferViews: meshBufferViewIds.nonMesh
-        };
-        addToArray(newBufferList, newBufferNonMesh);
-    }
-    return newBufferList;
 }

--- a/lib/splitPrimitives.js
+++ b/lib/splitPrimitives.js
@@ -1,6 +1,7 @@
 'use strict';
 var Cesium = require('cesium');
 var hashObject = require('object-hash');
+var addBuffer = require('./addBuffer');
 var addToArray = require('./addToArray');
 var findAccessorMinMax = require('./findAccessorMinMax');
 var ForEach = require('./ForEach');
@@ -162,26 +163,12 @@ function createNewAccessor(gltf, oldAccessor, dataArray) {
     var numberOfComponents = numberOfComponentsForType(type);
     var count = dataArray.length / numberOfComponents;
     var newBuffer = Buffer.from(ComponentDatatype.createTypedArray(componentType, dataArray).buffer);
-    var newBufferLength = newBuffer.length;
-    var buffer = {
-        byteLength: newBufferLength,
-        extras: {
-            _pipeline: {
-                source: newBuffer
-            }
-        }
-    };
-    var bufferId = addToArray(gltf.buffers, buffer);
-    var bufferView = {
-        buffer: bufferId,
-        byteOffset: 0,
-        byteLength: newBufferLength
-    };
-    var bufferViewId = addToArray(gltf.bufferViews, bufferView);
+    var newBufferViewId = addBuffer(gltf, newBuffer);
+
     var accessor = clone(oldAccessor, true);
     var accessorId = addToArray(gltf.accessors, accessor);
 
-    accessor.bufferView = bufferViewId;
+    accessor.bufferView = newBufferViewId;
     accessor.byteOffset = 0;
     accessor.count = count;
 

--- a/lib/updateAccessorComponentTypes.js
+++ b/lib/updateAccessorComponentTypes.js
@@ -1,6 +1,6 @@
 'use strict';
 var Cesium = require('cesium');
-var addToArray = require('./addToArray');
+var addBuffer = require('./addBuffer');
 var ForEach = require('./ForEach');
 var readAccessorPacked = require('./readAccessorPacked');
 
@@ -45,20 +45,6 @@ function updateAccessorComponentTypes(gltf) {
 function convertType(gltf, accessor, updatedComponentType) {
     var typedArray = ComponentDatatype.createTypedArray(updatedComponentType, readAccessorPacked(gltf, accessor));
     var newBuffer = new Uint8Array(typedArray.buffer);
-    var newBufferLength = newBuffer.length;
-    var buffer = {
-        byteLength: newBufferLength,
-        extras: {
-            _pipeline: {
-                source: newBuffer
-            }
-        }
-    };
-
-    var bufferId = addToArray(gltf.buffers, buffer);
+    accessor.bufferView = addBuffer(gltf, newBuffer);
     accessor.componentType = updatedComponentType;
-    accessor.bufferView = addToArray(gltf.bufferViews, {
-        buffer: bufferId,
-        byteLength: newBufferLength
-    });
 }

--- a/lib/writeResources.js
+++ b/lib/writeResources.js
@@ -1,6 +1,7 @@
 'use strict';
 var Cesium = require('cesium');
 var mime = require('mime');
+var addBuffer = require('./addBuffer');
 var ForEach = require('./ForEach');
 var getImageExtension = require('./getImageExtension');
 var mergeBuffers = require('./mergeBuffers');
@@ -109,24 +110,7 @@ function writeBufferView(gltf, object) {
     if (typeof source === 'string') {
         source = Buffer.from(source);
     }
-    var byteLength = source.length;
-    var buffers = gltf.buffers;
-    var bufferViews = gltf.bufferViews;
-
-    object.bufferView = bufferViews.length;
-    bufferViews.push({
-        buffer: buffers.length,
-        byteOffset: 0,
-        byteLength: byteLength
-    });
-    buffers.push({
-        byteLength: byteLength,
-        extras: {
-            _pipeline: {
-                source: source
-            }
-        }
-    });
+    object.bufferView = addBuffer(gltf, source);
 }
 
 function getProgram(gltf, shaderIndex) {

--- a/lib/writeResources.js
+++ b/lib/writeResources.js
@@ -42,8 +42,6 @@ function writeResources(gltf, options) {
     options.separateTextures = defaultValue(options.separateTextures, false);
     options.separateShaders = defaultValue(options.separateShaders, false);
     options.dataUris = defaultValue(options.dataUris, false);
-    options.dracoOptions = defaultValue(options.dracoOptions, {});
-    options.dracoOptions.uncompressedFallback = defaultValue(options.dracoOptions.uncompressedFallback, false);
 
     ForEach.image(gltf, function(image, i) {
         writeImage(gltf, image, i, options);
@@ -58,7 +56,7 @@ function writeResources(gltf, options) {
 
     // Buffers need to be written last because images and shaders may write to new buffers
     removeUnusedElements(gltf);
-    mergeBuffers(gltf, options.name, options.dracoOptions.uncompressedFallback);
+    mergeBuffers(gltf, options.name);
 
     ForEach.buffer(gltf, function(buffer, bufferId) {
         writeBuffer(gltf, buffer, bufferId, options);
@@ -67,11 +65,18 @@ function writeResources(gltf, options) {
 }
 
 function writeBuffer(gltf, buffer, i, options) {
-    if (defined(options.bufferStorage)) {
-        options.bufferStorage.buffer = buffer.extras._pipeline.source;
-        return;
+    if (defined(options.bufferStorage) && !options.separateBuffers) {
+        writeBufferStorage(buffer, options);
+    } else {
+        writeResource(gltf, buffer, i, options.separateBuffers, true, '.bin', options);
     }
-    writeResource(gltf, buffer, i, options.separateBuffers, true, '.bin', options);
+}
+
+function writeBufferStorage(buffer, options) {
+    var combinedBuffer = options.bufferStorage.buffer;
+    combinedBuffer = defaultValue(combinedBuffer, Buffer.alloc(0));
+    combinedBuffer = Buffer.concat([combinedBuffer, buffer.extras._pipeline.source]);
+    options.bufferStorage.buffer = combinedBuffer;
 }
 
 function writeImage(gltf, image, i, options) {
@@ -132,9 +137,9 @@ function getName(gltf, object, index, extension, options) {
         return objectName;
     } else if (extension === '.bin') {
         if (defined(gltfName)) {
-            return gltfName;
+            return gltfName + index;
         }
-        return 'buffer';
+        return 'buffer' + index;
     } else if (extension === '.glsl') {
         var programInfo = getProgram(gltf, index);
         var program = programInfo.program;

--- a/specs/lib/compressDracoMeshesSpec.js
+++ b/specs/lib/compressDracoMeshesSpec.js
@@ -192,5 +192,15 @@ describe('compressDracoMeshes', function() {
         expect(gltfOther.extensionsRequired.indexOf('KHR_draco_mesh_compression') >= 0).toBe(true);
         expect(gltf.buffers.length).toBe(6); // draco + image + 4 uncompressed attributes
         expect(gltfOther.buffers.length).toBe(2); // draco + image
+
+        expect(gltf.buffers[0].extras._pipeline.mergedBufferName).toBeUndefined();
+        expect(gltf.buffers[1].extras._pipeline.mergedBufferName).toBe('draco');
+        expect(gltf.buffers[2].extras._pipeline.mergedBufferName).toBe('uncompressed');
+        expect(gltf.buffers[3].extras._pipeline.mergedBufferName).toBe('uncompressed');
+        expect(gltf.buffers[4].extras._pipeline.mergedBufferName).toBe('uncompressed');
+        expect(gltf.buffers[5].extras._pipeline.mergedBufferName).toBe('uncompressed');
+
+        expect(gltfOther.buffers[0].extras._pipeline.mergedBufferName).toBeUndefined();
+        expect(gltfOther.buffers[1].extras._pipeline.mergedBufferName).toBeUndefined();
     });
 });

--- a/specs/lib/gltfToGlbSpec.js
+++ b/specs/lib/gltfToGlbSpec.js
@@ -9,14 +9,48 @@ describe('gltfToGlb', function() {
         spyOn(console, 'log');
         var gltf = fsExtra.readJsonSync(gltfPath);
         var options = {
+            separateTextures: true,
+            stats: true
+        };
+        expect(gltfToGlb(gltf, options)
+            .then(function(results) {
+                var glb = results.glb;
+                var separateResources = results.separateResources;
+                expect(Buffer.isBuffer(glb)).toBe(true);
+                expect(Object.keys(separateResources).length).toBe(1);
+                expect(console.log).toHaveBeenCalled();
+
+                // Header + JSON header + JSON content + binary header + binary content
+                var glbLength = glb.readUInt32LE(8);
+                var jsonChunkLength = glb.readUInt32LE(12);
+                var binaryChunkLength = glb.readUInt32LE(12 + 8 + jsonChunkLength);
+                var expectedLength = 12 + 8 + jsonChunkLength + 8 + binaryChunkLength;
+                expect(glbLength).toBe(expectedLength);
+                expect(glb.length).toBe(expectedLength);
+            }), done).toResolve();
+    });
+
+    it('gltfToGlb with separate resources', function(done) {
+        spyOn(console, 'log');
+        var gltf = fsExtra.readJsonSync(gltfPath);
+        var options = {
             separate: true,
             stats: true
         };
         expect(gltfToGlb(gltf, options)
             .then(function(results) {
-                expect(Buffer.isBuffer(results.glb)).toBe(true);
-                expect(results.separateResources).toBeDefined();
+                var glb = results.glb;
+                var separateResources = results.separateResources;
+                expect(Buffer.isBuffer(glb)).toBe(true);
+                expect(Object.keys(separateResources).length).toBe(2);
                 expect(console.log).toHaveBeenCalled();
+
+                // Header + JSON header + JSON content. No binary header or content.
+                var glbLength = glb.readUInt32LE(8);
+                var jsonChunkLength = glb.readUInt32LE(12);
+                var expectedLength = 12 + 8 + jsonChunkLength;
+                expect(glbLength).toBe(expectedLength);
+                expect(glb.length).toBe(expectedLength);
             }), done).toResolve();
     });
 });

--- a/specs/lib/mergeBuffersSpec.js
+++ b/specs/lib/mergeBuffersSpec.js
@@ -55,4 +55,110 @@ describe('mergeBuffers', function() {
                 expect(gltf.buffers[0].extras._pipeline.source).toEqual(expectedBuffer);
             }), done).toResolve();
     });
+
+    it('merges buffers based on mergedBufferName', function(done) {
+        var buffer0 = Buffer.from((new Uint8Array([1, 1, 1, 1])));
+        var buffer1 = Buffer.from((new Uint8Array([2, 2, 2, 2])));
+        var buffer2 = Buffer.from((new Uint8Array([3])));
+        var buffer3 = Buffer.from((new Uint8Array([5, 5])));
+        var buffer4 = Buffer.from((new Uint8Array([4, 4, 4])));
+        var buffer5 = Buffer.from((new Uint8Array([6, 7])));
+
+        var dataUri0 = 'data:application/octet-stream;base64,' + buffer0.toString('base64');
+        var dataUri1 = 'data:application/octet-stream;base64,' + buffer1.toString('base64');
+        var dataUri2 = 'data:application/octet-stream;base64,' + buffer2.toString('base64');
+        var dataUri3 = 'data:application/octet-stream;base64,' + buffer3.toString('base64');
+        var dataUri4 = 'data:application/octet-stream;base64,' + buffer4.toString('base64');
+        var dataUri5 = 'data:application/octet-stream;base64,' + buffer5.toString('base64');
+
+        // All buffer views start on 4-byte alignment, the buffer ends on a 4-byte alignment, and extraneous buffer data is removed
+        var expectedBuffer0 = Buffer.from((new Uint8Array([1, 1, 1, 1, 2, 2, 2, 2])));
+        var expectedBuffer1 = Buffer.from((new Uint8Array([3, 0, 0, 0, 4, 4, 4, 0])));
+        var expectedBuffer2 = Buffer.from((new Uint8Array([5, 5, 0, 0, 6, 0, 0, 0, 7, 0, 0, 0])));
+
+        var gltf = {
+            bufferViews: [
+                {
+                    buffer: 0,
+                    byteOffset: 0,
+                    byteLength: 4
+                },
+                {
+                    buffer: 1,
+                    byteOffset: 0,
+                    byteLength: 4
+                },
+                {
+                    buffer: 2,
+                    byteOffset: 0,
+                    byteLength: 1
+                },
+                {
+                    buffer: 3,
+                    byteOffset: 0,
+                    byteLength: 2
+                },
+                {
+                    buffer: 4,
+                    byteOffset: 0,
+                    byteLength: 3
+                },
+                {
+                    buffer: 5,
+                    byteOffset: 0,
+                    byteLength: 1
+                },
+                {
+                    buffer: 5,
+                    byteOffset: 1,
+                    byteLength: 1
+                }
+            ],
+            buffers: [
+                {
+                    byteLength: buffer0.length,
+                    uri: dataUri0
+                },
+                {
+                    byteLength: buffer1.length,
+                    uri: dataUri1
+                },
+                {
+                    byteLength: buffer2.length,
+                    uri: dataUri2
+                },
+                {
+                    byteLength: buffer3.length,
+                    uri: dataUri3
+                },
+                {
+                    byteLength: buffer4.length,
+                    uri: dataUri4
+                },
+                {
+                    byteLength: buffer5.length,
+                    uri: dataUri5
+                }
+            ]
+        };
+
+        expect(readResources(gltf)
+            .then(function(gltf) {
+                gltf.buffers[0].extras._pipeline.mergedBufferName = 'first';
+                gltf.buffers[1].extras._pipeline.mergedBufferName = 'first';
+                gltf.buffers[2].extras._pipeline.mergedBufferName = 'second';
+                gltf.buffers[3].extras._pipeline.mergedBufferName = undefined;
+                gltf.buffers[4].extras._pipeline.mergedBufferName = 'second';
+                gltf.buffers[5].extras._pipeline.mergedBufferName = undefined;
+
+                mergeBuffers(gltf);
+                expect(gltf.buffers.length).toBe(3);
+                expect(gltf.buffers[0].extras._pipeline.source).toEqual(expectedBuffer0);
+                expect(gltf.buffers[0].name).toEqual('first');
+                expect(gltf.buffers[1].extras._pipeline.source).toEqual(expectedBuffer1);
+                expect(gltf.buffers[1].name).toEqual('second');
+                expect(gltf.buffers[2].extras._pipeline.source).toEqual(expectedBuffer2);
+                expect(gltf.buffers[2].name).toBeUndefined();
+            }), done).toResolve();
+    });
 });


### PR DESCRIPTION
Fixes #412

* Merges buffers together that have the same `extra._pipeline.mergedBufferName`. For now only `compressDracoMeshes` sets this property but future stages may set this as well.
* Fixes bug where `gltfToGlb` was embedding buffer data rather than writing out a separate bin file when `separate` is passed in. This required some tweaks in `gltfToGlb#getGlb` to not always create the binary chunk.
* Fixes bug where if `mergeBuffers` produces multiple buffers and `gltfToGlb` has `separate` set to false then only the first buffer got written.
* Updated some other areas of the code to use the new `addBuffer` function.

@ggetz could you take a look at this? 