### PR TITLE
Created accessor bufferViews should be byte aligned

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ Change Log
 ### 2.0.1 - ????
 
 * Fixed a bug where the buffer `byteOffset` was not set properly when updating 1.0 accessor types to 2.0 allowed values. [#418](https://github.com/AnalyticalGraphicsInc/gltf-pipeline/pull/418)
+* Fixed a bug where bufferViews were not properly byte aligned when updating accessors from 1.0 to 2.0. [#421](https://github.com/AnalyticalGraphicsInc/gltf-pipeline/pull/421)
 
 ### 2.0.0 - 2018-08-14
 

--- a/lib/updateVersion.js
+++ b/lib/updateVersion.js
@@ -790,7 +790,8 @@ function moveByteStrideToBufferView(gltf) {
                 var accessorByteLength = accessor.count * accessorByteStride;
                 delete accessor.byteStride;
 
-                var nextAccessorByteStride = (i < accessorsLength - 1) ? computeAccessorByteStride(gltf, accessors[i + 1]) : undefined;
+                var hasNextAccessor = (i < accessorsLength - 1);
+                var nextAccessorByteStride = hasNextAccessor ? computeAccessorByteStride(gltf, accessors[i + 1]) : undefined;
                 if (accessorByteStride !== nextAccessorByteStride) {
                     var newBufferView = clone(bufferView, true);
                     if (bufferViewHasVertexAttributes[bufferViewId]) {
@@ -804,7 +805,8 @@ function moveByteStrideToBufferView(gltf) {
                         accessor.bufferView = newBufferViewId;
                         accessor.byteOffset = accessor.byteOffset - currentByteOffset;
                     }
-                    currentByteOffset = accessorByteOffset + accessorByteLength + accessorByteLength % 4;
+                    // Set current byte offset to next accessor's byte offset
+                    currentByteOffset = hasNextAccessor ? accessors[i + 1].byteOffset : undefined;
                     currentIndex = i + 1;
                 }
             }

--- a/lib/updateVersion.js
+++ b/lib/updateVersion.js
@@ -804,7 +804,7 @@ function moveByteStrideToBufferView(gltf) {
                         accessor.bufferView = newBufferViewId;
                         accessor.byteOffset = accessor.byteOffset - currentByteOffset;
                     }
-                    currentByteOffset = accessorByteOffset + accessorByteLength;
+                    currentByteOffset = accessorByteOffset + accessorByteLength + accessorByteLength % 4;
                     currentIndex = i + 1;
                 }
             }

--- a/specs/lib/updateVersionSpec.js
+++ b/specs/lib/updateVersionSpec.js
@@ -436,21 +436,21 @@ describe('updateVersion', function() {
                 },
                 accessor_position: {
                     bufferView: 'bufferViewAttributes',
-                    byteOffset: 72,
+                    byteOffset: 0,
                     componentType: WebGLConstants.FLOAT,
                     count: 3,
                     type: 'VEC3'
                 },
                 accessor_normal: {
                     bufferView: 'bufferViewAttributes',
-                    byteOffset: 0,
+                    byteOffset: 42,
                     componentType: WebGLConstants.BYTE,
                     count: 3,
                     type: 'VEC2'
                 },
                 accessor_texcoord: {
                     bufferView: 'bufferViewAttributes',
-                    byteOffset: 36,
+                    byteOffset: 50,
                     componentType: WebGLConstants.BYTE,
                     count: 3,
                     type: 'VEC2'
@@ -721,15 +721,15 @@ describe('updateVersion', function() {
                 var texcoordAccessor = gltf.accessors[primitive.attributes.TEXCOORD_0];
                 var positionBufferView = gltf.bufferViews[positionAccessor.bufferView];
                 var texcoordBufferView = gltf.bufferViews[texcoordAccessor.bufferView];
-                expect(positionAccessor.bufferView).toBe(2);
-                expect(normalAccessor.bufferView).toBe(1);
-                expect(texcoordAccessor.bufferView).toBe(1);
-                expect(texcoordBufferView.byteLength).toBe(42);
-                expect(texcoordBufferView.byteOffset).toBe(12); // First unrelated buffer view is 12 bytes
-                expect(texcoordBufferView.byteStride).toBe(2);
-                expect(positionBufferView.byteLength).toBe(64);
-                expect(positionBufferView.byteOffset).toBe(42 + 12 + 2); // First unrelated buffer view is 12 bytes + byte alignment
+                expect(positionAccessor.bufferView).toBe(1);
+                expect(normalAccessor.bufferView).toBe(2);
+                expect(texcoordAccessor.bufferView).toBe(2);
+                expect(positionBufferView.byteLength).toBe(36);
+                expect(positionBufferView.byteOffset).toBe(12); // First unrelated buffer view is 12 bytes
                 expect(positionBufferView.byteStride).toBe(12);
+                expect(texcoordBufferView.byteLength).toBe(50 - 42 + 6); // Padding to next buffer view
+                expect(texcoordBufferView.byteOffset).toBe(42 + 12); // Byte offset of previous accessor plus byte length
+                expect(texcoordBufferView.byteStride).toBe(2);
                 expect(positionAccessor.byteStride).toBeUndefined();
                 expect(normalAccessor.byteStride).toBeUndefined();
                 expect(texcoordAccessor.byteStride).toBeUndefined();

--- a/specs/lib/updateVersionSpec.js
+++ b/specs/lib/updateVersionSpec.js
@@ -424,22 +424,22 @@ describe('updateVersion', function() {
                 },
                 accessor_position: {
                     bufferView: 'bufferViewAttributes',
-                    byteOffset: 0,
+                    byteOffset: 72,
                     componentType: WebGLConstants.FLOAT,
                     count: 3,
                     type: 'VEC3'
                 },
                 accessor_normal: {
                     bufferView: 'bufferViewAttributes',
-                    byteOffset: 36,
-                    componentType: WebGLConstants.FLOAT,
+                    byteOffset: 0,
+                    componentType: WebGLConstants.BYTE,
                     count: 3,
-                    type: 'VEC3'
+                    type: 'VEC2'
                 },
                 accessor_texcoord: {
                     bufferView: 'bufferViewAttributes',
-                    byteOffset: 72,
-                    componentType: WebGLConstants.FLOAT,
+                    byteOffset: 36,
+                    componentType: WebGLConstants.BYTE,
                     count: 3,
                     type: 'VEC2'
                 },
@@ -708,15 +708,15 @@ describe('updateVersion', function() {
                 var texcoordAccessor = gltf.accessors[primitive.attributes.TEXCOORD_0];
                 var positionBufferView = gltf.bufferViews[positionAccessor.bufferView];
                 var texcoordBufferView = gltf.bufferViews[texcoordAccessor.bufferView];
-                expect(positionAccessor.bufferView).toBe(1);
+                expect(positionAccessor.bufferView).toBe(2);
                 expect(normalAccessor.bufferView).toBe(1);
-                expect(texcoordAccessor.bufferView).toBe(2);
-                expect(positionBufferView.byteLength).toBe(72);
-                expect(positionBufferView.byteOffset).toBe(12); // First unrelated buffer view is 12 bytes
+                expect(texcoordAccessor.bufferView).toBe(1);
+                expect(texcoordBufferView.byteLength).toBe(42);
+                expect(texcoordBufferView.byteOffset).toBe(12); // First unrelated buffer view is 12 bytes
+                expect(texcoordBufferView.byteStride).toBe(2);
+                expect(positionBufferView.byteLength).toBe(64);
+                expect(positionBufferView.byteOffset).toBe(42 + 12 + 2); // First unrelated buffer view is 12 bytes + byte alignment
                 expect(positionBufferView.byteStride).toBe(12);
-                expect(texcoordBufferView.byteLength).toBe(24);
-                expect(texcoordBufferView.byteOffset).toBe(72 + 12); // First unrelated buffer view is 12 bytes
-                expect(texcoordBufferView.byteStride).toBe(8);
                 expect(positionAccessor.byteStride).toBeUndefined();
                 expect(normalAccessor.byteStride).toBeUndefined();
                 expect(texcoordAccessor.byteStride).toBeUndefined();


### PR DESCRIPTION
This is why `Cesium_Air.gltf` was not rendering in https://github.com/AnalyticalGraphicsInc/cesium/pull/6805

The bufferViews created when splitting accessors with different byte strides must be byte aligned.