### PR TITLE
Add removePipelineExtras to cesium-build files

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -210,6 +210,7 @@ gulp.task('build-cesium', function () {
         'addPipelineExtras.js',
         'ForEach.js',
         'parseGlb.js',
+        'removePipelineExtras.js',
         'updateVersion.js'
     ];
 


### PR DESCRIPTION
Add `removePipelineExtras.js` to list of files for `build-cesium` task as part of https://github.com/AnalyticalGraphicsInc/cesium/pull/6805