### PR TITLE
fix possible infinite loop in writeResources

### DIFF
--- a/lib/writeResources.js
+++ b/lib/writeResources.js
@@ -172,9 +172,10 @@ function getRelativePath(gltf, object, index, extension, options) {
     relativePath = name + extension;
 
     // Check if a file of the same name already exists, and if so, append a number
-    const number = 1;
+    let number = 1;
     while (defined(options.separateResources[relativePath])) {
         relativePath = name + '_' + number + extension;
+        number++;
     }
     return relativePath;
 }


### PR DESCRIPTION
Having a `gltf` with a plurality of images with the same `name` would cause this to infinite-loop.