### PR TITLE
Don't remove empty node if it contains extensions or extras

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+### 2.0.2 - ????-??-??
+
+* Fixed a bug where nodes containing extensions or extras where being removed in the glTF 1.0 to 2.0 upgrade stage. [#431](https://github.com/AnalyticalGraphicsInc/gltf-pipeline/pull/431)
+
 ### 2.0.1 - 2018-09-19
 
 * Fixed a bug where the buffer `byteOffset` was not set properly when updating 1.0 accessor types to 2.0 allowed values. [#418](https://github.com/AnalyticalGraphicsInc/gltf-pipeline/pull/418)

--- a/lib/updateVersion.js
+++ b/lib/updateVersion.js
@@ -836,7 +836,7 @@ function isNodeEmpty(node) {
         (!defined(node.scale) || Cartesian3.fromArray(node.scale).equals(new Cartesian3(1.0, 1.0, 1.0))) &&
         (!defined(node.rotation) || Cartesian4.fromArray(node.rotation).equals(new Cartesian4(0.0, 0.0, 0.0, 1.0))) &&
         (!defined(node.matrix) || Matrix4.fromColumnMajorArray(node.matrix).equals(Matrix4.IDENTITY)) &&
-        !defined(node.extensions && !defined(node.extras));
+        !defined(node.extensions) && !defined(node.extras);
 }
 
 function deleteNode(gltf, nodeId) {

--- a/lib/updateVersion.js
+++ b/lib/updateVersion.js
@@ -835,7 +835,8 @@ function isNodeEmpty(node) {
         (!defined(node.translation) || Cartesian3.fromArray(node.translation).equals(Cartesian3.ZERO)) &&
         (!defined(node.scale) || Cartesian3.fromArray(node.scale).equals(new Cartesian3(1.0, 1.0, 1.0))) &&
         (!defined(node.rotation) || Cartesian4.fromArray(node.rotation).equals(new Cartesian4(0.0, 0.0, 0.0, 1.0))) &&
-        (!defined(node.matrix) || Matrix4.fromColumnMajorArray(node.matrix).equals(Matrix4.IDENTITY));
+        (!defined(node.matrix) || Matrix4.fromColumnMajorArray(node.matrix).equals(Matrix4.IDENTITY)) &&
+        !defined(node.extensions && !defined(node.extras));
 }
 
 function deleteNode(gltf, nodeId) {

--- a/specs/lib/updateVersionSpec.js
+++ b/specs/lib/updateVersionSpec.js
@@ -325,6 +325,18 @@ describe('updateVersion', function() {
                 'WEB3D_quantized_attributes',
                 'UNKOWN_EXTENSION'
             ],
+            extensions: {
+                KHR_materials_common: {
+                    lights: {
+                        directionalLight: {
+                            directional: {
+                                color: [1, 0, 0]
+                            },
+                            type: 'directional'
+                        }
+                    }
+                }
+            },
             meshes: {
                 mesh: {
                     primitives: [
@@ -543,6 +555,13 @@ describe('updateVersion', function() {
                         0, 0, 1, 0,
                         0, 0, 0, 1
                     ]
+                },
+                lightNode: {
+                    extensions: {
+                        KHR_materials_common: {
+                            light: 'directionalLight'
+                        }
+                    }
                 }
             },
             programs: {
@@ -562,7 +581,8 @@ describe('updateVersion', function() {
                 defaultScene: {
                     nodes: [
                         'rootTransform',
-                        'emptyNodeParent'
+                        'emptyNodeParent',
+                        'lightNode'
                     ]
                 }
             },
@@ -631,7 +651,8 @@ describe('updateVersion', function() {
                 expect(getNodeByName(gltf, 'nonEmptyNodeParent')).toBeDefined();
                 expect(getNodeByName(gltf, 'emptyNodeParent')).toBeUndefined();
                 expect(getNodeByName(gltf, 'emptyNode')).toBeUndefined();
-                expect(gltf.scenes[0].nodes.length).toBe(1);
+                expect(getNodeByName(gltf, 'lightNode')).toBeDefined();
+                expect(gltf.scenes[0].nodes.length).toBe(2);
 
                 // Expect material values to be moved to material KHR_techniques_webgl extension
                 var material = gltf.materials[0];


### PR DESCRIPTION
Fixes a bug where nodes containing extensions or extras where being removed in the glTF 1.0 to 2.0 upgrade stage.

This came up in https://github.com/AnalyticalGraphicsInc/cesium/issues/7205 where the `KHR_materials_common` lights were getting removed.

@ggetz can you review?