### PR TITLE
Fix error when updating component type for accessors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,11 @@
 Change Log
 ==========
 
-### 2.0.0 2018-08-14
+### 2.0.1 - ????
+
+* Fixed a bug where the buffer `byteOffset` was not set properly when updating 1.0 accessor types to 2.0 allowed values. [#418](https://github.com/AnalyticalGraphicsInc/gltf-pipeline/pull/418)
+
+### 2.0.0 - 2018-08-14
 
 * Breaking changes
     * Project updated to process glTF 2.0 models. Any glTF 1.0 models will be upgraded to glTF 2.0 automatically and use the `KHR_techniques_webgl` and `KHR_blend` extensions.
@@ -72,7 +76,7 @@ Change Log
 * Change Cesium `Geometry`'s and `VertexFormat`'s `binormal` attribute to bitangent.
 * Fixed a bug in `combinePrimitives` where combining primitives can overflow uint16 for the resulting indices. [#230](https://github.com/AnalyticalGraphicsInc/gltf-pipeline/issues/230)
 * Made `generateNormals` stage optional and added `smoothNormals` option for generating smooth normals if the model does not have normals. [#240](https://github.com/AnalyticalGraphicsInc/gltf-pipeline/pull/240)
-* `updateVersion` stage for upgrades the glTF version of an asset from `1.0` to `2.0`. [#223](https://github.com/AnalyticalGraphicsInc/gltf-pipeline/pull/223) 
+* `updateVersion` stage for upgrades the glTF version of an asset from `1.0` to `2.0`. [#223](https://github.com/AnalyticalGraphicsInc/gltf-pipeline/pull/223)
    * All pipeline stages now operate on glTF `2.0` assets.
 
 ### 0.1.0-alpha10 - 2017-01-10

--- a/lib/updateAccessorComponentTypes.js
+++ b/lib/updateAccessorComponentTypes.js
@@ -47,4 +47,5 @@ function convertType(gltf, accessor, updatedComponentType) {
     var newBuffer = new Uint8Array(typedArray.buffer);
     accessor.bufferView = addBuffer(gltf, newBuffer);
     accessor.componentType = updatedComponentType;
+    accessor.byteOffset = 0;
 }

--- a/specs/lib/updateAccessorComponentTypeSpec.js
+++ b/specs/lib/updateAccessorComponentTypeSpec.js
@@ -48,6 +48,7 @@ describe('updateAccessorComponentTypes', function() {
                 }, {
                     bufferView: 1,
                     componentType: WebGLConstants.FLOAT,
+                    byteOffset: 12,
                     count: 24,
                     type: 'VEC4'
                 }, {
@@ -87,6 +88,7 @@ describe('updateAccessorComponentTypes', function() {
 
             expect(gltf.accessors[1].componentType).toBe(WebGLConstants.UNSIGNED_SHORT);
             expect(gltf.accessors[1].bufferView).toBe(4);
+            expect(gltf.accessors[1].byteOffset).toBe(0);
             expect(gltf.bufferViews[4].buffer).toBe(2);
             expect(gltf.bufferViews[4].byteLength).toBe(192);
 
@@ -125,6 +127,7 @@ describe('updateAccessorComponentTypes', function() {
                 }, {
                     bufferView: 1,
                     componentType: WebGLConstants.BYTE,
+                    byteOffset: 12,
                     count: 24,
                     type: 'VEC4'
                 }, {
@@ -162,6 +165,7 @@ describe('updateAccessorComponentTypes', function() {
 
             expect(gltf.accessors[1].componentType).toBe(WebGLConstants.UNSIGNED_BYTE);
             expect(gltf.accessors[1].bufferView).toBe(3);
+            expect(gltf.accessors[1].byteOffset).toBe(0);
             expect(gltf.bufferViews[3].buffer).toBe(1);
             expect(gltf.bufferViews[3].byteLength).toBe(96);
 


### PR DESCRIPTION
Additional fix after https://github.com/AnalyticalGraphicsInc/gltf-pipeline/pull/406

The accessor's `byteOffset` needs to be set to 0 for the new buffer.