### PR TITLE
Fixed removePipelineExtras for use in browsers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ Change Log
 ### 2.0.1 - ????
 
 * Fixed a bug where the buffer `byteOffset` was not set properly when updating 1.0 accessor types to 2.0 allowed values. [#418](https://github.com/AnalyticalGraphicsInc/gltf-pipeline/pull/418)
+* Fixed a bug in `removePipelineExtras` when run in the browser. [#422](https://github.com/AnalyticalGraphicsInc/gltf-pipeline/pull/422)
 
 ### 2.0.0 - 2018-08-14
 

--- a/lib/removePipelineExtras.js
+++ b/lib/removePipelineExtras.js
@@ -34,9 +34,14 @@ function removePipelineExtras(gltf) {
 }
 
 function removeExtras(object) {
-    if (defined(object.extras) && defined(object.extras._pipeline)) {
+    if (!defined(object.extras)) {
+        return;
+    }
+
+    if (defined(object.extras._pipeline)) {
         delete object.extras._pipeline;
     }
+
     if (Object.keys(object.extras).length === 0) {
         delete object.extras;
     }


### PR DESCRIPTION
`Object.keys` casts `undefined` to an empty object in Node, but fails in the browser. This adds an extra check for `undefined`.