### PR TITLE
Add WebP to image extension header check

### DIFF
--- a/lib/getImageExtension.js
+++ b/lib/getImageExtension.js
@@ -15,6 +15,8 @@ module.exports = getImageExtension;
  */
 function getImageExtension(data) {
     var header = data.slice(0, 2);
+    var webpHeaderRIFFChars = data.slice(0, 4);
+    var webpHeaderWEBPChars = data.slice(8, 12);
     if (header.equals(Buffer.from([0x42, 0x4D]))) {
         return '.bmp';
     } else if (header.equals(Buffer.from([0x47, 0x49]))) {
@@ -27,6 +29,9 @@ function getImageExtension(data) {
         return '.ktx';
     } else if (header.equals(Buffer.from([0x48, 0x78]))) {
         return '.crn';
+    } else if (webpHeaderRIFFChars.equals(Buffer.from([0x52, 0x49, 0x46, 0x46])) && webpHeaderWEBPChars.equals(Buffer.from([0x57, 0x45, 0x42, 0x50]))) {
+        // https://developers.google.com/speed/webp/docs/riff_container#webp_file_header
+        return '.webp';
     }
 
     throw new RuntimeError('Image data does not have valid header');


### PR DESCRIPTION
This adds a check to support using WebP images with gltf-pipeline.