### PR TITLE
Remove -s flag from Draco instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ npm install -g gltf-pipeline
 `gltf-pipeline -i model.glb -j`
 
 #### Converting a glTF to Draco glTF
-`gltf-pipeline -i model.gltf -o modelDraco.gltf -d -s`
+`gltf-pipeline -i model.gltf -o modelDraco.gltf -d`
 
 ### Saving separate textures
 `gltf-pipeline -i model.gltf -t`


### PR DESCRIPTION
Removes the `-s` flag from the Draco instructions in the readme. I think this was causing confusion because `-d` and `-s` don't need to be run together.