### PR TITLE
readAccessorPacked: Fix accessor reading with undefined byteOffsets

### DIFF
--- a/lib/readAccessorPacked.js
+++ b/lib/readAccessorPacked.js
@@ -33,7 +33,9 @@ function readAccessorPacked(gltf, accessor) {
 
     const bufferView = gltf.bufferViews[accessor.bufferView];
     const source = gltf.buffers[bufferView.buffer].extras._pipeline.source;
-    let byteOffset = accessor.byteOffset + bufferView.byteOffset + source.byteOffset;
+    let byteOffset = (accessor.byteOffset || 0)
+        + (bufferView.byteOffset || 0)
+        + (source.byteOffset || 0);
 
     const dataView = new DataView(source.buffer);
     const components = new Array(numberOfComponents);


### PR DESCRIPTION
Hi @likangning93 !

First of all: thanks for sharing the code of gltf-pipeline, I am currently trying to some custom gltf processing and this is really helping me out.

On the way I found a small bug that caused accessors being read incorrectly if no byteOffset is set on either the bufferView, accessor or source. According to the spec ([accessor.byteOffset](https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#accessorbyteoffset) & [bufferView.byteOffset](https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#accessorbyteoffset)) these should default to 0.

This may not be an issue with the command line tool, I suspect it may fill in default values before processing. In this case, maybe I should be calling something before doing this kind of processing?

Cheers, Jonathan.