### PR TITLE
Add support for the basis compressed texture file extension

### DIFF
--- a/lib/getImageExtension.js
+++ b/lib/getImageExtension.js
@@ -33,6 +33,8 @@ function getImageExtension(data) {
     } else if (webpHeaderRIFFChars.equals(Buffer.from([0x52, 0x49, 0x46, 0x46])) && webpHeaderWEBPChars.equals(Buffer.from([0x57, 0x45, 0x42, 0x50]))) {
         // See https://developers.google.com/speed/webp/docs/riff_container#webp_file_header
         return '.webp';
+    } else if (header.equals(Buffer.from([0x73, 0x42]))) {
+        return '.basis';
     }
 
     throw new RuntimeError('Image data does not have valid header');


### PR DESCRIPTION
When converting a `.gltf` file to a `.glb`, the `.basis` compressed texture file extension is not accepted as a valid file header. 

I added the file header, because soon basis will be supported in a GLTF (https://github.com/KhronosGroup/glTF/pull/1612).