### PR TITLE
Quantization volume option

### DIFF
--- a/lib/compressDracoMeshes.js
+++ b/lib/compressDracoMeshes.js
@@ -14,6 +14,7 @@ const replaceWithDecompressedPrimitive = require('./replaceWithDecompressedPrimi
 const splitPrimitives = require('./splitPrimitives');
 
 const arrayFill = Cesium.arrayFill;
+const Cartesian3 = Cesium.Cartesian3;
 const Check = Cesium.Check;
 const clone = Cesium.clone;
 const ComponentDatatype = Cesium.ComponentDatatype;
@@ -41,6 +42,7 @@ module.exports = compressDracoMeshes;
  * @param {Number} [options.dracoOptions.quantizeGenericBits=12] A value between 0 and 30 specifying the number of bits used for skinning attributes (joint indices and joint weights) and custom attributes. Lower values produce better compression, but will lose precision. A value of 0 does not set quantization.
  * @param {Boolean} [options.dracoOptions.uncompressedFallback=false] If set, add uncompressed fallback versions of the compressed meshes.
  * @param {Boolean} [options.dracoOptions.unifiedQuantization=false] Quantize positions, defined by the unified bounding box of all primitives. If not set, quantization is applied separately.
+ * @param {Object} [options.dracoOptions.quantizationVolume] An AxisAlignedBoundingBox defining the explicit quantization volume.
  * @returns {Object} The glTF asset with compressed meshes.
  *
  * @private
@@ -57,6 +59,8 @@ function compressDracoMeshes(gltf, options) {
     const quantizeGenericBits = defaultValue(dracoOptions.quantizeGenericBits, defaults.quantizeGenericBits);
     const uncompressedFallback = defaultValue(dracoOptions.uncompressedFallback, defaults.uncompressedFallback);
     const unifiedQuantization = defaultValue(dracoOptions.unifiedQuantization, defaults.unifiedQuantization);
+    const quantizationVolume = dracoOptions.quantizationVolume;
+    const explicitQuantization = unifiedQuantization || defined(quantizationVolume);
     checkRange('compressionLevel', compressionLevel, 0, 10);
     checkRange('quantizePositionBits', quantizePositionBits, 0, 30);
     checkRange('quantizeNormalBits', quantizeNormalBits, 0, 30);
@@ -70,7 +74,10 @@ function compressDracoMeshes(gltf, options) {
     let positionOrigin;
     let positionRange;
 
-    if (unifiedQuantization) {
+    if (defined(quantizationVolume)) {
+        positionOrigin = Cartesian3.pack(quantizationVolume.minimum, new Array(3));
+        positionRange = Cartesian3.maximumComponent(Cartesian3.subtract(quantizationVolume.maximum, quantizationVolume.minimum, new Cartesian3()));
+    } else if (unifiedQuantization) {
         // Collect bounding box from all primitives. Currently works only for vec3 positions (XYZ).
         const accessors = gltf.accessors;
         const min = arrayFill(new Array(3), Number.POSITIVE_INFINITY);
@@ -88,7 +95,7 @@ function compressDracoMeshes(gltf, options) {
             }
         });
         positionOrigin = min;
-        positionRange = Math.max(max[0] - min[0], Math.max(max[1] - min[1], max[2] - min[2]));
+        positionRange = Math.max(max[0] - min[0], max[1] - min[1], max[2] - min[2]);
     }
 
     let addedExtension = false;
@@ -164,7 +171,7 @@ function compressDracoMeshes(gltf, options) {
             const encodedDracoDataArray = new encoderModule.DracoInt8Array();
             encoder.SetSpeedOptions(10 - compressionLevel, 10 - compressionLevel);  // Compression level is 10 - speed.
             if (quantizePositionBits > 0) {
-                if (unifiedQuantization) {
+                if (explicitQuantization) {
                     encoder.SetAttributeExplicitQuantization(encoderModule.POSITION, quantizePositionBits, 3, positionOrigin, positionRange);
                 } else {
                     encoder.SetAttributeQuantization(encoderModule.POSITION, quantizePositionBits);

--- a/specs/lib/compressDracoMeshesSpec.js
+++ b/specs/lib/compressDracoMeshesSpec.js
@@ -1,5 +1,5 @@
 'use strict';
-const { clone, DeveloperError} = require('cesium');
+const { AxisAlignedBoundingBox, Cartesian3, clone, DeveloperError} = require('cesium');
 const fsExtra = require('fs-extra');
 const readResources = require('../../lib/readResources');
 const compressDracoMeshes = require('../../lib/compressDracoMeshes');
@@ -100,6 +100,31 @@ describe('compressDracoMeshes', () => {
         const dracoBufferUnified = getDracoBuffer(gltfUnified);
         const dracoBufferNonUnified = getDracoBuffer(gltfNonUnified);
         expect(dracoBufferNonUnified).not.toEqual(dracoBufferUnified);
+    });
+
+    it('uses explicit quantization volume', async () => {
+        const gltfVolume = await readGltf(multipleBoxesPath);
+        const gltfUnified = await readGltf(multipleBoxesPath);
+        const gltfDefault = await readGltf(multipleBoxesPath);
+        const aabb = new AxisAlignedBoundingBox(new Cartesian3(-10.0, -10.0, -10.0), new Cartesian3(10.0, 10.0, 10.0));
+        compressDracoMeshes(gltfVolume, {
+            dracoOptions: {
+                quantizationVolume: aabb
+            }
+        });
+        compressDracoMeshes(gltfUnified, {
+            dracoOptions: {
+                unifiedQuantization: true
+            }
+        });
+        compressDracoMeshes(gltfDefault, {
+            dracoOptions: {}
+        });
+        const dracoBufferVolume = getDracoBuffer(gltfVolume);
+        const dracoBufferUnified = getDracoBuffer(gltfUnified);
+        const dracoBufferDefault = getDracoBuffer(gltfDefault);
+        expect(dracoBufferVolume).not.toEqual(dracoBufferDefault);
+        expect(dracoBufferVolume).not.toEqual(dracoBufferUnified);
     });
 
     it('applies quantization bits', () => {


### PR DESCRIPTION
Adds an option to `compressDracoMeshes` that defines the explicit quantization volume to use rather the automatically computed ones.