### PR TITLE
Remove more unused elements

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 Change Log
 ==========
 
+### HEAD
+
+* Added removal of unused materials, nodes and meshes. [#465](https://github.com/AnalyticalGraphicsInc/gltf-pipeline/pull/465)
+* Added `keepUnusedElements` flag to keep unused materials, nodes and meshes. [#465](https://github.com/AnalyticalGraphicsInc/gltf-pipeline/pull/465)
+
 ### 2.1.3 - 2019-03-21
 
 * Fixed a crash when saving separate resources that would exceed the Node buffer size limit. [#468](https://github.com/AnalyticalGraphicsInc/gltf-pipeline/pull/468)

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ processGltf(gltf, options)
 |`--separate`, `-s`|Write separate buffers, shaders, and textures instead of embedding them in the glTF.|No, default `false`|
 |`--separateTextures`, `-t`|Write out separate textures only.|No, default `false`|
 |`--stats`|Print statistics to console for output glTF file.|No, default `false`|
+|`--keepUnusedElements`|Keep unused materials, nodes and meshes.|No, default `false`|
 |`--draco.compressMeshes`, `-d`|Compress the meshes using Draco. Adds the KHR_draco_mesh_compression extension.|No, default `false`|
 |`--draco.compressionLevel`|Draco compression level [0-10], most is 10, least is 0. A value of 0 will apply sequential encoding and preserve face order.|No, default `7`|
 |`--draco.quantizePositionBits`|Quantization bits for position attribute when using Draco compression.|No, default `14`|

--- a/bin/gltf-pipeline.js
+++ b/bin/gltf-pipeline.js
@@ -69,6 +69,11 @@ const argv = yargs
             type: 'boolean',
             default: defaults.stats
         },
+        keepUnusedElements: {
+            describe: 'Keep unused materials, nodes and meshes.',
+            type: 'boolean',
+            default: false
+        },
         'draco.compressMeshes': {
             alias: 'd',
             describe: 'Compress the meshes using Draco. Adds the KHR_draco_mesh_compression extension.',

--- a/bin/gltf-pipeline.js
+++ b/bin/gltf-pipeline.js
@@ -72,7 +72,7 @@ const argv = yargs
         keepUnusedElements: {
             describe: 'Keep unused materials, nodes and meshes.',
             type: 'boolean',
-            default: false
+            default: defaults.keepUnusedElements
         },
         'draco.compressMeshes': {
             alias: 'd',

--- a/lib/ForEach.js
+++ b/lib/ForEach.js
@@ -348,6 +348,21 @@ ForEach.skin = function(gltf, handler) {
     return ForEach.topLevel(gltf, 'skins', handler);
 };
 
+ForEach.skinJoint = function(skin, handler) {
+    const joints = skin.joints;
+    if (defined(joints)) {
+        const jointsLength = joints.length;
+        for (let i = 0; i < jointsLength; i++) {
+            const joint = joints[i];
+            const value = handler(joint);
+
+            if (defined(value)) {
+                return value;
+            }
+        }
+    }
+};
+
 ForEach.techniqueAttribute = function(technique, handler) {
     const attributes = technique.attributes;
     for (const attributeName in attributes) {

--- a/lib/compressDracoMeshes.js
+++ b/lib/compressDracoMeshes.js
@@ -226,7 +226,7 @@ function compressDracoMeshes(gltf, options) {
         } else {
             addExtensionsRequired(gltf, 'KHR_draco_mesh_compression');
         }
-        removeUnusedElements(gltf);
+        removeUnusedElements(gltf, ['accessor', 'bufferView', 'buffer']);
 
         if (uncompressedFallback) {
             assignMergedBufferNames(gltf);

--- a/lib/processGltf.js
+++ b/lib/processGltf.js
@@ -7,6 +7,7 @@ const getStatistics = require('./getStatistics');
 const readResources = require('./readResources');
 const removeDefaults = require('./removeDefaults');
 const removePipelineExtras = require('./removePipelineExtras');
+const removeUnusedElements = require('./removeUnusedElements');
 const updateVersion = require('./updateVersion');
 const writeResources = require('./writeResources');
 const compressDracoMeshes = require('./compressDracoMeshes');
@@ -82,6 +83,9 @@ function getStages(options) {
     if (defined(options.dracoOptions)) {
         stages.push(compressDracoMeshes);
     }
+    if (!defined(options.keepUnusedElements)) {
+        stages.push((gltf, options) => removeUnusedElements(gltf));
+    }
     return stages;
 }
 
@@ -113,6 +117,12 @@ processGltf.defaults = {
      * @default false
      */
     stats: false,
+    /**
+     * Keep unused 'node', 'mesh' and 'material' elements.
+     * @type Boolean
+     * @default false
+     */
+    keepUnusedElements: false,
     /**
      * Gets or sets whether to compress the meshes using Draco. Adds the KHR_draco_mesh_compression extension.
      * @type Boolean

--- a/lib/processGltf.js
+++ b/lib/processGltf.js
@@ -84,7 +84,9 @@ function getStages(options) {
         stages.push(compressDracoMeshes);
     }
     if (!options.keepUnusedElements) {
-        stages.push((gltf, options) => removeUnusedElements(gltf));
+        stages.push(function(gltf, options) {
+            removeUnusedElements(gltf);
+        });
     }
     return stages;
 }

--- a/lib/processGltf.js
+++ b/lib/processGltf.js
@@ -83,7 +83,7 @@ function getStages(options) {
     if (defined(options.dracoOptions)) {
         stages.push(compressDracoMeshes);
     }
-    if (!defined(options.keepUnusedElements)) {
+    if (!options.keepUnusedElements) {
         stages.push((gltf, options) => removeUnusedElements(gltf));
     }
     return stages;

--- a/lib/removeUnusedElements.js
+++ b/lib/removeUnusedElements.js
@@ -18,9 +18,12 @@ module.exports = removeUnusedElements;
  *
  * @private
  */
-function removeUnusedElements(gltf, elementTypes=['node', 'mesh', 'material', 'accessor', 'bufferView', 'buffer']) {
+function removeUnusedElements(gltf, elementTypes) {
+    if(elementTypes === undefined) {
+        elementTypes = ['node', 'mesh', 'material', 'accessor', 'bufferView', 'buffer'];
+    }
     ['mesh', 'node', 'material', 'accessor', 'bufferView', 'buffer'].forEach(function(type) {
-        if(elementTypes.includes(type)) {
+        if (elementTypes.includes(type)) {
             removeUnusedElementsByType(gltf, type);
         }
     });
@@ -46,7 +49,7 @@ function removeUnusedElementsByType(gltf, type) {
         const length = arrayOfObjects.length;
 
         for (let i = 0; i < length; ++i) {
-            if(!usedIds[i]) {
+            if (!usedIds[i]) {
                 Remove[type](gltf, i - removed);
                 removed++;
             }
@@ -171,11 +174,11 @@ Remove.mesh = function(gltf, meshId) {
     meshes.splice(meshId, 1);
 
     ForEach.node(gltf, function(n) {
-        if(defined(n.mesh)) {
-            if(n.mesh > meshId) {
+        if (defined(n.mesh)) {
+            if (n.mesh > meshId) {
                 --n.mesh;
-            } else if(n.mesh === meshId) {
-                /* Remove reference to deleted mesh */
+            } else if (n.mesh === meshId) {
+                // Remove reference to deleted mesh
                 delete n.mesh;
             }
         }
@@ -184,25 +187,39 @@ Remove.mesh = function(gltf, meshId) {
 
 Remove.node = function(gltf, nodeId) {
     const nodes = gltf.nodes;
-
-    /* Remove this node from parent */
-    const parentId = findParentNode(gltf, nodeId);
-    if(parentId >= 0) {
-        nodes[parentId].children = nodes[parentId].children.filter(x => x !== nodeId);
-    }
-
     nodes.splice(nodeId, 1);
 
-    /* Shift all node references */
-    nodes.forEach(other => {
-        if(defined(other.children)) {
-            other.children = other.children.map(x => x > nodeId ? x - 1 : x);
+    // Shift all node references
+    ForEach.skin(gltf, function(s) {
+        if (s.skeleton) {
+            s.skeleton -= s.skeleton > nodeId ? 1 : 0;
+        }
+
+        s.joints -= s.joints.map(function(x) { x > nodeId ? x - 1 : x });
+    });
+    ForEach.animation(gltf, function(animation) {
+        if(animation.target && animation.target.node) {
+            animation.target.node -= animation.target.node > nodeId ? 1 : 0;
         }
     });
-    ForEach.scene(gltf, (s, i) => {
+    ForEach.technique(gltf, function(technique) {
+        ForEach.techniqueUniform(technique, function(uniform) {
+            if (defined(uniform.node)) {
+                uniform.node -= uniform.node > nodeId ? 1 : 0;
+            }
+        });
+    });
+    ForEach.node(gltf, function(n) {
+        if (!n.children) return;
+
+        n.children = n.children
+            .filter(function(x) { x !== nodeId }) // Remove
+            .map(function(x) { x > nodeId ? x - 1 : x }); // Shift indices
+    });
+    ForEach.scene(gltf, function(s, i) {
         s.nodes = s.nodes
-            .filter(x => x !== nodeId) /* Remove */
-            .map(x => x > nodeId ? x - 1 : x); /* Shift indices */
+            .filter(function(x) { x !== nodeId }) // Remove
+            .map(function(x) { x > nodeId ? x - 1 : x }); // Shift indices
     });
 };
 
@@ -210,13 +227,11 @@ Remove.material = function(gltf, materialId) {
     const materials = gltf.materials;
     materials.splice(materialId, 1);
 
-    /* Shift other material ids */
-    ForEach.mesh(gltf, (m, j) => {
-        m.primitives.forEach(p => {
-            if(p.material > materialId) {
-                --p.material;
-            }
-        });
+    // Shift other material ids
+    ForEach.meshPrimitive(gltf, function(p) {
+        if (p.material > materialId) {
+            --p.material;
+        }
     });
 
     return gltf;
@@ -327,20 +342,20 @@ getListOfElementsIdsInUse.bufferView = function(gltf) {
 
 getListOfElementsIdsInUse.mesh = function(gltf) {
     const usedMeshIds = {};
-    ForEach.mesh(gltf, (mesh, i) => {
-        if(!defined(mesh.primitives) || mesh.primitives.length === 0) {
+    ForEach.mesh(gltf, function(mesh, i) {
+        if (!defined(mesh.primitives) || mesh.primitives.length === 0) {
             usedMeshIds[i] = false;
         }
     });
 
-    ForEach.node(gltf, (node, i) => {
-        if(!defined(node.mesh)) {
+    ForEach.node(gltf, function(node, i) {
+        if (!defined(node.mesh)) {
             return;
         }
-        /* Mesh marked as empty in previous step? */
+        // Mesh marked as empty in previous step?
         const meshIsEmpty = defined(usedMeshIds[node.mesh]);
 
-        if(!meshIsEmpty) {
+        if (!meshIsEmpty) {
             usedMeshIds[node.mesh] = true;
         }
     });
@@ -348,40 +363,61 @@ getListOfElementsIdsInUse.mesh = function(gltf) {
     return usedMeshIds;
 };
 
-/* Find parent node id of the given node, or -1 if no parent */
+// Find parent node id of the given node, or -1 if no parent
 function findParentNode(gltf, node) {
-    return gltf.nodes.findIndex(n => (n.children || []).includes(node));
+    return gltf.nodes.findIndex(function(n) { (n.children || []).includes(node) });
 }
 
 /* Check if node is empty. It is considered empty if neither referencing
  * mesh, camera, extensions and has no children */
 function nodeIsEmpty(gltf, node) {
-    if(defined(node.mesh) || defined(node.camera) || defined(node.skin)
+    if (defined(node.mesh) || defined(node.camera) || defined(node.skin)
         || defined(node.weights) || defined(node.extras)
         || (defined(node.extensions) && node.extensions.length !== 0)) {
         return false;
     }
 
-    /* Empty if no children or children are all empty nodes */
+    // Empty if no children or children are all empty nodes
     return !defined(node.children)
-        || node.children.filter(n => !nodeIsEmpty(gltf, gltf.nodes[n])).length === 0;
+        || node.children.filter(function(n) { !nodeIsEmpty(gltf, gltf.nodes[n]) }).length === 0;
 }
 
 getListOfElementsIdsInUse.node = function(gltf) {
     const usedNodeIds = {};
-    ForEach.node(gltf, (node, nodeId) => {
-        if(!nodeIsEmpty(gltf, node)) {
+    ForEach.node(gltf, function(node, nodeId) {
+        if (!nodeIsEmpty(gltf, node)) {
             usedNodeIds[nodeId] = true;
         }
     });
+    ForEach.skin(gltf, function(s) {
+        if (s.skeleton) {
+            usedNodeIds[s.skeleton] = true;
+        }
 
-    ForEach.animation(gltf, (anim, animId) => {
-        if(!defined(anim.channels)) {
+        ForEach.joint(s, function(j) {
+            usedNodeIds[j] = true;
+        });
+    });
+    ForEach.animation(gltf, function(animation) {
+        if(animation.target && animation.target.node) {
+            usedNodeIds[animation.target.node] = true;
+        }
+    });
+    ForEach.technique(gltf, function(technique) {
+        ForEach.techniqueUniform(technique, function(uniform) {
+            if (defined(uniform.node)) {
+                usedNodeIds[uniform.node] = true;
+            }
+        });
+    });
+
+    ForEach.animation(gltf, function(anim, animId) {
+        if (!defined(anim.channels)) {
             return;
         }
 
-        anim.channels.forEach(c => {
-            if(defined(c.target) && defined(c.target.node)) {
+        anim.channels.forEach(function(c) {
+            if (defined(c.target) && defined(c.target.node)) {
                 /* Keep all nodes that are being targeted
                 * by an animation */
                 usedNodeIds[c.target.node] = true;
@@ -394,8 +430,9 @@ getListOfElementsIdsInUse.node = function(gltf) {
 
 getListOfElementsIdsInUse.material = function(gltf) {
     const usedMaterialIds = {};
-    gltf.meshes.forEach((m, i) => {
-        m.primitives.forEach((p, i) => {
+
+    ForEach.mesh(gltf, function(mesh) {
+        ForEach.meshPrimitive(mesh, function(p) {
             usedMaterialIds[p.material] = true;
         });
     });

--- a/lib/removeUnusedElements.js
+++ b/lib/removeUnusedElements.js
@@ -12,20 +12,28 @@ module.exports = removeUnusedElements;
  * This function currently only works for accessors, buffers, and bufferViews.
  *
  * @param {Object} gltf A javascript object containing a glTF asset.
+ * @param {Array<string>} elementTypes Element types to be removed. Needs to be a subset of
+ *          ['node', 'mesh', 'material', 'accessor', 'bufferView', 'buffer'], other items
+ *          will be ignored.
  *
  * @private
  */
-function removeUnusedElements(gltf) {
-    removeUnusedElementsByType(gltf, 'accessor');
-    removeUnusedElementsByType(gltf, 'bufferView');
-    removeUnusedElementsByType(gltf, 'buffer');
+function removeUnusedElements(gltf, elementTypes=['node', 'mesh', 'material', 'accessor', 'bufferView', 'buffer']) {
+    ['mesh', 'node', 'material', 'accessor', 'bufferView', 'buffer'].forEach(function(type) {
+        if(elementTypes.includes(type)) {
+            removeUnusedElementsByType(gltf, type);
+        }
+    });
     return gltf;
 }
 
 const TypeToGltfElementName = {
     accessor: 'accessors',
     buffer: 'buffers',
-    bufferView: 'bufferViews'
+    bufferView: 'bufferViews',
+    node: 'nodes',
+    material: 'materials',
+    mesh: 'meshes'
 };
 
 function removeUnusedElementsByType(gltf, type) {
@@ -38,7 +46,7 @@ function removeUnusedElementsByType(gltf, type) {
         const length = arrayOfObjects.length;
 
         for (let i = 0; i < length; ++i) {
-            if (!usedIds[i]) {
+            if(!usedIds[i]) {
                 Remove[type](gltf, i - removed);
                 removed++;
             }
@@ -158,6 +166,62 @@ Remove.bufferView = function(gltf, bufferViewId) {
     }
 };
 
+Remove.mesh = function(gltf, meshId) {
+    const meshes = gltf.meshes;
+    meshes.splice(meshId, 1);
+
+    ForEach.node(gltf, function(n) {
+        if(defined(n.mesh)) {
+            if(n.mesh > meshId) {
+                --n.mesh;
+            } else if(n.mesh === meshId) {
+                /* Remove reference to deleted mesh */
+                delete n.mesh;
+            }
+        }
+    });
+};
+
+Remove.node = function(gltf, nodeId) {
+    const nodes = gltf.nodes;
+
+    /* Remove this node from parent */
+    const parentId = findParentNode(gltf, nodeId);
+    if(parentId >= 0) {
+        nodes[parentId].children = nodes[parentId].children.filter(x => x !== nodeId);
+    }
+
+    nodes.splice(nodeId, 1);
+
+    /* Shift all node references */
+    nodes.forEach(other => {
+        if(defined(other.children)) {
+            other.children = other.children.map(x => x > nodeId ? x - 1 : x);
+        }
+    });
+    ForEach.scene(gltf, (s, i) => {
+        s.nodes = s.nodes
+            .filter(x => x !== nodeId) /* Remove */
+            .map(x => x > nodeId ? x - 1 : x); /* Shift indices */
+    });
+};
+
+Remove.material = function(gltf, materialId) {
+    const materials = gltf.materials;
+    materials.splice(materialId, 1);
+
+    /* Shift other material ids */
+    ForEach.mesh(gltf, (m, j) => {
+        m.primitives.forEach(p => {
+            if(p.material > materialId) {
+                --p.material;
+            }
+        });
+    });
+
+    return gltf;
+};
+
 /**
  * Contains functions for getting a list of element ids in use by the glTF asset.
  * @constructor
@@ -259,4 +323,82 @@ getListOfElementsIdsInUse.bufferView = function(gltf) {
     }
 
     return usedBufferViewIds;
+};
+
+getListOfElementsIdsInUse.mesh = function(gltf) {
+    const usedMeshIds = {};
+    ForEach.mesh(gltf, (mesh, i) => {
+        if(!defined(mesh.primitives) || mesh.primitives.length === 0) {
+            usedMeshIds[i] = false;
+        }
+    });
+
+    ForEach.node(gltf, (node, i) => {
+        if(!defined(node.mesh)) {
+            return;
+        }
+        /* Mesh marked as empty in previous step? */
+        const meshIsEmpty = defined(usedMeshIds[node.mesh]);
+
+        if(!meshIsEmpty) {
+            usedMeshIds[node.mesh] = true;
+        }
+    });
+
+    return usedMeshIds;
+};
+
+/* Find parent node id of the given node, or -1 if no parent */
+function findParentNode(gltf, node) {
+    return gltf.nodes.findIndex(n => (n.children || []).includes(node));
+}
+
+/* Check if node is empty. It is considered empty if neither referencing
+ * mesh, camera, extensions and has no children */
+function nodeIsEmpty(gltf, node) {
+    if(defined(node.mesh) || defined(node.camera) || defined(node.skin)
+        || defined(node.weights) || defined(node.extras)
+        || (defined(node.extensions) && node.extensions.length !== 0)) {
+        return false;
+    }
+
+    /* Empty if no children or children are all empty nodes */
+    return !defined(node.children)
+        || node.children.filter(n => !nodeIsEmpty(gltf, gltf.nodes[n])).length === 0;
+}
+
+getListOfElementsIdsInUse.node = function(gltf) {
+    const usedNodeIds = {};
+    ForEach.node(gltf, (node, nodeId) => {
+        if(!nodeIsEmpty(gltf, node)) {
+            usedNodeIds[nodeId] = true;
+        }
+    });
+
+    ForEach.animation(gltf, (anim, animId) => {
+        if(!defined(anim.channels)) {
+            return;
+        }
+
+        anim.channels.forEach(c => {
+            if(defined(c.target) && defined(c.target.node)) {
+                /* Keep all nodes that are being targeted
+                * by an animation */
+                usedNodeIds[c.target.node] = true;
+            }
+        });
+    });
+
+    return usedNodeIds;
+};
+
+getListOfElementsIdsInUse.material = function(gltf) {
+    const usedMaterialIds = {};
+    gltf.meshes.forEach((m, i) => {
+        m.primitives.forEach((p, i) => {
+            usedMaterialIds[p.material] = true;
+        });
+    });
+
+    return usedMaterialIds;
 };

--- a/lib/removeUnusedElements.js
+++ b/lib/removeUnusedElements.js
@@ -195,7 +195,9 @@ Remove.node = function(gltf, nodeId) {
             s.skeleton -= s.skeleton > nodeId ? 1 : 0;
         }
 
-        s.joints -= s.joints.map(function(x) { x > nodeId ? x - 1 : x });
+        s.joints -= s.joints.map(function(x) {
+            return x > nodeId ? x - 1 : x;
+        });
     });
     ForEach.animation(gltf, function(animation) {
         if(animation.target && animation.target.node) {
@@ -210,16 +212,26 @@ Remove.node = function(gltf, nodeId) {
         });
     });
     ForEach.node(gltf, function(n) {
-        if (!n.children) return;
+        if (!n.children) {
+            return;
+        }
 
         n.children = n.children
-            .filter(function(x) { x !== nodeId }) // Remove
-            .map(function(x) { x > nodeId ? x - 1 : x }); // Shift indices
+            .filter(function(x) {
+                return x !== nodeId; // Remove
+            })
+            .map(function(x) {
+                return x > nodeId ? x - 1 : x; // Shift indices
+            });
     });
     ForEach.scene(gltf, function(s, i) {
         s.nodes = s.nodes
-            .filter(function(x) { x !== nodeId }) // Remove
-            .map(function(x) { x > nodeId ? x - 1 : x }); // Shift indices
+            .filter(function(x) {
+                return x !== nodeId; // Remove
+            })
+            .map(function(x) {
+                return x > nodeId ? x - 1 : x; // Shift indices
+            });
     });
 };
 
@@ -363,11 +375,6 @@ getListOfElementsIdsInUse.mesh = function(gltf) {
     return usedMeshIds;
 };
 
-// Find parent node id of the given node, or -1 if no parent
-function findParentNode(gltf, node) {
-    return gltf.nodes.findIndex(function(n) { (n.children || []).includes(node) });
-}
-
 /* Check if node is empty. It is considered empty if neither referencing
  * mesh, camera, extensions and has no children */
 function nodeIsEmpty(gltf, node) {
@@ -379,7 +386,9 @@ function nodeIsEmpty(gltf, node) {
 
     // Empty if no children or children are all empty nodes
     return !defined(node.children)
-        || node.children.filter(function(n) { !nodeIsEmpty(gltf, gltf.nodes[n]) }).length === 0;
+        || node.children.filter(function(n) {
+            return !nodeIsEmpty(gltf, gltf.nodes[n]);
+        }).length === 0;
 }
 
 getListOfElementsIdsInUse.node = function(gltf) {

--- a/lib/removeUnusedElements.js
+++ b/lib/removeUnusedElements.js
@@ -3,27 +3,25 @@ const Cesium = require('cesium');
 const ForEach = require('./ForEach');
 const hasExtension = require('./hasExtension');
 
+const defaultValue = Cesium.defaultValue;
 const defined = Cesium.defined;
 
 module.exports = removeUnusedElements;
 
+const allElementTypes = ['mesh', 'node', 'material', 'accessor', 'bufferView', 'buffer'];
+
 /**
  * Removes unused elements from gltf.
- * This function currently only works for accessors, buffers, and bufferViews.
  *
  * @param {Object} gltf A javascript object containing a glTF asset.
- * @param {Array<string>} elementTypes Element types to be removed. Needs to be a subset of
- *          ['node', 'mesh', 'material', 'accessor', 'bufferView', 'buffer'], other items
- *          will be ignored.
+ * @param {String[]} [elementTypes=['mesh', 'node', 'material', 'accessor', 'bufferView', 'buffer']] Element types to be removed. Needs to be a subset of ['mesh', 'node', 'material', 'accessor', 'bufferView', 'buffer'], other items will be ignored.
  *
  * @private
  */
 function removeUnusedElements(gltf, elementTypes) {
-    if(elementTypes === undefined) {
-        elementTypes = ['node', 'mesh', 'material', 'accessor', 'bufferView', 'buffer'];
-    }
-    ['mesh', 'node', 'material', 'accessor', 'bufferView', 'buffer'].forEach(function(type) {
-        if (elementTypes.includes(type)) {
+    elementTypes = defaultValue(elementTypes, allElementTypes);
+    allElementTypes.forEach(function(type) {
+        if (elementTypes.indexOf(type) > -1) {
             removeUnusedElementsByType(gltf, type);
         }
     });
@@ -156,8 +154,8 @@ Remove.bufferView = function(gltf, bufferViewId) {
     });
 
     if (hasExtension(gltf, 'KHR_draco_mesh_compression')) {
-        ForEach.mesh(gltf, function (mesh) {
-            ForEach.meshPrimitive(mesh, function (primitive) {
+        ForEach.mesh(gltf, function(mesh) {
+            ForEach.meshPrimitive(mesh, function(primitive) {
                 if (defined(primitive.extensions) &&
                     defined(primitive.extensions.KHR_draco_mesh_compression)) {
                     if (primitive.extensions.KHR_draco_mesh_compression.bufferView > bufferViewId) {
@@ -173,13 +171,13 @@ Remove.mesh = function(gltf, meshId) {
     const meshes = gltf.meshes;
     meshes.splice(meshId, 1);
 
-    ForEach.node(gltf, function(n) {
-        if (defined(n.mesh)) {
-            if (n.mesh > meshId) {
-                --n.mesh;
-            } else if (n.mesh === meshId) {
+    ForEach.node(gltf, function(node) {
+        if (defined(node.mesh)) {
+            if (node.mesh > meshId) {
+                node.mesh--;
+            } else if (node.mesh === meshId) {
                 // Remove reference to deleted mesh
-                delete n.mesh;
+                delete node.mesh;
             }
         }
     });
@@ -190,33 +188,35 @@ Remove.node = function(gltf, nodeId) {
     nodes.splice(nodeId, 1);
 
     // Shift all node references
-    ForEach.skin(gltf, function(s) {
-        if (s.skeleton) {
-            s.skeleton -= s.skeleton > nodeId ? 1 : 0;
+    ForEach.skin(gltf, function(skin) {
+        if (defined(skin.skeleton) && skin.skeleton > nodeId) {
+            skin.skeleton--;
         }
 
-        s.joints -= s.joints.map(function(x) {
+        skin.joints = skin.joints.map(function(x) {
             return x > nodeId ? x - 1 : x;
         });
     });
     ForEach.animation(gltf, function(animation) {
-        if(animation.target && animation.target.node) {
-            animation.target.node -= animation.target.node > nodeId ? 1 : 0;
-        }
-    });
-    ForEach.technique(gltf, function(technique) {
-        ForEach.techniqueUniform(technique, function(uniform) {
-            if (defined(uniform.node)) {
-                uniform.node -= uniform.node > nodeId ? 1 : 0;
+        ForEach.animationChannel(animation, function(channel) {
+            if (defined(channel.target) && defined(channel.target.node) && (channel.target.node > nodeId)) {
+                channel.target.node--;
             }
         });
     });
-    ForEach.node(gltf, function(n) {
-        if (!n.children) {
+    ForEach.technique(gltf, function(technique) {
+        ForEach.techniqueUniform(technique, function(uniform) {
+            if (defined(uniform.node) && uniform.node > nodeId) {
+                uniform.node--;
+            }
+        });
+    });
+    ForEach.node(gltf, function(node) {
+        if (!defined(node.children)) {
             return;
         }
 
-        n.children = n.children
+        node.children = node.children
             .filter(function(x) {
                 return x !== nodeId; // Remove
             })
@@ -224,8 +224,8 @@ Remove.node = function(gltf, nodeId) {
                 return x > nodeId ? x - 1 : x; // Shift indices
             });
     });
-    ForEach.scene(gltf, function(s, i) {
-        s.nodes = s.nodes
+    ForEach.scene(gltf, function(scene) {
+        scene.nodes = scene.nodes
             .filter(function(x) {
                 return x !== nodeId; // Remove
             })
@@ -240,13 +240,13 @@ Remove.material = function(gltf, materialId) {
     materials.splice(materialId, 1);
 
     // Shift other material ids
-    ForEach.meshPrimitive(gltf, function(p) {
-        if (p.material > materialId) {
-            --p.material;
-        }
+    ForEach.mesh(gltf, function(mesh) {
+        ForEach.meshPrimitive(mesh, function(primitive) {
+            if (defined(primitive.material) && primitive.material > materialId) {
+                primitive.material--;
+            }
+        });
     });
-
-    return gltf;
 };
 
 /**
@@ -354,29 +354,20 @@ getListOfElementsIdsInUse.bufferView = function(gltf) {
 
 getListOfElementsIdsInUse.mesh = function(gltf) {
     const usedMeshIds = {};
-    ForEach.mesh(gltf, function(mesh, i) {
-        if (!defined(mesh.primitives) || mesh.primitives.length === 0) {
-            usedMeshIds[i] = false;
-        }
-    });
-
-    ForEach.node(gltf, function(node, i) {
-        if (!defined(node.mesh)) {
-            return;
-        }
-        // Mesh marked as empty in previous step?
-        const meshIsEmpty = defined(usedMeshIds[node.mesh]);
-
-        if (!meshIsEmpty) {
-            usedMeshIds[node.mesh] = true;
+    ForEach.node(gltf, function(node) {
+        if (defined(node.mesh && defined(gltf.meshes))) {
+            const mesh = gltf.meshes[node.mesh];
+            if (defined(mesh) && defined(mesh.primitives) && (mesh.primitives.length > 0)) {
+                usedMeshIds[node.mesh] = true;
+            }
         }
     });
 
     return usedMeshIds;
 };
 
-/* Check if node is empty. It is considered empty if neither referencing
- * mesh, camera, extensions and has no children */
+// Check if node is empty. It is considered empty if neither referencing
+// mesh, camera, extensions and has no children
 function nodeIsEmpty(gltf, node) {
     if (defined(node.mesh) || defined(node.camera) || defined(node.skin)
         || defined(node.weights) || defined(node.extras)
@@ -398,38 +389,26 @@ getListOfElementsIdsInUse.node = function(gltf) {
             usedNodeIds[nodeId] = true;
         }
     });
-    ForEach.skin(gltf, function(s) {
-        if (s.skeleton) {
-            usedNodeIds[s.skeleton] = true;
+    ForEach.skin(gltf, function(skin) {
+        if (defined(skin.skeleton)) {
+            usedNodeIds[skin.skeleton] = true;
         }
 
-        ForEach.joint(s, function(j) {
-            usedNodeIds[j] = true;
+        ForEach.skinJoint(skin, function(joint) {
+            usedNodeIds[joint] = true;
         });
     });
     ForEach.animation(gltf, function(animation) {
-        if(animation.target && animation.target.node) {
-            usedNodeIds[animation.target.node] = true;
-        }
+        ForEach.animationChannel(animation, function(channel) {
+            if (defined(channel.target) && defined(channel.target.node)) {
+                usedNodeIds[channel.target.node] = true;
+            }
+        });
     });
     ForEach.technique(gltf, function(technique) {
         ForEach.techniqueUniform(technique, function(uniform) {
             if (defined(uniform.node)) {
                 usedNodeIds[uniform.node] = true;
-            }
-        });
-    });
-
-    ForEach.animation(gltf, function(anim, animId) {
-        if (!defined(anim.channels)) {
-            return;
-        }
-
-        anim.channels.forEach(function(c) {
-            if (defined(c.target) && defined(c.target.node)) {
-                /* Keep all nodes that are being targeted
-                * by an animation */
-                usedNodeIds[c.target.node] = true;
             }
         });
     });
@@ -441,8 +420,10 @@ getListOfElementsIdsInUse.material = function(gltf) {
     const usedMaterialIds = {};
 
     ForEach.mesh(gltf, function(mesh) {
-        ForEach.meshPrimitive(mesh, function(p) {
-            usedMaterialIds[p.material] = true;
+        ForEach.meshPrimitive(mesh, function(primitive) {
+            if (defined(primitive.material)) {
+                usedMaterialIds[primitive.material] = true;
+            }
         });
     });
 

--- a/lib/splitPrimitives.js
+++ b/lib/splitPrimitives.js
@@ -90,7 +90,7 @@ function splitPrimitives(gltf) {
                 }
             }
         }
-        removeUnusedElements(gltf);
+        removeUnusedElements(gltf, ['accessor', 'bufferView', 'buffer']);
     }
 
     return gltf;

--- a/lib/updateVersion.js
+++ b/lib/updateVersion.js
@@ -814,7 +814,7 @@ function moveByteStrideToBufferView(gltf) {
     }
 
     // Remove unused buffer views
-    removeUnusedElements(gltf);
+    removeUnusedElements(gltf, ['accessor', 'bufferView', 'buffer']);
 }
 
 function requirePositionAccessorMinMax(gltf) {

--- a/lib/writeResources.js
+++ b/lib/writeResources.js
@@ -55,7 +55,7 @@ function writeResources(gltf, options) {
     });
 
     // Buffers need to be written last because images and shaders may write to new buffers
-    removeUnusedElements(gltf);
+    removeUnusedElements(gltf, ['acessor', 'bufferView', 'buffer']);
     mergeBuffers(gltf, options.name);
 
     ForEach.buffer(gltf, function(buffer, bufferId) {

--- a/specs/lib/removeUnusedElementsSpec.js
+++ b/specs/lib/removeUnusedElementsSpec.js
@@ -379,13 +379,13 @@ describe('removeUnusedElements', () => {
             expect(Object.keys(gltf)).toContain(k);
             expect(gltf[k].length).toBe(remaining[k].length);
 
-            /* Check that at least the remaining elements are present */
-            ForEach.topLevel(gltf, k, (element, index) => {
+            // Check that at least the remaining elements are present
+            ForEach.topLevel(gltf, k, (element) => {
                 expect(remaining[k]).toContain(element.name);
             });
 
-            /* Check that all the elements should actually remain */
-            remaining[k].forEach((name, index) => {
+            // Check that all the elements should actually remain
+            remaining[k].forEach((name) => {
                 expect(gltf[k].map(x => x.name)).toContain(name);
             });
         });


### PR DESCRIPTION
Hi everybody!

While writing a custom stage for gltf-pipeline, I had the need to remove unused materials, meshes and nodes.

I figured this might not always be desirable, which is why I added `--removeUnused material,node,accessor` to `gtlf-pipeline.js` to allow specification of which types of elements should be removed.
To keep backwards compatibility, this defaults to `accessor,buffer,bufferView`.

Since order of removal matters, I ensured that the order is always the same independent of the order of given element types.

Are you interested in this pullrequest? Then I will make sure to test this and clean it up, as this is currently just some code extracted from my custom stage.

Looking forward to your reply,
Jonathan.

