### PR TITLE
Stop ignoring the keepUnusedElements flag.

### DIFF
--- a/bin/gltf-pipeline.js
+++ b/bin/gltf-pipeline.js
@@ -168,6 +168,7 @@ const options = {
     separate: argv.separate,
     separateTextures: argv.separateTextures,
     stats: argv.stats,
+    keepUnusedElements: argv.keepUnusedElements,
     name: outputName,
     dracoOptions: dracoOptions
 };


### PR DESCRIPTION
The --keepUnusedElements flag was ignored in the gltf-pipeline.js commandline tool. Closes #508 