### PR TITLE
Update build-cesium task for ES6

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -185,28 +185,22 @@ function amdify(source, subDependencyMapping) {
     // amdify source
     // indent
     outputSource = outputSource.replace(/\n/g, '\n    ');
+    outputSource = outputSource.replace(/'use strict';/g, '');
+
     // wrap define header
-    const variables = [];
-    const paths = [];
+    const lines = [];
     for (const variable in requireMapping) {
         if (Object.prototype.hasOwnProperty.call(requireMapping, variable)) {
-            variables.push(variable);
-            paths.push(requireMapping[variable]);
+            lines.push('import ' + variable + ' from \'' + requireMapping[variable] + '\'');
         }
     }
-    let defineHeader = 'define([], function() {\n    ';
-    if (paths.length > 0) {
-        const definePathsHeader = '\'' + paths.join('\',\n        \'') + '\'';
-        const defineVariablesHeader = variables.join(',\n        ');
-        defineHeader =
-            'define([\n' +
-            '        ' + definePathsHeader + '\n' +
-            '    ], function(\n' +
-            '        ' + defineVariablesHeader + ') {\n    ';
+    let defineHeader = '';
+    if (lines.length > 0) {
+        defineHeader = lines.join('\n') + '\n';
     }
-    let defineFooter = '\n});\n';
+    let defineFooter = '\n';
     if (defined(returnValue)) {
-        defineFooter = '\n    return ' + returnValue + ';' + defineFooter;
+        defineFooter = '\n    export default ' + returnValue + ';\n';
     }
     outputSource = defineHeader + outputSource + defineFooter;
     // remove repeat newlines

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -183,8 +183,6 @@ function amdify(source, subDependencyMapping) {
         }
     }
     // amdify source
-    // indent
-    outputSource = outputSource.replace(/\n/g, '\n    ');
     outputSource = outputSource.replace(/'use strict';/g, '');
 
     // wrap define header
@@ -200,7 +198,7 @@ function amdify(source, subDependencyMapping) {
     }
     let defineFooter = '\n';
     if (defined(returnValue)) {
-        defineFooter = '\n    export default ' + returnValue + ';\n';
+        defineFooter = '\nexport default ' + returnValue + ';\n';
     }
     outputSource = defineHeader + outputSource + defineFooter;
     // remove repeat newlines


### PR DESCRIPTION
This changes the Cesium build to output ES6 modules instead of AMD.  This is needed for Cesium's move to ES6.

@lilleyse are you the best person to review this?

We can hold off on merging until the Cesium PR is ready, but I wanted to get this opened  so I could reference it elsewhere.