### PR TITLE
Split techniques for primitives that use different attributes

### DIFF
--- a/lib/processModelMaterialsCommon.js
+++ b/lib/processModelMaterialsCommon.js
@@ -766,6 +766,8 @@ function getTechniqueKey(khrMaterialsCommon) {
             techniqueKey += skinningInfo.type + ';';
         }
         techniqueKey += primitiveInfo.hasVertexColors;
+        techniqueKey += primitiveInfo.hasNormals;
+        techniqueKey += primitiveInfo.hasTexcoords;
     }
 
     return techniqueKey;
@@ -925,7 +927,9 @@ function splitIncompatibleMaterials(gltf) {
                         type = jointAccessor.type;
                     }
                     var isSkinned = defined(jointAccessorId);
-                    var hasVertexColors = defined(primitive.attributes.COLOR_0);
+                    var hasVertexColors = defined(primitive.attributes.COLOR) || defined(primitive.attributes.COLOR_0);
+                    var hasNormals = defined(primitive.attributes.NORMAL);
+                    var hasTexcoords = defined(primitive.attributes.TEXCOORD) || defined(primitive.attributes.TEXCOORD_0);
 
                     var primitiveInfo = khrMaterialsCommon.extras._pipeline.primitive;
                     if (!defined(primitiveInfo)) {
@@ -935,13 +939,19 @@ function splitIncompatibleMaterials(gltf) {
                                 componentType: componentType,
                                 type: type
                             },
-                            hasVertexColors: hasVertexColors
+                            hasVertexColors: hasVertexColors,
+                            hasNormals: hasNormals,
+                            hasTexcoords: hasTexcoords
                         };
-                    } else if ((primitiveInfo.skinning.skinned !== isSkinned) || (primitiveInfo.skinning.type !== type) || (primitiveInfo.hasVertexColors !== hasVertexColors)) {
+                    } else if ((primitiveInfo.skinning.skinned !== isSkinned) ||
+                               (primitiveInfo.skinning.type !== type) ||
+                               (primitiveInfo.hasVertexColors !== hasVertexColors) ||
+                               (primitiveInfo.hasNormals !== hasNormals) ||
+                               (primitiveInfo.hasTexcoords !== hasTexcoords)) {
                         // This primitive uses the same material as another one that either:
                         // * Isn't skinned
                         // * Uses a different type to store joints and weights
-                        // * Doesn't have vertex colors
+                        // * Has different attributes
                         materialId = getUniqueId(gltf, materialId);
                         primitive.material = materialId;
                         // Split this off as a separate material
@@ -952,7 +962,9 @@ function splitIncompatibleMaterials(gltf) {
                                 componentType: componentType,
                                 type: type
                             },
-                            hasVertexColors : hasVertexColors
+                            hasVertexColors: hasVertexColors,
+                            hasNormals: hasNormals,
+                            hasTexcoords: hasTexcoords
                         };
                         materials[materialId] = clonedMaterial;
                     }

--- a/specs/lib/processModelMaterialsCommonSpec.js
+++ b/specs/lib/processModelMaterialsCommonSpec.js
@@ -326,7 +326,7 @@ describe('processModelMaterialsCommon', function() {
         expect(techniqueMat3.parameters.joint.type).toEqual(WebGLConstants.FLOAT_MAT3);
     });
 
-    it('splits two materials with different attributes', function() {
+    it('splits a material used by meshes with different attributes', function() {
         var gltf = {
             accessors: {
                 positionAccessor_0: {

--- a/specs/lib/processModelMaterialsCommonSpec.js
+++ b/specs/lib/processModelMaterialsCommonSpec.js
@@ -325,4 +325,84 @@ describe('processModelMaterialsCommon', function() {
         expect(techniqueVec4.parameters.joint.type).toEqual(WebGLConstants.FLOAT_VEC4);
         expect(techniqueMat3.parameters.joint.type).toEqual(WebGLConstants.FLOAT_MAT3);
     });
+
+    it('splits two materials with different attributes', function() {
+        var gltf = {
+            accessors: {
+                positionAccessor_0: {
+                    componentType: WebGLConstants.FLOAT,
+                    type: 'VEC3'
+                },
+                normalAccessor_0: {
+                    componentType: WebGLConstants.FLOAT,
+                    type: 'VEC3'
+                },
+                texcoordAccessor_0: {
+                    componentType: WebGLConstants.FLOAT,
+                    type: 'VEC2'
+                },
+                positionAccessor_1: {
+                    componentType: WebGLConstants.FLOAT,
+                    type: 'VEC3'
+                },
+                normalAccessor_1: {
+                    componentType: WebGLConstants.FLOAT,
+                    type: 'VEC3'
+                }
+            },
+            extensionsUsed: [
+                'KHR_materials_common'
+            ],
+            materials: {
+                material: {
+                    extensions: {
+                        KHR_materials_common: {
+                            jointCount: 14,
+                            technique: 'BLINN'
+                        }
+                    }
+                }
+            },
+            meshes: {
+                mesh_0: {
+                    primitives: [{
+                        attributes: {
+                            POSITION: 'positionAccessor_0',
+                            NORMAL: 'normalAccessor_0',
+                            TEXCOORD: 'texcoordAccessor_0'
+                        },
+                        material: 'material'
+                    }]
+                },
+                mesh_1: {
+                    primitives: [{
+                        attributes: {
+                            POSITION: 'positionAccessor_1',
+                            NORMAL: 'normalAccessor_1'
+                        },
+                        material: 'material'
+                    }]
+                }
+            }
+        };
+        addDefaults(gltf);
+        addPipelineExtras(gltf);
+        processModelMaterialsCommon(gltf);
+
+        var meshes = gltf.meshes;
+        var primitive0 = meshes.mesh_0.primitives[0];
+        var primitive1 = meshes.mesh_1.primitives[0];
+        var material0Id = primitive0.material;
+        var material1Id = primitive1.material;
+        expect(primitive0).not.toEqual(primitive1);
+
+        var materials = gltf.materials;
+        var techniques = gltf.techniques;
+        var technique0 = techniques[materials[material0Id].technique];
+        var technique1 = techniques[materials[material1Id].technique];
+        expect(technique0.parameters.normal).toBeDefined();
+        expect(technique0.parameters.texcoord).toBeDefined();
+        expect(technique1.parameters.normal).toBeDefined();
+        expect(technique1.parameters.texcoord).toBeUndefined();
+    });
 });


### PR DESCRIPTION
Take into account whether a primitive has normals or texture coordinates when deciding whether to split incompatible techniques/materials.

This targets the 1.0 branch.