### PR TITLE
Add default material to primitive

### DIFF
--- a/lib/addDefaults.js
+++ b/lib/addDefaults.js
@@ -1,5 +1,6 @@
 'use strict';
 var Cesium = require('cesium');
+var addToArray = require('./addToArray');
 var ForEach = require('./ForEach');
 var getAccessorByteStride = require('./getAccessorByteStride');
 
@@ -31,6 +32,12 @@ function addDefaults(gltf) {
     ForEach.mesh(gltf, function(mesh) {
         ForEach.meshPrimitive(mesh, function(primitive) {
             primitive.mode = defaultValue(primitive.mode, WebGLConstants.TRIANGLES);
+            if (!defined(primitive.material)) {
+                if (!defined(gltf.materials)) {
+                    gltf.materials = [];
+                }
+                primitive.material = addToArray(gltf.materials, {});
+            }
         });
     });
 

--- a/specs/lib/addDefaultsSpec.js
+++ b/specs/lib/addDefaultsSpec.js
@@ -75,6 +75,7 @@ describe('addDefaults', function() {
 
         var gltfWithDefaults = addDefaults(gltf);
         var primitive = gltfWithDefaults.meshes[0].primitives[0];
+        var material = gltfWithDefaults.materials[0];
         var positionAccessor = gltfWithDefaults.accessors[0];
         var positionTargetAccessor = gltfWithDefaults.accessors[1];
         var indicesAccessor = gltfWithDefaults.accessors[2];
@@ -84,6 +85,11 @@ describe('addDefaults', function() {
         var otherBufferView = gltfWithDefaults.bufferViews[3];
 
         expect(primitive.mode).toBe(WebGLConstants.TRIANGLES);
+        expect(primitive.material).toBe(0);
+
+        expect(material.emissiveFactor).toEqual([0.0, 0.0, 0.0]);
+        expect(material.alphaMode).toBe('OPAQUE');
+        expect(material.doubleSided).toBe(false);
 
         expect(positionAccessor.byteOffset).toBe(0);
         expect(positionAccessor.normalized).toBe(false);


### PR DESCRIPTION
Adds a default material to each primitive that does not specify a material.

Test model: [CUBE.gltf.txt](https://github.com/AnalyticalGraphicsInc/gltf-pipeline/files/2272530/CUBE.gltf.txt)

@ggetz can you review?