### PR TITLE
Fix for cesium build of gltf-pipeline

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -118,6 +118,8 @@ function amdify(source, subDependencyMapping) {
     let requirePath;
 
     source = source.replace(/\r\n/g, '\n');
+    source = source.replace(/\b(let|const)\b/g, 'var');
+
     let outputSource = source;
 
     // find module exports


### PR DESCRIPTION
Replaces const/let with var so CesiumJS can use the amdify'd version of gltf-pipeline. I checked that the built files still work in CesiumJS.