### PR TITLE
Separate resources no longer hit Node buffer size limit

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+### 2.1.3 - 2019-03-??
+
+* Fixed a crash when saving separate resources that would exceed the Node buffer size limit. [#468](https://github.com/AnalyticalGraphicsInc/gltf-pipeline/pull/468)
+
 ### 2.1.2 - 2019-03-14
 
 * Fixed reading absolute uris. [#466](https://github.com/AnalyticalGraphicsInc/gltf-pipeline/pull/466)

--- a/lib/mergeBuffers.js
+++ b/lib/mergeBuffers.js
@@ -1,4 +1,5 @@
 'use strict';
+const BUFFER_MAX_BYTE_LENGTH = require('buffer').constants.MAX_LENGTH;
 const Cesium = require('cesium');
 const ForEach = require('./ForEach');
 
@@ -23,12 +24,29 @@ function mergeBuffers(gltf, defaultName) {
     });
     baseBufferName = defaultValue(baseBufferName, 'buffer');
 
+    let buffersByteLength = 0;
+    ForEach.buffer(gltf, function(buffer) {
+        buffersByteLength += buffer.extras._pipeline.source.length;
+    });
+
+    // Don't merge buffers if the merged buffer will exceed the Node limit.
+    const splitBuffers = (buffersByteLength > mergeBuffers._getBufferMaxByteLength());
+
     const buffersToMerge = {};
+    const mergedNameCount = {};
 
     ForEach.bufferView(gltf, function(bufferView) {
         const buffer = gltf.buffers[bufferView.buffer];
         let mergedName = buffer.extras._pipeline.mergedBufferName;
         mergedName = defined(mergedName) ? baseBufferName + '-' + mergedName : baseBufferName;
+
+        if (splitBuffers) {
+            if (!defined(mergedNameCount[mergedName])) {
+                mergedNameCount[mergedName] = 0;
+            }
+            mergedName += '-' + mergedNameCount[mergedName]++;
+        }
+
         if (!defined(buffersToMerge[mergedName])) {
             buffersToMerge[mergedName] = {
                 buffers: [],
@@ -88,3 +106,8 @@ function allocateBufferPadding(byteLength) {
     }
     return Buffer.alloc(0);
 }
+
+// Exposed for testing
+mergeBuffers._getBufferMaxByteLength = function() {
+    return BUFFER_MAX_BYTE_LENGTH;
+};

--- a/lib/mergeBuffers.js
+++ b/lib/mergeBuffers.js
@@ -60,8 +60,10 @@ function mergeBuffers(gltf, defaultName) {
 
         const sourceBufferViewData = Buffer.from(buffer.extras._pipeline.source.slice(bufferView.byteOffset, bufferView.byteOffset + bufferView.byteLength));
         const bufferViewPadding = allocateBufferPadding(byteLength);
-        buffers.push(bufferViewPadding);
-        byteLength += bufferViewPadding.byteLength;
+        if (defined(bufferViewPadding)) {
+            buffers.push(bufferViewPadding);
+            byteLength += bufferViewPadding.byteLength;
+        }
 
         bufferView.byteOffset = byteLength;
         bufferView.buffer = index;
@@ -81,8 +83,10 @@ function mergeBuffers(gltf, defaultName) {
             const byteLength = buffersToMerge[mergedName].byteLength;
             const index = buffersToMerge[mergedName].index;
             const bufferPadding = allocateBufferPadding(byteLength);
-            buffers.push(bufferPadding);
-            const mergedSource = Buffer.concat(buffers);
+            if (defined(bufferPadding)) {
+                buffers.push(bufferPadding);
+            }
+            const mergedSource = (buffers.length > 1) ? Buffer.concat(buffers) : buffers[0];
             gltf.buffers[index] = {
                 name: mergedName,
                 byteLength: mergedSource.byteLength,
@@ -104,7 +108,7 @@ function allocateBufferPadding(byteLength) {
         const bytesToPad = 4 - alignment;
         return Buffer.alloc(bytesToPad);
     }
-    return Buffer.alloc(0);
+    return undefined;
 }
 
 // Exposed for testing

--- a/specs/lib/mergeBuffersSpec.js
+++ b/specs/lib/mergeBuffersSpec.js
@@ -157,4 +157,123 @@ describe('mergeBuffers', () => {
         expect(gltf.buffers[2].extras._pipeline.source).toEqual(expectedBuffer2);
         expect(gltf.buffers[2].name).toBe('buffer');
     });
+
+    it('does not merge buffers if merged buffers would exceed the Node buffer size limit', async () => {
+        const buffer0 = Buffer.from((new Uint8Array([1, 1, 1, 1])));
+        const buffer1 = Buffer.from((new Uint8Array([2, 2, 2, 2])));
+        const buffer2 = Buffer.from((new Uint8Array([3])));
+        const buffer3 = Buffer.from((new Uint8Array([5, 5])));
+        const buffer4 = Buffer.from((new Uint8Array([4, 4, 4])));
+        const buffer5 = Buffer.from((new Uint8Array([6, 7])));
+
+        const dataUri0 = 'data:application/octet-stream;base64,' + buffer0.toString('base64');
+        const dataUri1 = 'data:application/octet-stream;base64,' + buffer1.toString('base64');
+        const dataUri2 = 'data:application/octet-stream;base64,' + buffer2.toString('base64');
+        const dataUri3 = 'data:application/octet-stream;base64,' + buffer3.toString('base64');
+        const dataUri4 = 'data:application/octet-stream;base64,' + buffer4.toString('base64');
+        const dataUri5 = 'data:application/octet-stream;base64,' + buffer5.toString('base64');
+
+        // All buffer views start on 4-byte alignment, the buffer ends on a 4-byte alignment, and extraneous buffer data is removed
+        const expectedBuffer0 = Buffer.from((new Uint8Array([1, 1, 1, 1])));
+        const expectedBuffer1 = Buffer.from((new Uint8Array([2, 2, 2, 2])));
+        const expectedBuffer2 = Buffer.from((new Uint8Array([3, 0, 0, 0])));
+        const expectedBuffer3 = Buffer.from((new Uint8Array([5, 5, 0, 0])));
+        const expectedBuffer4 = Buffer.from((new Uint8Array([4, 4, 4, 0])));
+        const expectedBuffer5 = Buffer.from((new Uint8Array([6, 0, 0, 0])));
+        const expectedBuffer6 = Buffer.from((new Uint8Array([7, 0, 0, 0])));
+
+        const gltf = {
+            bufferViews: [
+                {
+                    buffer: 0,
+                    byteOffset: 0,
+                    byteLength: 4
+                },
+                {
+                    buffer: 1,
+                    byteOffset: 0,
+                    byteLength: 4
+                },
+                {
+                    buffer: 2,
+                    byteOffset: 0,
+                    byteLength: 1
+                },
+                {
+                    buffer: 3,
+                    byteOffset: 0,
+                    byteLength: 2
+                },
+                {
+                    buffer: 4,
+                    byteOffset: 0,
+                    byteLength: 3
+                },
+                {
+                    buffer: 5,
+                    byteOffset: 0,
+                    byteLength: 1
+                },
+                {
+                    buffer: 5,
+                    byteOffset: 1,
+                    byteLength: 1
+                }
+            ],
+            buffers: [
+                {
+                    byteLength: buffer0.length,
+                    uri: dataUri0
+                },
+                {
+                    byteLength: buffer1.length,
+                    uri: dataUri1
+                },
+                {
+                    byteLength: buffer2.length,
+                    uri: dataUri2
+                },
+                {
+                    byteLength: buffer3.length,
+                    uri: dataUri3
+                },
+                {
+                    byteLength: buffer4.length,
+                    uri: dataUri4
+                },
+                {
+                    byteLength: buffer5.length,
+                    uri: dataUri5
+                }
+            ]
+        };
+
+        await readResources(gltf);
+        gltf.buffers[0].extras._pipeline.mergedBufferName = 'first';
+        gltf.buffers[1].extras._pipeline.mergedBufferName = 'first';
+        gltf.buffers[2].extras._pipeline.mergedBufferName = 'second';
+        gltf.buffers[3].extras._pipeline.mergedBufferName = undefined;
+        gltf.buffers[4].extras._pipeline.mergedBufferName = 'second';
+        gltf.buffers[5].extras._pipeline.mergedBufferName = undefined;
+
+        spyOn(mergeBuffers, '_getBufferMaxByteLength').and.returnValue(0);
+
+        mergeBuffers(gltf);
+        expect(gltf.buffers.length).toBe(7);
+        expect(gltf.bufferViews.length).toBe(7);
+        expect(gltf.buffers[0].extras._pipeline.source).toEqual(expectedBuffer0);
+        expect(gltf.buffers[0].name).toEqual('buffer-first-0');
+        expect(gltf.buffers[1].extras._pipeline.source).toEqual(expectedBuffer1);
+        expect(gltf.buffers[1].name).toEqual('buffer-first-1');
+        expect(gltf.buffers[2].extras._pipeline.source).toEqual(expectedBuffer2);
+        expect(gltf.buffers[2].name).toEqual('buffer-second-0');
+        expect(gltf.buffers[3].extras._pipeline.source).toEqual(expectedBuffer3);
+        expect(gltf.buffers[3].name).toBe('buffer-0');
+        expect(gltf.buffers[4].extras._pipeline.source).toEqual(expectedBuffer4);
+        expect(gltf.buffers[4].name).toBe('buffer-second-1');
+        expect(gltf.buffers[5].extras._pipeline.source).toEqual(expectedBuffer5);
+        expect(gltf.buffers[5].name).toBe('buffer-1');
+        expect(gltf.buffers[6].extras._pipeline.source).toEqual(expectedBuffer6);
+        expect(gltf.buffers[6].name).toBe('buffer-2');
+    });
 });


### PR DESCRIPTION
Same idea as https://github.com/AnalyticalGraphicsInc/obj2gltf/pull/185.

Before merging buffers check to see if the merged buffer would exceed the Node buffer size limit (~2GB). If it does, save the buffers as separate .bin files instead of merging them into a single .bin file.